### PR TITLE
Implement VideoAspectRatio feature for cross-platform video scaling

### DIFF
--- a/mediamp-api/src/commonMain/kotlin/MediampPlayer.kt
+++ b/mediamp-api/src/commonMain/kotlin/MediampPlayer.kt
@@ -15,9 +15,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.MediaMetadata
 import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.features.PlayerFeatures
+import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.features.buildPlayerFeatures
 import org.openani.mediamp.metadata.AudioTrack
 import org.openani.mediamp.metadata.Chapter
@@ -366,6 +368,15 @@ public class DummyMediampPlayer(
                         Chapter("chapter2", durationMillis = 5_000L, 90_000L),
                     ),
                 )
+            },
+        )
+        add(
+            VideoAspectRatio,
+            object : VideoAspectRatio {
+                override val mode: MutableStateFlow<AspectRatioMode> = MutableStateFlow(AspectRatioMode.FIT)
+                override fun setMode(mode: AspectRatioMode) {
+                    this.mode.value = mode
+                }
             },
         )
     }

--- a/mediamp-api/src/commonMain/kotlin/features/MediaMetadata.kt
+++ b/mediamp-api/src/commonMain/kotlin/features/MediaMetadata.kt
@@ -64,3 +64,11 @@ public val MediampPlayer.subtitleTracks
  */
 public val MediampPlayer.chapters
     get() = features[MediaMetadata]?.chapters
+
+/**
+ * Shortcut to access the [VideoAspectRatio] feature.
+ *
+ * This method is stable, meaning that it always return the same instance for the same input ([this]).
+ */
+public val MediampPlayer.videoAspectRatio
+    get() = features[VideoAspectRatio.Key]

--- a/mediamp-api/src/commonMain/kotlin/features/MediaMetadata.kt
+++ b/mediamp-api/src/commonMain/kotlin/features/MediaMetadata.kt
@@ -65,10 +65,3 @@ public val MediampPlayer.subtitleTracks
 public val MediampPlayer.chapters
     get() = features[MediaMetadata]?.chapters
 
-/**
- * Shortcut to access the [VideoAspectRatio] feature.
- *
- * This method is stable, meaning that it always return the same instance for the same input ([this]).
- */
-public val MediampPlayer.videoAspectRatio
-    get() = features[VideoAspectRatio.Key]

--- a/mediamp-api/src/commonMain/kotlin/features/VideoAspectRatio.kt
+++ b/mediamp-api/src/commonMain/kotlin/features/VideoAspectRatio.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.features
+
+import kotlinx.coroutines.flow.StateFlow
+import org.openani.mediamp.InternalForInheritanceMediampApi
+
+/**
+ * Video aspect ratio scaling modes.
+ */
+public enum class AspectRatioMode {
+    /**
+     * Fit the video to the container while maintaining the original aspect ratio.
+     * The video will be scaled to fit entirely within the container, potentially leaving black bars.
+     */
+    FIT,
+
+    /**
+     * Stretch the video to fill the entire container.
+     * The video aspect ratio may be changed to match the container.
+     */
+    STRETCH,
+
+    /**
+     * Fill the container while maintaining the original aspect ratio.
+     * The video may be cropped if the aspect ratios don't match.
+     */
+    FILL
+}
+
+/**
+ * An optional feature of the [org.openani.mediamp.MediampPlayer] that allows controlling video aspect ratio scaling.
+ */
+@SubclassOptInRequired(InternalForInheritanceMediampApi::class)
+public interface VideoAspectRatio : Feature {
+    /**
+     * A hot flow of the current aspect ratio mode.
+     */
+    public val mode: StateFlow<AspectRatioMode>
+
+    /**
+     * Sets the aspect ratio mode.
+     */
+    public fun setMode(mode: AspectRatioMode)
+
+    public companion object Key : FeatureKey<VideoAspectRatio>
+}

--- a/mediamp-api/src/commonMain/kotlin/features/VideoAspectRatio.kt
+++ b/mediamp-api/src/commonMain/kotlin/features/VideoAspectRatio.kt
@@ -31,7 +31,7 @@ public enum class AspectRatioMode {
      * Fill the container while maintaining the original aspect ratio.
      * The video may be cropped if the aspect ratios don't match.
      */
-    FILL
+    CROP
 }
 
 /**

--- a/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioIntegrationTest.kt
+++ b/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioIntegrationTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.features
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.openani.mediamp.DummyMediampPlayer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class VideoAspectRatioIntegrationTest {
+    @Test
+    fun `test aspect ratio mode changes are reflected in flow`() = runTest {
+        val player = DummyMediampPlayer()
+        val aspectRatio = player.features[VideoAspectRatio.Key]!!
+        
+        // Test initial state
+        assertEquals(AspectRatioMode.FIT, aspectRatio.mode.value)
+        
+        // Test mode changes
+        aspectRatio.setMode(AspectRatioMode.STRETCH)
+        assertEquals(AspectRatioMode.STRETCH, aspectRatio.mode.first())
+        
+        aspectRatio.setMode(AspectRatioMode.FILL)
+        assertEquals(AspectRatioMode.FILL, aspectRatio.mode.first())
+        
+        aspectRatio.setMode(AspectRatioMode.FIT)
+        assertEquals(AspectRatioMode.FIT, aspectRatio.mode.first())
+    }
+
+    @Test
+    fun `test aspect ratio feature is available on all players`() = runTest {
+        val player = DummyMediampPlayer()
+        val aspectRatio = player.features[VideoAspectRatio.Key]
+        
+        assertNotNull(aspectRatio, "VideoAspectRatio feature should be available")
+        assertNotNull(aspectRatio.mode, "VideoAspectRatio mode flow should not be null")
+    }
+
+    @Test
+    fun `test aspect ratio mode enum values`() {
+        // Ensure all expected modes are available
+        val modes = AspectRatioMode.values()
+        assertEquals(3, modes.size)
+        
+        val modeNames = modes.map { it.name }.toSet()
+        assertEquals(setOf("FIT", "STRETCH", "FILL"), modeNames)
+    }
+}

--- a/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioIntegrationTest.kt
+++ b/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioIntegrationTest.kt
@@ -28,8 +28,8 @@ class VideoAspectRatioIntegrationTest {
         aspectRatio.setMode(AspectRatioMode.STRETCH)
         assertEquals(AspectRatioMode.STRETCH, aspectRatio.mode.first())
         
-        aspectRatio.setMode(AspectRatioMode.FILL)
-        assertEquals(AspectRatioMode.FILL, aspectRatio.mode.first())
+        aspectRatio.setMode(AspectRatioMode.CROP)
+        assertEquals(AspectRatioMode.CROP, aspectRatio.mode.first())
         
         aspectRatio.setMode(AspectRatioMode.FIT)
         assertEquals(AspectRatioMode.FIT, aspectRatio.mode.first())

--- a/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioIntegrationTest.kt
+++ b/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioIntegrationTest.kt
@@ -51,6 +51,6 @@ class VideoAspectRatioIntegrationTest {
         assertEquals(3, modes.size)
         
         val modeNames = modes.map { it.name }.toSet()
-        assertEquals(setOf("FIT", "STRETCH", "FILL"), modeNames)
+        assertEquals(setOf("FIT", "STRETCH", "CROP"), modeNames)
     }
 }

--- a/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioTest.kt
+++ b/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.features
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.openani.mediamp.DummyMediampPlayer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class VideoAspectRatioTest {
+    @Test
+    fun `test default aspect ratio mode is FIT`() = runTest {
+        val player = DummyMediampPlayer()
+        val aspectRatio = player.features[VideoAspectRatio.Key]
+        
+        assertNotNull(aspectRatio)
+        assertEquals(AspectRatioMode.FIT, aspectRatio.mode.value)
+    }
+
+    @Test
+    fun `test setting aspect ratio mode`() = runTest {
+        val player = DummyMediampPlayer()
+        val aspectRatio = player.features[VideoAspectRatio.Key]!!
+        
+        aspectRatio.setMode(AspectRatioMode.STRETCH)
+        assertEquals(AspectRatioMode.STRETCH, aspectRatio.mode.first())
+        
+        aspectRatio.setMode(AspectRatioMode.FILL)
+        assertEquals(AspectRatioMode.FILL, aspectRatio.mode.first())
+        
+        aspectRatio.setMode(AspectRatioMode.FIT)
+        assertEquals(AspectRatioMode.FIT, aspectRatio.mode.first())
+    }
+
+    @Test
+    fun `test aspect ratio mode flow updates`() = runTest {
+        val player = DummyMediampPlayer()
+        val aspectRatio = player.features[VideoAspectRatio.Key]!!
+        
+        var receivedMode: AspectRatioMode? = null
+        
+        // Collect the first emission
+        receivedMode = aspectRatio.mode.first()
+        assertEquals(AspectRatioMode.FIT, receivedMode)
+        
+        // Change mode and verify
+        aspectRatio.setMode(AspectRatioMode.STRETCH)
+        receivedMode = aspectRatio.mode.first()
+        assertEquals(AspectRatioMode.STRETCH, receivedMode)
+    }
+}

--- a/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioTest.kt
+++ b/mediamp-api/src/jvmTest/kotlin/features/VideoAspectRatioTest.kt
@@ -33,8 +33,8 @@ class VideoAspectRatioTest {
         aspectRatio.setMode(AspectRatioMode.STRETCH)
         assertEquals(AspectRatioMode.STRETCH, aspectRatio.mode.first())
         
-        aspectRatio.setMode(AspectRatioMode.FILL)
-        assertEquals(AspectRatioMode.FILL, aspectRatio.mode.first())
+        aspectRatio.setMode(AspectRatioMode.CROP)
+        assertEquals(AspectRatioMode.CROP, aspectRatio.mode.first())
         
         aspectRatio.setMode(AspectRatioMode.FIT)
         assertEquals(AspectRatioMode.FIT, aspectRatio.mode.first())

--- a/mediamp-avkit/src/appleMain/kotlin/AVKitMediampPlayer.kt
+++ b/mediamp-avkit/src/appleMain/kotlin/AVKitMediampPlayer.kt
@@ -29,10 +29,12 @@ import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.InternalForInheritanceMediampApi
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.AudioLevelController
 import org.openani.mediamp.features.Buffering
 import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.features.PlayerFeatures
+import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.features.buildPlayerFeatures
 import org.openani.mediamp.metadata.MediaProperties
 import org.openani.mediamp.source.MediaData
@@ -167,10 +169,22 @@ public class AVKitMediampPlayer(
     }
 
     @OptIn(ExperimentalMediampApi::class)
+    private val videoAspectRatioFeature = object : VideoAspectRatio {
+        private val _mode = MutableStateFlow(AspectRatioMode.FIT)
+
+        override val mode: StateFlow<AspectRatioMode> get() = _mode
+
+        override fun setMode(mode: AspectRatioMode) {
+            _mode.value = mode
+        }
+    }
+
+    @OptIn(ExperimentalMediampApi::class)
     override val features: PlayerFeatures = buildPlayerFeatures {
         add(Buffering, bufferingFeature)
         add(AudioLevelController, audioLevelController)
         add(PlaybackSpeed, playbackSpeedFeature)
+        add(VideoAspectRatio, videoAspectRatioFeature)
     }
 
     // ------------------------------------------------------------------------------------

--- a/mediamp-avkit/src/appleMain/kotlin/AVKitMediampPlayerSurface.kt
+++ b/mediamp-avkit/src/appleMain/kotlin/AVKitMediampPlayerSurface.kt
@@ -59,7 +59,7 @@ public fun AVKitMediampPlayerSurface(
             it.videoGravity = when (aspectRatioMode) {
                 AspectRatioMode.FIT -> AVLayerVideoGravityResizeAspect
                 AspectRatioMode.STRETCH -> AVLayerVideoGravityResize
-                AspectRatioMode.FILL -> AVLayerVideoGravityResizeAspectFill
+                AspectRatioMode.CROP -> AVLayerVideoGravityResizeAspectFill
             }
         },
         onRelease = {

--- a/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/main/kotlin/ExoPlayerMediampPlayer.kt
@@ -46,10 +46,12 @@ import org.openani.mediamp.InternalForInheritanceMediampApi
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.PlaybackState
 import org.openani.mediamp.exoplayer.internal.SeekableInputDataSource
+import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.Buffering
 import org.openani.mediamp.features.MediaMetadata
 import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.features.PlayerFeatures
+import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.features.buildPlayerFeatures
 import org.openani.mediamp.internal.MutableTrackGroup
 import org.openani.mediamp.io.SeekableInput
@@ -336,6 +338,7 @@ class ExoPlayerMediampPlayer @UiThread constructor(
     private val buffering = ExoPlayerBuffering()
     private val mediaMetadataFeature = ExoPlayerMediaMetadata()
     private val playbackSpeed = PlaybackSpeedImpl(exoPlayer)
+    private val videoAspectRatio = ExoPlayerVideoAspectRatio()
 
     override val currentPositionMillis: MutableStateFlow<Long> = MutableStateFlow(0)
 
@@ -344,6 +347,7 @@ class ExoPlayerMediampPlayer @UiThread constructor(
         add(PlaybackSpeed, playbackSpeed)
         add(Buffering, buffering)
         add(MediaMetadata, mediaMetadataFeature)
+        add(VideoAspectRatio, videoAspectRatio)
     }
 
     override fun getCurrentMediaProperties(): MediaProperties? {
@@ -460,4 +464,13 @@ internal class ExoPlayerMediaMetadata : MediaMetadata {
 internal class ExoPlayerBuffering : Buffering {
     override val isBuffering: MutableStateFlow<Boolean> = MutableStateFlow(false)
     override val bufferedPercentage = MutableStateFlow(0)
+}
+
+@kotlin.OptIn(InternalForInheritanceMediampApi::class)
+internal class ExoPlayerVideoAspectRatio : VideoAspectRatio {
+    override val mode: MutableStateFlow<AspectRatioMode> = MutableStateFlow(AspectRatioMode.FIT)
+
+    override fun setMode(mode: AspectRatioMode) {
+        this.mode.value = mode
+    }
 }

--- a/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampPlayerSurfaceProvider.kt
+++ b/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampPlayerSurfaceProvider.kt
@@ -8,6 +8,7 @@
 
 package org.openani.mediamp.exoplayer.compose
 
+import androidx.annotation.OptIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.media3.common.util.UnstableApi
@@ -18,7 +19,7 @@ import kotlin.reflect.KClass
 class ExoPlayerMediampPlayerSurfaceProvider : MediampPlayerSurfaceProvider<ExoPlayerMediampPlayer> {
     override val forClass: KClass<ExoPlayerMediampPlayer> = ExoPlayerMediampPlayer::class
 
-    @UnstableApi
+    @OptIn(UnstableApi::class)
     @Composable
     override fun Surface(mediampPlayer: ExoPlayerMediampPlayer, modifier: Modifier) {
         ExoPlayerMediampPlayerSurface(mediampPlayer, modifier)

--- a/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampPlayerSurfaceProvider.kt
+++ b/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampPlayerSurfaceProvider.kt
@@ -10,6 +10,7 @@ package org.openani.mediamp.exoplayer.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.media3.common.util.UnstableApi
 import org.openani.mediamp.compose.MediampPlayerSurfaceProvider
 import org.openani.mediamp.exoplayer.ExoPlayerMediampPlayer
 import kotlin.reflect.KClass
@@ -17,6 +18,7 @@ import kotlin.reflect.KClass
 class ExoPlayerMediampPlayerSurfaceProvider : MediampPlayerSurfaceProvider<ExoPlayerMediampPlayer> {
     override val forClass: KClass<ExoPlayerMediampPlayer> = ExoPlayerMediampPlayer::class
 
+    @UnstableApi
     @Composable
     override fun Surface(mediampPlayer: ExoPlayerMediampPlayer, modifier: Modifier) {
         ExoPlayerMediampPlayerSurface(mediampPlayer, modifier)

--- a/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampSurface.kt
+++ b/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampSurface.kt
@@ -47,7 +47,7 @@ fun ExoPlayerMediampPlayerSurface(
             view.resizeMode = when (aspectRatioMode) {
                 AspectRatioMode.FIT -> AspectRatioFrameLayout.RESIZE_MODE_FIT
                 AspectRatioMode.STRETCH -> AspectRatioFrameLayout.RESIZE_MODE_FILL
-                AspectRatioMode.FILL -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                AspectRatioMode.CROP -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
             }
         },
     )

--- a/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampSurface.kt
+++ b/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampSurface.kt
@@ -8,6 +8,7 @@
 
 package org.openani.mediamp.exoplayer.compose
 
+import androidx.annotation.OptIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -20,7 +21,7 @@ import org.openani.mediamp.exoplayer.ExoPlayerMediampPlayer
 import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.VideoAspectRatio
 
-@UnstableApi
+@OptIn(UnstableApi::class)
 @Composable
 fun ExoPlayerMediampPlayerSurface(
     mediampPlayer: ExoPlayerMediampPlayer,

--- a/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampSurface.kt
+++ b/mediamp-exoplayer/src/main/kotlin/compose/ExoPlayerMediampSurface.kt
@@ -9,17 +9,27 @@
 package org.openani.mediamp.exoplayer.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import org.openani.mediamp.exoplayer.ExoPlayerMediampPlayer
+import org.openani.mediamp.features.AspectRatioMode
+import org.openani.mediamp.features.VideoAspectRatio
 
+@UnstableApi
 @Composable
 fun ExoPlayerMediampPlayerSurface(
     mediampPlayer: ExoPlayerMediampPlayer,
     modifier: Modifier = Modifier,
     configuration: PlayerView.() -> Unit = {},
 ) {
+    val aspectRatioMode by mediampPlayer.features[VideoAspectRatio.Key]?.mode?.collectAsState() 
+        ?: return // Return early if VideoAspectRatio feature is not available
+    
     AndroidView(
         factory = { context ->
             PlayerView(context).apply {
@@ -33,7 +43,12 @@ fun ExoPlayerMediampPlayerSurface(
         },
         update = { view ->
             view.player = mediampPlayer.impl
+            // Apply aspect ratio mode to PlayerView
+            view.resizeMode = when (aspectRatioMode) {
+                AspectRatioMode.FIT -> AspectRatioFrameLayout.RESIZE_MODE_FIT
+                AspectRatioMode.STRETCH -> AspectRatioFrameLayout.RESIZE_MODE_FILL
+                AspectRatioMode.FILL -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+            }
         },
     )
-
 }

--- a/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
+++ b/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
@@ -30,12 +30,14 @@ import org.openani.mediamp.InternalForInheritanceMediampApi
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.AudioLevelController
 import org.openani.mediamp.features.Buffering
 import org.openani.mediamp.features.MediaMetadata
 import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.features.PlayerFeatures
 import org.openani.mediamp.features.Screenshots
+import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.features.buildPlayerFeatures
 import org.openani.mediamp.internal.MutableTrackGroup
 import org.openani.mediamp.metadata.AudioTrack
@@ -237,6 +239,7 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
     private val playbackSpeed = VlcPlaybackSpeed(player)
     private val audioLevelController = VlcAudioLevelController(player)
     private val mediaMetadata = VlcMediaMetadata()
+    private val videoAspectRatio = VlcVideoAspectRatio()
 
     @OptIn(ExperimentalMediampApi::class)
     override val features: PlayerFeatures = buildPlayerFeatures {
@@ -245,6 +248,7 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
         add(AudioLevelController.Key, audioLevelController)
         add(PlaybackSpeed.Key, playbackSpeed)
         add(MediaMetadata, mediaMetadata)
+        add(VideoAspectRatio.Key, videoAspectRatio)
     }
 
     override fun getCurrentPlaybackState(): PlaybackState {
@@ -621,6 +625,15 @@ internal class VlcBuffering(
             delay(1500)
         }
     }.distinctUntilChanged()
+}
+
+@OptIn(InternalForInheritanceMediampApi::class)
+internal class VlcVideoAspectRatio : VideoAspectRatio {
+    override val mode: MutableStateFlow<AspectRatioMode> = MutableStateFlow(AspectRatioMode.FIT)
+
+    override fun setMode(mode: AspectRatioMode) {
+        this.mode.value = mode
+    }
 }
 
 

--- a/mediamp-vlc/src/main/kotlin/compose/VlcMediampPlayerSurface.kt
+++ b/mediamp-vlc/src/main/kotlin/compose/VlcMediampPlayerSurface.kt
@@ -128,7 +128,7 @@ internal class FrameSizeCalculator {
         when (aspectRatioMode) {
             AspectRatioMode.FIT -> calculateFitInside(imageSize, frameSize)
             AspectRatioMode.STRETCH -> calculateStretch(frameSize)
-            AspectRatioMode.FILL -> calculateFill(imageSize, frameSize)
+            AspectRatioMode.CROP -> calculateFill(imageSize, frameSize)
         }
 
         lastImageSize = imageSize

--- a/mediamp-vlc/src/main/kotlin/compose/VlcMediampPlayerSurface.kt
+++ b/mediamp-vlc/src/main/kotlin/compose/VlcMediampPlayerSurface.kt
@@ -10,6 +10,8 @@ package org.openani.mediamp.vlc.compose
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
@@ -18,7 +20,10 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.util.fastCoerceAtLeast
 import org.openani.mediamp.InternalMediampApi
+import org.openani.mediamp.features.AspectRatioMode
+import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.vlc.VlcMediampPlayer
+import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 
@@ -30,12 +35,16 @@ public fun VlcMediampPlayerSurface(
     val frameSizeCalculator = remember {
         FrameSizeCalculator()
     }
+    val aspectRatioMode by mediampPlayer.features[VideoAspectRatio.Key]?.mode?.collectAsState() 
+        ?: return // Return early if VideoAspectRatio feature is not available
+    
     @OptIn(InternalMediampApi::class)
     Canvas(modifier) {
         val bitmap = mediampPlayer.surface.bitmap ?: return@Canvas
         frameSizeCalculator.calculate(
             IntSize(bitmap.width, bitmap.height),
             Size(size.width, size.height),
+            aspectRatioMode,
         )
         drawImage(
             bitmap,
@@ -50,12 +59,16 @@ public fun VlcMediampPlayerSurface(
 internal class FrameSizeCalculator {
     private var lastImageSize: IntSize = IntSize.Zero
     private var lastFrameSizePx: IntSize = IntSize.Zero
+    private var lastAspectRatioMode: AspectRatioMode = AspectRatioMode.FIT
 
     var dstSize: IntSize = IntSize.Zero
         private set
     var dstOffset: IntOffset = IntOffset.Zero
         private set
 
+    /**
+     * Calculate size and offset for FIT mode - maintain aspect ratio, fit entirely within container.
+     */
     private fun calculateFitInside(
         imageSize: IntSize,
         frameSize: Size
@@ -75,14 +88,51 @@ internal class FrameSizeCalculator {
         dstOffset = IntOffset(offsetX, offsetY)
     }
 
-    fun calculate(imageSize: IntSize, frameSize: Size) {
+    /**
+     * Calculate size and offset for STRETCH mode - fill entire container, may change aspect ratio.
+     */
+    private fun calculateStretch(
+        frameSize: Size
+    ) {
+        dstSize = IntSize(frameSize.width.roundToInt(), frameSize.height.roundToInt())
+        dstOffset = IntOffset.Zero
+    }
+
+    /**
+     * Calculate size and offset for FILL mode - maintain aspect ratio, fill entire container.
+     */
+    private fun calculateFill(
+        imageSize: IntSize,
+        frameSize: Size
+    ) {
+        val scale = max(
+            frameSize.width / imageSize.width,
+            frameSize.height / imageSize.height,
+        )
+
+        val scaledW = (imageSize.width * scale).roundToInt()
+        val scaledH = (imageSize.height * scale).roundToInt()
+
+        dstSize = IntSize(scaledW, scaledH)
+
+        val offsetX = ((frameSize.width - scaledW) / 2f).roundToInt()
+        val offsetY = ((frameSize.height - scaledH) / 2f).roundToInt()
+        dstOffset = IntOffset(offsetX, offsetY)
+    }
+
+    fun calculate(imageSize: IntSize, frameSize: Size, aspectRatioMode: AspectRatioMode) {
         val frameSizePx = IntSize(frameSize.width.roundToInt(), frameSize.height.roundToInt())
 
-        if (lastImageSize == imageSize && lastFrameSizePx == frameSizePx) return
+        if (lastImageSize == imageSize && lastFrameSizePx == frameSizePx && lastAspectRatioMode == aspectRatioMode) return
 
-        calculateFitInside(imageSize, frameSize)
+        when (aspectRatioMode) {
+            AspectRatioMode.FIT -> calculateFitInside(imageSize, frameSize)
+            AspectRatioMode.STRETCH -> calculateStretch(frameSize)
+            AspectRatioMode.FILL -> calculateFill(imageSize, frameSize)
+        }
 
         lastImageSize = imageSize
         lastFrameSizePx = frameSizePx
+        lastAspectRatioMode = aspectRatioMode
     }
 }

--- a/mediamp-vlc/src/test/kotlin/AspectRatioModeTest.kt
+++ b/mediamp-vlc/src/test/kotlin/AspectRatioModeTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024-2025 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.vlc.compose
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import org.openani.mediamp.features.AspectRatioMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AspectRatioModeTest {
+    private val calculator = FrameSizeCalculator()
+
+    @Test
+    fun `test FIT mode maintains aspect ratio and fits within container`() {
+        // 16:9 video in 4:3 container
+        calculator.calculate(
+            imageSize = IntSize(1920, 1080),
+            frameSize = Size(800f, 600f),
+            aspectRatioMode = AspectRatioMode.FIT
+        )
+
+        // Should maintain 16:9 aspect ratio, fit height
+        assertEquals(IntSize(800, 450), calculator.dstSize)
+        assertEquals(IntOffset(0, 75), calculator.dstOffset) // Centered vertically
+    }
+
+    @Test
+    fun `test STRETCH mode fills entire container`() {
+        calculator.calculate(
+            imageSize = IntSize(1920, 1080),
+            frameSize = Size(800f, 600f),
+            aspectRatioMode = AspectRatioMode.STRETCH
+        )
+
+        // Should fill entire container
+        assertEquals(IntSize(800, 600), calculator.dstSize)
+        assertEquals(IntOffset.Zero, calculator.dstOffset)
+    }
+
+    @Test
+    fun `test FILL mode maintains aspect ratio and fills container`() {
+        // 16:9 video in 4:3 container
+        calculator.calculate(
+            imageSize = IntSize(1920, 1080),
+            frameSize = Size(800f, 600f),
+            aspectRatioMode = AspectRatioMode.FILL
+        )
+
+        // Should maintain 16:9 aspect ratio, fill width
+        assertEquals(IntSize(1067, 600), calculator.dstSize)
+        assertEquals(IntOffset(-133, 0), calculator.dstOffset) // Centered horizontally
+    }
+
+    @Test
+    fun `test caching works correctly with different modes`() {
+        val imageSize = IntSize(1920, 1080)
+        val frameSize = Size(800f, 600f)
+
+        // First calculation with FIT
+        calculator.calculate(imageSize, frameSize, AspectRatioMode.FIT)
+        val fitSize = calculator.dstSize
+        val fitOffset = calculator.dstOffset
+
+        // Second calculation with same parameters should use cache
+        calculator.calculate(imageSize, frameSize, AspectRatioMode.FIT)
+        assertEquals(fitSize, calculator.dstSize)
+        assertEquals(fitOffset, calculator.dstOffset)
+
+        // Different mode should recalculate
+        calculator.calculate(imageSize, frameSize, AspectRatioMode.STRETCH)
+        assertEquals(IntSize(800, 600), calculator.dstSize)
+        assertEquals(IntOffset.Zero, calculator.dstOffset)
+    }
+}

--- a/mediamp-vlc/src/test/kotlin/AspectRatioModeTest.kt
+++ b/mediamp-vlc/src/test/kotlin/AspectRatioModeTest.kt
@@ -51,7 +51,7 @@ class AspectRatioModeTest {
         calculator.calculate(
             imageSize = IntSize(1920, 1080),
             frameSize = Size(800f, 600f),
-            aspectRatioMode = AspectRatioMode.FILL
+            aspectRatioMode = AspectRatioMode.CROP
         )
 
         // Should maintain 16:9 aspect ratio, fill width

--- a/mediamp-vlc/src/test/kotlin/FrameSizeCalculatorTest.kt
+++ b/mediamp-vlc/src/test/kotlin/FrameSizeCalculatorTest.kt
@@ -11,6 +11,7 @@ package org.openani.mediamp.vlc.compose
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import org.openani.mediamp.features.AspectRatioMode
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.test.Test
@@ -33,7 +34,7 @@ class FrameSizeCalculatorTest {
         val img = IntSize(1920, 1080)          // 16:9
         val frame = Size(800f, 600f)            // 4:3 – width-limited
 
-        c.calculate(img, frame)
+        c.calculate(img, frame, AspectRatioMode.FIT)
 
         // fits in frame
         assertTrue(c.dstSize.width <= frame.width.roundToInt() + SIZE_EPS)
@@ -61,7 +62,7 @@ class FrameSizeCalculatorTest {
         val img = IntSize(1080, 1920)          // 9:16
         val frame = Size(400f, 900f)            // height-limited
 
-        c.calculate(img, frame)
+        c.calculate(img, frame, AspectRatioMode.FIT)
 
         assertTrue(c.dstSize.width <= frame.width.roundToInt() + SIZE_EPS)
         assertTrue(c.dstSize.height <= frame.height.roundToInt() + SIZE_EPS)
@@ -77,7 +78,7 @@ class FrameSizeCalculatorTest {
         val img = IntSize(1600, 900)          // 16:9
         val frame = Size(300.4f, 200.6f)       // deliberate fractions
 
-        c.calculate(img, frame)
+        c.calculate(img, frame, AspectRatioMode.FIT)
 
         assertTrue(c.dstSize.width <= frame.width.roundToInt() + SIZE_EPS)
         assertTrue(c.dstSize.height <= frame.height.roundToInt() + SIZE_EPS)
@@ -93,7 +94,7 @@ class FrameSizeCalculatorTest {
         val img = IntSize(8000, 6000)
         val frame = Size(1f, 1f)
 
-        c.calculate(img, frame)
+        c.calculate(img, frame, AspectRatioMode.FIT)
 
         assertEquals(IntSize(1, 1), c.dstSize)
         assertEquals(IntOffset(0, 0), c.dstOffset)
@@ -106,12 +107,12 @@ class FrameSizeCalculatorTest {
         val img = IntSize(1920, 1080)
         val frame = Size(500f, 500f)
 
-        c.calculate(img, frame)
+        c.calculate(img, frame, AspectRatioMode.FIT)
         val firstSize = c.dstSize
         val firstOffset = c.dstOffset
 
         // Call again with identical params
-        c.calculate(img, frame)
+        c.calculate(img, frame, AspectRatioMode.FIT)
 
         assertEquals(firstSize, c.dstSize)
         assertEquals(firstOffset, c.dstOffset)


### PR DESCRIPTION
## What
Implements the `VideoAspectRatio` feature to enable dynamic video aspect ratio control across all MediaMP platforms. Users can now switch between `FIT`, `STRETCH`, and `CROP` modes at runtime.

## Where
- VLC (Desktop): Custom `FrameSizeCalculator`
- ExoPlayer (Android): Native `AspectRatioFrameLayout.resizeMode` integration
- AVKit (iOS): Native `AVPlayerLayer.videoGravity` property mapping
- API Layer: Reactive state management via `StateFlow<AspectRatioMode>`

## Why
User can switch different video proportions to adapt to the corresponding screen.

## Testing
- Unit tests for all aspect ratio calculations
- Integration tests for state management
- Cross-platform compatibility verified