### PR TITLE
Fix build Windows Server 2019 workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ on:
     paths-ignore:
     - '**/*macosDmg.md'
 jobs:
-  build_github-windows-2019:
-    name: 'Build (Windows Server 2019 x86_64)'
+  build_github-windows-2022:
+    name: 'Build (Windows Server 2022 x86_64)'
     runs-on:
-    - 'windows-2019'
+    - 'windows-2022'
     permissions:
       actions: 'write'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,10 @@ jobs:
         prerelease: '${{ contains(steps.step-1.outputs.tag, ''-'') }}'
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-  release_github-windows-2019:
-    name: 'Windows Server 2019 x86_64'
+  release_github-windows-2022:
+    name: 'Windows Server 2022 x86_64'
     runs-on:
-    - 'windows-2019'
+    - 'windows-2022'
     needs:
     - 'create-release'
     steps:
@@ -236,7 +236,7 @@ jobs:
     - 'macos-13'
     needs:
     - 'create-release'
-    - 'release_github-windows-2019'
+    - 'release_github-windows-2022'
     - 'release_self-hosted-macos-15'
     steps:
     - id: 'step-0'

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -36,8 +36,6 @@
 
 
 import Secrets.GITHUB_REPOSITORY
-import Src_main.Arch
-import Src_main.OS
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.actions.DownloadArtifact
 import io.github.typesafegithub.workflows.actions.actions.GithubScript
@@ -329,8 +327,8 @@ val Runner.isSelfHosted: Boolean
 // Machines for Build and Release
 val buildMatrixInstances = listOf(
     MatrixInstance(
-        runner = Runner.GithubWindowsServer2019,
-        name = "Windows Server 2019 x86_64",
+        runner = Runner.GithubWindowsServer2022,
+        name = "Windows Server 2022 x86_64",
         uploadApk = false,
         composeResourceTriple = "windows-x64",
         gradleHeap = "4g",
@@ -540,7 +538,7 @@ workflow(
         },
     )
 
-    val win = addJob(buildMatrixInstances[Runner.GithubWindowsServer2019])
+    val win = addJob(buildMatrixInstances[Runner.GithubWindowsServer2022])
     val macAarch64 = addJob(buildMatrixInstances[Runner.SelfHostedMacOS15])
 
     addJob(buildMatrixInstances[Runner.GithubMacOS13], needs = listOf(win, macAarch64)) { matrix ->


### PR DESCRIPTION
修复编译 Windows Server 工作流

Windows Server 2019 has been retired.
The Windows Server 2019 image has been removed as of 2025-06-30.
For more details, see https://github.com/actions/runner-images/issues/12045
