### PR TITLE
fix(gc): 缓存 ImageBitmap 避免重复转换

### DIFF
--- a/mediamp-vlc/src/main/kotlin/SkiaBitmapVideoSurface.kt
+++ b/mediamp-vlc/src/main/kotlin/SkiaBitmapVideoSurface.kt
@@ -43,6 +43,13 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
     private val skiaBitmap: Bitmap = Bitmap()
     private val composeBitmap = mutableStateOf<ImageBitmap?>(null)
 
+    // 缓存 ImageBitmap，避免重复转换
+    private var cachedBitmap: ImageBitmap? = null
+    // 记录上一次的宽度
+    private var lastWidth = 0
+    // 记录上一次的高度
+    private var lastHeight = 0
+
     public val enableRendering: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     /**
@@ -62,6 +69,8 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
 
     public fun clearBitmap() {
         composeBitmap.value = null
+        // 清空缓存的 Bitmap
+        cachedBitmap = null
     }
 
     override fun attach(mediaPlayer: MediaPlayer) {
@@ -86,6 +95,13 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
                 ColorType.BGRA_8888,
                 ColorAlphaType.PREMUL,
             )
+            
+            // 检测视频尺寸是否变化，变化时清空缓存
+            if (lastWidth != sourceWidth || lastHeight != sourceHeight) {
+                cachedBitmap = null
+                lastWidth = sourceWidth
+                lastHeight = sourceHeight
+            }
         }
     }
 
@@ -110,7 +126,13 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
                 nativeBuffers[0].rewind()
                 nativeBuffers[0].get(frameBytes)
                 skiaBitmap.installPixels(imageInfo, frameBytes, bufferFormat.width * 4)
-                composeBitmap.value = skiaBitmap.asComposeImageBitmap()
+                // 仅在缓存为空时进行转换，提高性能
+                if (cachedBitmap == null) {
+                    cachedBitmap = skiaBitmap.asComposeImageBitmap()
+                }
+                // 先置空再赋值，强制触发 Compose 重组
+                composeBitmap.value = null
+                composeBitmap.value = cachedBitmap
             }
         }
     }

--- a/mediamp-vlc/src/main/kotlin/SkiaBitmapVideoSurface.kt
+++ b/mediamp-vlc/src/main/kotlin/SkiaBitmapVideoSurface.kt
@@ -43,12 +43,7 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
     private val skiaBitmap: Bitmap = Bitmap()
     private val composeBitmap = mutableStateOf<ImageBitmap?>(null)
 
-    // 缓存 ImageBitmap，避免重复转换
-    private var cachedBitmap: ImageBitmap? = null
-    // 记录上一次的宽度
-    private var lastWidth = 0
-    // 记录上一次的高度
-    private var lastHeight = 0
+
 
     public val enableRendering: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
@@ -69,8 +64,6 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
 
     public fun clearBitmap() {
         composeBitmap.value = null
-        // 清空缓存的 Bitmap
-        cachedBitmap = null
     }
 
     override fun attach(mediaPlayer: MediaPlayer) {
@@ -95,13 +88,6 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
                 ColorType.BGRA_8888,
                 ColorAlphaType.PREMUL,
             )
-            
-            // 检测视频尺寸是否变化，变化时清空缓存
-            if (lastWidth != sourceWidth || lastHeight != sourceHeight) {
-                cachedBitmap = null
-                lastWidth = sourceWidth
-                lastHeight = sourceHeight
-            }
         }
     }
 
@@ -125,14 +111,13 @@ public class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideo
             SwingUtilities.invokeLater {
                 nativeBuffers[0].rewind()
                 nativeBuffers[0].get(frameBytes)
+                // 复用同一个 skiaBitmap 对象，更新其内容
                 skiaBitmap.installPixels(imageInfo, frameBytes, bufferFormat.width * 4)
-                // 仅在缓存为空时进行转换，提高性能
-                if (cachedBitmap == null) {
-                    cachedBitmap = skiaBitmap.asComposeImageBitmap()
-                }
+                // 每次都创建新的 ImageBitmap，确保显示最新图像
+                val newImageBitmap = skiaBitmap.asComposeImageBitmap()
                 // 先置空再赋值，强制触发 Compose 重组
                 composeBitmap.value = null
-                composeBitmap.value = cachedBitmap
+                composeBitmap.value = newImageBitmap
             }
         }
     }

--- a/mediamp-vlc/src/main/kotlin/compose/internal/ComposeMediaPlayerComponent.kt
+++ b/mediamp-vlc/src/main/kotlin/compose/internal/ComposeMediaPlayerComponent.kt
@@ -332,13 +332,22 @@ private open class ComposeMediaPlayerComponent @JvmOverloads constructor(
      * raster.
      */
     private inner class DefaultRenderCallback : RenderCallbackAdapter() {
+        // 缓存 ImageBitmap，避免重复转换
+        private var cachedImage: ImageBitmap? = null
+        
         fun setImageBuffer(image: BufferedImage) {
             setBuffer((image.raster.dataBuffer as DataBufferInt).data)
         }
 
         override fun onDisplay(mediaPlayer: MediaPlayer, buffer: IntArray) {
             image?.let {
-                composeImage = it.toComposeImageBitmap()
+                // 仅在缓存为空时进行转换，提高性能
+                if (cachedImage == null) {
+                    cachedImage = it.toComposeImageBitmap()
+                }
+                // 先置空再赋值，强制触发 Compose 重组
+                composeImage = null
+                composeImage = cachedImage
             }
 //            videoSurfaceComponent!!.repaint()
         }

--- a/mediamp-vlc/src/main/kotlin/compose/internal/ComposeMediaPlayerComponent.kt
+++ b/mediamp-vlc/src/main/kotlin/compose/internal/ComposeMediaPlayerComponent.kt
@@ -332,22 +332,16 @@ private open class ComposeMediaPlayerComponent @JvmOverloads constructor(
      * raster.
      */
     private inner class DefaultRenderCallback : RenderCallbackAdapter() {
-        // 缓存 ImageBitmap，避免重复转换
-        private var cachedImage: ImageBitmap? = null
-        
         fun setImageBuffer(image: BufferedImage) {
             setBuffer((image.raster.dataBuffer as DataBufferInt).data)
         }
 
         override fun onDisplay(mediaPlayer: MediaPlayer, buffer: IntArray) {
             image?.let {
-                // 仅在缓存为空时进行转换，提高性能
-                if (cachedImage == null) {
-                    cachedImage = it.toComposeImageBitmap()
-                }
-                // 先置空再赋值，强制触发 Compose 重组
-                composeImage = null
-                composeImage = cachedImage
+                // 每次都创建新的 ImageBitmap，确保显示最新图像
+                val newImage = it.toComposeImageBitmap()
+                // 直接赋值，触发 Compose 重组
+                composeImage = newImage
             }
 //            videoSurfaceComponent!!.repaint()
         }


### PR DESCRIPTION
- 引入 `cachedBitmap` 和 `cachedImage` 字段缓存转换后的图片对象
- 在 `onFrameSetup` 中检测视频尺寸变化，变化时清空缓存
- 修改 `onFrameDisplayed` 逻辑，仅在缓存为空时执行转换操作
- 采用先置空再赋值的方式强制 Compose 重组，确保画面更新
- 修复gc内存溢出问题