### PR TITLE
Fixed the issue that some custom data sources and scheduling accuracy were lost

### DIFF
--- a/mediamp-api/src/commonMain/kotlin/AbstractMediampPlayer.kt
+++ b/mediamp-api/src/commonMain/kotlin/AbstractMediampPlayer.kt
@@ -60,9 +60,9 @@ public abstract class AbstractMediampPlayer<D : AbstractMediampPlayer.Data>(
             if (properties.durationMillis == 0L) {
                 return@combine 0f
             }
-            (duration / properties.durationMillis).toFloat().coerceIn(0f, 1f)
+            (duration.toFloat() / properties.durationMillis.toFloat()).coerceIn(0f, 1f)
         }
-
+    
     private val closed = MutableStateFlow(false)
 
     private val setVideoSourceMutex = Mutex()

--- a/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
@@ -153,7 +153,7 @@ class ExoPlayerMediampPlayer @UiThread constructor(
                             data.createInput()
                         }
                         val factory = ProgressiveMediaSource.Factory {
-                            SeekableInputDataSource(data, file)
+                            SeekableInputDataSource(data, file!!)
                         }
 
                         exoPlayer.setMediaSource(
@@ -164,6 +164,10 @@ class ExoPlayerMediampPlayer @UiThread constructor(
                     }
                 },
             )
+        }
+
+        else -> {
+            throw IllegalArgumentException("Unsupported MediaData type: $data")
         }
     }
 

--- a/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
@@ -276,7 +276,6 @@ class ExoPlayerMediampPlayer @UiThread constructor(
                     private fun updateVideoProperties(): Boolean {
                         val video = videoFormat ?: return false
                         val audio = audioFormat ?: return false
-                        val data = openResource.value?.mediaData ?: return false
                         val title = mediaMetadata.title
                         val duration = duration
 

--- a/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
@@ -153,7 +153,7 @@ class ExoPlayerMediampPlayer @UiThread constructor(
                             data.createInput()
                         }
                         val factory = ProgressiveMediaSource.Factory {
-                            SeekableInputDataSource(data, file!!)
+                            SeekableInputDataSource(data, file)
                         }
 
                         exoPlayer.setMediaSource(

--- a/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
@@ -165,10 +165,6 @@ class ExoPlayerMediampPlayer @UiThread constructor(
                 },
             )
         }
-
-        else -> {
-            throw IllegalArgumentException("Unsupported MediaData type: $data")
-        }
     }
 
     private val exoPlayer: ExoPlayer = run {


### PR DESCRIPTION
在自定义ExoPlayer数据源时 百分比进度监听可能不会正常工作
```kotlin
AbstractMediampPlayer.setMediaData(data: MediaData)
```
然后 其中的 openResource value为null 间接导致
```kotlin
ExoPlayerMediampPlayer->updateVideoProperties
                    @MainThread
                    private fun updateVideoProperties(): Boolean {
                        val video = videoFormat ?: return false
                        val audio = audioFormat ?: return false
                        val data = openResource.value?.mediaData ?: return false
                        val title = mediaMetadata.title
                        val duration = duration

                        // 注意, 要把所有 UI 属性全都读出来然后 captured 到 background -- ExoPlayer 所有属性都需要在主线程
                        mediaProperties.value = MediaProperties(
                            title = title?.toString(),
                            durationMillis = duration,
                        )
                        return true
                    }
```
val data = openResource.value?.mediaData ?: return false没有成功触发

本次pr解决了此问题