### PR TITLE
添加 Windows ARM64 FFmpeg runtime 支持

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,80 @@ jobs:
     - id: 'step-6'
       name: 'Build FFmpeg artifacts'
       run: './gradlew :mediamp-ffmpeg:ffmpegBuildAll "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=x86_64" "-Pmediamp.ffmpeg.buildvariant=windows"'
+  build_github-windows-11-arm64:
+    name: 'Build (Windows 11 AArch64 (GitHub))'
+    runs-on:
+    - 'windows-11-arm'
+    permissions:
+      actions: 'write'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+      with:
+        lfs: 'true'
+        submodules: 'recursive'
+    - id: 'step-1'
+      name: 'Setup JDK 17 for Windows ARM64'
+      uses: 'gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d'
+      with:
+        java-version: '17'
+        distribution: 'microsoft'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - id: 'step-2'
+      name: 'Setup JBR 21 for other OS'
+      uses: 'gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d'
+      with:
+        java-version: '21'
+        distribution: 'jetbrains'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - id: 'step-3'
+      run: 'echo "jvm.toolchain.version=21" >> local.properties'
+    - id: 'step-4'
+      name: 'Setup MSYS2 clangarm64'
+      uses: 'msys2/setup-msys2@v2'
+      with:
+        msystem: 'CLANGARM64'
+        update: 'true'
+        install: |-
+          mingw-w64-clang-aarch64-clang
+          mingw-w64-clang-aarch64-lld
+          mingw-w64-clang-aarch64-pkgconf
+          mingw-w64-clang-aarch64-nasm
+          mingw-w64-clang-aarch64-openssl
+          mingw-w64-clang-aarch64-ca-certificates
+    - id: 'step-5'
+      name: 'Configure MSYS2 root'
+      run: |-
+        $msys2Dir = '${{ steps.step-4.outputs.msys2-location }}'.Replace('\', '/')
+        "msys2.dir=$msys2Dir" >> local.properties
+    - id: 'step-6'
+      name: 'Setup Gradle'
+      uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        cache-disabled: 'true'
+    - id: 'step-7'
+      name: 'Clean and download dependencies'
+      uses: 'nick-fields/retry@v2'
+      with:
+        timeout_minutes: '60'
+        max_attempts: '3'
+        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+    - id: 'step-8'
+      name: 'Build FFmpeg artifacts'
+      run: './gradlew :mediamp-ffmpeg:ffmpegBuildAll "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+    - id: 'step-9'
+      name: 'Build FFmpeg runtime jar'
+      run: './gradlew :mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+    - id: 'step-10'
+      name: 'Upload FFmpeg runtime jar'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'mediamp-ffmpeg-runtime-windows-arm64'
+        path: 'mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-arm64.jar'
+        if-no-files-found: 'error'
+        overwrite: 'true'
   build_github-ubuntu-2404:
     name: 'Build (Ubuntu 24.04 x86_64)'
     runs-on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,94 @@ jobs:
         path: 'mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-x64.jar'
         if-no-files-found: 'error'
         overwrite: 'true'
+  release_github-windows-11-arm64:
+    name: 'Windows 11 AArch64 (GitHub)'
+    runs-on:
+    - 'windows-11-arm'
+    needs:
+    - 'create-release'
+    steps:
+    - id: 'step-0'
+      uses: 'actions/checkout@v4'
+      with:
+        lfs: 'true'
+        submodules: 'recursive'
+    - id: 'step-1'
+      name: 'Get Tag'
+      uses: 'dawidd6/action-get-tag@v1'
+    - id: 'step-2'
+      uses: 'bhowell2/github-substring-action@v1.0.0'
+      with:
+        value: '${{ steps.step-1.outputs.tag }}'
+        index_of_str: 'v'
+        default_return_value: '${{ steps.step-1.outputs.tag }}'
+    - id: 'step-3'
+      name: 'Setup JDK 17 for Windows ARM64'
+      uses: 'gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d'
+      with:
+        java-version: '17'
+        distribution: 'microsoft'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - id: 'step-4'
+      name: 'Setup JBR 21 for other OS'
+      uses: 'gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d'
+      with:
+        java-version: '21'
+        distribution: 'jetbrains'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - id: 'step-5'
+      run: 'echo "jvm.toolchain.version=21" >> local.properties'
+    - id: 'step-6'
+      name: 'Setup MSYS2 clangarm64'
+      uses: 'msys2/setup-msys2@v2'
+      with:
+        msystem: 'CLANGARM64'
+        update: 'true'
+        install: |-
+          mingw-w64-clang-aarch64-clang
+          mingw-w64-clang-aarch64-lld
+          mingw-w64-clang-aarch64-pkgconf
+          mingw-w64-clang-aarch64-nasm
+          mingw-w64-clang-aarch64-openssl
+          mingw-w64-clang-aarch64-ca-certificates
+    - id: 'step-7'
+      name: 'Configure MSYS2 root'
+      run: |-
+        $msys2Dir = '${{ steps.step-6.outputs.msys2-location }}'.Replace('\', '/')
+        "msys2.dir=$msys2Dir" >> local.properties
+    - id: 'step-8'
+      name: 'Setup Gradle'
+      uses: 'gradle/actions/setup-gradle@v3'
+      with:
+        cache-disabled: 'true'
+    - id: 'step-9'
+      name: 'Clean and download dependencies'
+      uses: 'nick-fields/retry@v2'
+      with:
+        timeout_minutes: '60'
+        max_attempts: '3'
+        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+    - id: 'step-10'
+      name: 'Update Release Version Name'
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        GITHUB_REPOSITORY: '${{ secrets.GITHUB_REPOSITORY }}'
+        CI_RELEASE_ID: '${{ needs.create-release.outputs.id }}'
+        CI_TAG: '${{ steps.step-1.outputs.tag }}'
+      run: './gradlew updateReleaseVersionNameFromGit "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+    - id: 'step-11'
+      name: 'Build FFmpeg runtime jar'
+      run: './gradlew :mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+    - id: 'step-12'
+      name: 'Upload FFmpeg runtime jar'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'mediamp-ffmpeg-runtime-windows-arm64'
+        path: 'mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-arm64.jar'
+        if-no-files-found: 'error'
+        overwrite: 'true'
   release_github-ubuntu-2404:
     name: 'Ubuntu 24.04 x86_64'
     runs-on:
@@ -269,6 +357,7 @@ jobs:
     needs:
     - 'create-release'
     - 'release_github-windows-2022'
+    - 'release_github-windows-11-arm64'
     - 'release_github-ubuntu-2404'
     - 'release_github-macos-15-intel'
     if: '${{ github.repository == ''open-ani/mediamp'' }}'
@@ -375,16 +464,21 @@ jobs:
     - id: 'step-14'
       uses: 'actions/download-artifact@v4'
       with:
+        name: 'mediamp-ffmpeg-runtime-windows-arm64'
+        path: 'mediamp-ffmpeg/build/prebuilt-runtime-jars/windows-arm64'
+    - id: 'step-15'
+      uses: 'actions/download-artifact@v4'
+      with:
         name: 'mediamp-ffmpeg-runtime-linux-x64'
         path: 'mediamp-ffmpeg/build/prebuilt-runtime-jars/linux-x64'
-    - id: 'step-15'
+    - id: 'step-16'
       uses: 'actions/download-artifact@v4'
       with:
         name: 'mediamp-ffmpeg-runtime-macos-x64'
         path: 'mediamp-ffmpeg/build/prebuilt-runtime-jars/macos-x64'
-    - id: 'step-16'
-      run: 'ls -R mediamp-ffmpeg/build/prebuilt-runtime-jars || true'
     - id: 'step-17'
+      run: 'ls -R mediamp-ffmpeg/build/prebuilt-runtime-jars || true'
+    - id: 'step-18'
       name: 'Publish'
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: '${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}'
@@ -393,7 +487,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingInMemoryKeyId: '${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyId }}'
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: '${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}'
       run: './gradlew publish "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=ios,macos,android"'
-    - id: 'step-18'
+    - id: 'step-19'
       name: 'Cleanup temp files'
       continue-on-error: true
       run: 'chmod +x ./ci-helper/cleanup-temp-files-macos.sh && ./ci-helper/cleanup-temp-files-macos.sh'

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -53,6 +53,7 @@ import io.github.typesafegithub.workflows.domain.JobOutputs
 import io.github.typesafegithub.workflows.domain.Mode
 import io.github.typesafegithub.workflows.domain.Permission
 import io.github.typesafegithub.workflows.domain.RunnerType
+import io.github.typesafegithub.workflows.domain.actions.CustomAction
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.JobBuilder
@@ -262,6 +263,14 @@ sealed class Runner(
         labels = setOf("windows-2022"),
     )
 
+    object GithubWindows11Arm64 : GithubHosted(
+        id = "github-windows-11-arm64",
+        displayName = "Windows 11 AArch64 (GitHub)",
+        os = OS.WINDOWS,
+        arch = Arch.AARCH64,
+        labels = setOf("windows-11-arm"),
+    )
+
     object GithubMacOS14 : GithubHosted(
         id = "github-macos-14",
         displayName = "macOS 14 AArch64 (GitHub)",
@@ -346,6 +355,20 @@ val buildMatrixInstances = listOf(
         buildAllAndroidAbis = false,
     ),
     MatrixInstance(
+        runner = Runner.GithubWindows11Arm64,
+        uploadApk = false,
+        composeResourceTriple = "windows-arm64",
+        gradleHeap = "4g",
+        uploadDesktopInstallers = true,
+        ffmpegBuildVariant = "windows",
+        extraGradleArgs = listOf(
+            "-P$ANI_ANDROID_ABIS=arm64-v8a",
+        ),
+        buildAllAndroidAbis = false,
+        // The Windows ARM64 job only builds and uploads the FFmpeg runtime artifact.
+        runTests = false,
+    ),
+    MatrixInstance(
         runner = Runner.GithubUbuntu2404,
         name = "Ubuntu 24.04 x86_64",
         uploadApk = false,
@@ -388,6 +411,7 @@ fun getBuildJobBody(matrix: MatrixInstance): JobBuilder<BuildJobOutputs>.() -> U
 
     with(WithMatrix(matrix)) {
         freeSpace()
+        installJdk17ForWindowsArm64()
         installJbr21()
         chmod777()
         installDependencies()
@@ -395,6 +419,7 @@ fun getBuildJobBody(matrix: MatrixInstance): JobBuilder<BuildJobOutputs>.() -> U
 
         gradleCheck()
         buildFfmpegArtifacts()
+        uploadWindowsArm64Runtime()
         verifyAppleXcframeworkPublication()
         // uploadMediampBackendMpv()
 
@@ -535,6 +560,7 @@ workflow(
                 val gitTag = getGitTag()
 
                 freeSpace()
+                installJdk17ForWindowsArm64()
                 installJbr21()
                 chmod777()
                 installDependencies()
@@ -571,6 +597,15 @@ workflow(
             )
         }
     }
+    val winArm64 = addJob(buildMatrixInstances[Runner.GithubWindows11Arm64]) {
+        with(WithMatrix(it)) {
+            uploadFfmpegRuntimeJar(
+                task = ":mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64",
+                artifactName = ArtifactNames.ffmpegRuntimeJar("windows-arm64"),
+                path = "mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-arm64.jar",
+            )
+        }
+    }
     val linux = addJob(buildMatrixInstances[Runner.GithubUbuntu2404]) {
         with(WithMatrix(it)) {
             uploadFfmpegRuntimeJar(
@@ -590,10 +625,10 @@ workflow(
         }
     }
 
-    addJob(buildMatrixInstances[Runner.SelfHostedMacOS15], needs = listOf(win, linux, macX8664)) { matrix ->
+    addJob(buildMatrixInstances[Runner.SelfHostedMacOS15], needs = listOf(win, winArm64, linux, macX8664)) { matrix ->
         with(WithMatrix(matrix)) {
             uploadFfmpegAppleXcframeworkZip()
-            listOf("windows-x64", "linux-x64", "macos-x64").forEach { platformId ->
+            listOf("windows-x64", "windows-arm64", "linux-x64", "macos-x64").forEach { platformId ->
                 uses(
                     action = DownloadArtifact(
                         name = ArtifactNames.ffmpegRuntimeJar(platformId),
@@ -763,6 +798,19 @@ class WithMatrix(
         )
     }
 
+    fun JobBuilder<*>.installJdk17ForWindowsArm64() {
+        if (matrix.isWindowsAArch64) {
+            uses(
+                name = "Setup JDK 17 for Windows ARM64",
+                action = SetupJava_Untyped(
+                    distribution_Untyped = "microsoft",
+                    javaVersion_Untyped = "17",
+                ),
+                env = mapOf("GITHUB_TOKEN" to expr { secrets.GITHUB_TOKEN }),
+            )
+        }
+    }
+
     fun JobBuilder<*>.installGitLfs() {
         when (matrix.os) {
             OS.WINDOWS -> {
@@ -842,6 +890,37 @@ class WithMatrix(
     }
 
     fun JobBuilder<*>.installDependencies() {
+        if (matrix.isWindowsAArch64) {
+            val msys2 = uses(
+                name = "Setup MSYS2 clangarm64",
+                action = CustomAction(
+                    actionOwner = "msys2",
+                    actionName = "setup-msys2",
+                    actionVersion = "v2",
+                    inputs = mapOf(
+                        "msystem" to "CLANGARM64",
+                        "update" to "true",
+                        "install" to """
+                            mingw-w64-clang-aarch64-clang
+                            mingw-w64-clang-aarch64-lld
+                            mingw-w64-clang-aarch64-pkgconf
+                            mingw-w64-clang-aarch64-nasm
+                            mingw-w64-clang-aarch64-openssl
+                            mingw-w64-clang-aarch64-ca-certificates
+                        """.trimIndent(),
+                    ),
+                ),
+            )
+            run(
+                name = "Configure MSYS2 root",
+                command = shell(
+                    $$"""
+                    $msys2Dir = '$${expr { msys2.outputs["msys2-location"] }}'.Replace('\', '/')
+                    "msys2.dir=$msys2Dir" >> local.properties
+                    """.trimIndent(),
+                ),
+            )
+        }
         if (matrix.isMacOSX64) {
             run(
                 name = "Install dependencies for macOS",
@@ -874,6 +953,16 @@ class WithMatrix(
             runGradle(
                 name = "Build FFmpeg artifacts",
                 tasks = arrayOf(":mediamp-ffmpeg:ffmpegBuildAll"),
+            )
+        }
+    }
+
+    fun JobBuilder<*>.uploadWindowsArm64Runtime() {
+        if (matrix.isWindowsAArch64) {
+            uploadFfmpegRuntimeJar(
+                task = ":mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64",
+                artifactName = ArtifactNames.ffmpegRuntimeJar("windows-arm64"),
+                path = "mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-arm64.jar",
             )
         }
     }
@@ -994,6 +1083,7 @@ val MatrixInstance.isUnix get() = (os == OS.UBUNTU) or (os == (OS.MACOS))
 
 val MatrixInstance.isMacOSAArch64 get() = (os == OS.MACOS) and (arch == Arch.AARCH64)
 val MatrixInstance.isMacOSX64 get() = (os == OS.MACOS) and (arch == Arch.X64)
+val MatrixInstance.isWindowsAArch64 get() = (os == OS.WINDOWS) and (arch == Arch.AARCH64)
 fun MatrixInstance.hasFfmpegBuildVariant(variant: String): Boolean {
     return ffmpegBuildVariant?.split(',')?.map { it.trim() }?.any { it == variant } == true
 }

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegBuildTasks.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegBuildTasks.kt
@@ -59,7 +59,7 @@ internal fun registerHostFfmpegTasks(context: FfmpegBuildContext) {
     when (context.hostOs) {
         Os.Windows -> {
             if (context.isBuildVariantEnabled("windows")) {
-                previousTargetTask = registerFfmpegTasks(context, context.windowsTarget(), sourceTemplateTask, sourceTemplateDir, previousTargetTask)
+                previousTargetTask = registerFfmpegTasks(context, context.hostWindowsTarget(), sourceTemplateTask, sourceTemplateDir, previousTargetTask)
             } else {
                 project.logger.lifecycle(
                     "Skipping FFmpeg windows targets: ${context.buildProperties.buildVariantPropertyName} does not include 'windows'.",
@@ -117,7 +117,12 @@ internal fun registerHostFfmpegTasks(context: FfmpegBuildContext) {
     }
 }
 
-internal fun FfmpegBuildContext.windowsTarget(): FfmpegBuildTarget = FfmpegBuildTarget(
+internal fun FfmpegBuildContext.hostWindowsTarget(): FfmpegBuildTarget = when (hostArch) {
+    Arch.AARCH64 -> windowsArm64Target()
+    else -> windowsX64Target()
+}
+
+private fun FfmpegBuildContext.windowsX64Target(): FfmpegBuildTarget = FfmpegBuildTarget(
     name = "WindowsX64",
     extraFlags = listOf(
         "--arch=x86_64",
@@ -135,6 +140,45 @@ internal fun FfmpegBuildContext.windowsTarget(): FfmpegBuildTarget = FfmpegBuild
     shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
     libExtension = "dll",
     libPrefix = "",
+    msys2Packages = listOf(
+        "make",
+        "diffutils",
+        "pkg-config",
+        "mingw-w64-ucrt-x86_64-ca-certificates",
+        "mingw-w64-ucrt-x86_64-gcc",
+        "mingw-w64-ucrt-x86_64-nasm",
+        "mingw-w64-ucrt-x86_64-openssl",
+    ),
+)
+
+private fun FfmpegBuildContext.windowsArm64Target(): FfmpegBuildTarget = FfmpegBuildTarget(
+    name = "WindowsArm64",
+    extraFlags = listOf(
+        "--arch=aarch64",
+        "--target-os=mingw32",
+        "--cc=${msys2Dir.resolve("clangarm64/bin/clang.exe").absolutePath.toMsysPath()}",
+        "--cxx=${msys2Dir.resolve("clangarm64/bin/clang++.exe").absolutePath.toMsysPath()}",
+        "--enable-openssl",
+        "--enable-protocol=udp",
+        "--enable-protocol=tcp",
+        "--enable-protocol=tls",
+        "--enable-protocol=http",
+        "--enable-protocol=https",
+    ),
+    env = mapOf("MSYSTEM" to "CLANGARM64"),
+    shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
+    libExtension = "dll",
+    libPrefix = "",
+    msys2Packages = listOf(
+        "make",
+        "diffutils",
+        "pkg-config",
+        "mingw-w64-clang-aarch64-ca-certificates",
+        "mingw-w64-clang-aarch64-clang",
+        "mingw-w64-clang-aarch64-nasm",
+        "mingw-w64-clang-aarch64-openssl",
+        "mingw-w64-clang-aarch64-pkgconf",
+    ),
 )
 
 private fun registerAndroidTargetsIfAvailable(
@@ -192,6 +236,7 @@ private fun registerFfmpegTasks(
         if (msys2Dir != null) {
             this.msys2Dir.set(msys2Dir)
         }
+        msys2Packages.set(target.msys2Packages)
     }
 
     val buildTask = project.tasks.register<FfmpegBuildTask>("ffmpegBuild${target.name}") {
@@ -222,7 +267,7 @@ private fun registerFfmpegTasks(
         buildDirPath.set(buildDir)
         this.installDir.set(installDir)
         this.outputDir.set(project.layout.buildDirectory.dir("ffmpeg-output/${target.name}"))
-        if (target.name.startsWith("Android") || target.name == "LinuxX64" || target.name == "MacosArm64" || target.name == "MacosX64" || target.name == "WindowsX64") {
+        if (target.name.startsWith("Android") || target.name == "LinuxX64" || target.name == "MacosArm64" || target.name == "MacosX64" || target.name.startsWith("Windows")) {
             commandWrapperSource.set(context.commandWrapperSource)
             jniWrapperSource.set(context.jniWrapperSource)
         }

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegRuntimePublishing.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegRuntimePublishing.kt
@@ -223,7 +223,10 @@ private fun runtimeManifestEntries(
             val msys2Root = msys2Dir ?: error("MSYS2 directory must be available when packaging Windows FFmpeg runtimes.")
             orderWindowsDllsByDependencies(
                 execOperations = execOperations,
-                objdumpExecutable = resolveWindowsObjdump(msys2Root),
+                objdumpExecutable = resolveWindowsObjdump(
+                    msys2Root,
+                    windowsMsysBinDir(target),
+                ),
                 dllFiles = dependencyLibraries,
             )
         }
@@ -249,6 +252,13 @@ private fun runtimeManifestEntries(
     return (orderedShared + wrapperFiles.sortedBy { it.name.lowercase() } + orderedNonShared)
         .map { manifestRelativePath(outputDir, it) }
 }
+
+private fun windowsMsysBinDir(target: DesktopRuntimeTarget): String =
+    when (target.targetName) {
+        "WindowsArm64" -> "clangarm64/bin"
+        "WindowsX64" -> "ucrt64/bin"
+        else -> error("Unknown Windows FFmpeg runtime target: ${target.targetName}")
+    }
 
 private fun wrapperLibraryName(os: String): String =
     when (os) {

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegSupport.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegSupport.kt
@@ -36,6 +36,7 @@ internal data class FfmpegBuildTarget(
     val shell: String = "bash",
     val libExtension: String,
     val libPrefix: String = "lib",
+    val msys2Packages: List<String> = emptyList(),
 )
 
 internal data class AppleRuntimeTarget(

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTaskTypes.kt
@@ -60,6 +60,9 @@ abstract class FfmpegConfigureTask : DefaultTask() {
     @get:Optional
     abstract val msys2Dir: DirectoryProperty
 
+    @get:Input
+    abstract val msys2Packages: ListProperty<String>
+
     @get:Inject
     abstract val execOperations: ExecOperations
 
@@ -85,16 +88,8 @@ abstract class FfmpegConfigureTask : DefaultTask() {
         if (hostOs == "Windows") {
             val msys2Root = msys2Dir.orNull?.asFile
                 ?: error("MSYS2 directory must be configured for Windows FFmpeg builds.")
-            val packages = listOf(
-                "make",
-                "diffutils",
-                "pkg-config",
-                "mingw-w64-ucrt-x86_64-ca-certificates",
-                "mingw-w64-ucrt-x86_64-gcc",
-                "mingw-w64-ucrt-x86_64-nasm",
-                "mingw-w64-ucrt-x86_64-openssl",
-            )
-            logger.lifecycle("Ensuring MSYS2 UCRT64 packages: ${packages.joinToString()}")
+            val packages = msys2Packages.get()
+            logger.lifecycle("Ensuring MSYS2 packages: ${packages.joinToString()}")
             execOperations.exec {
                 commandLine(
                     shell.get(),
@@ -284,7 +279,7 @@ abstract class FfmpegAssembleTask : DefaultTask() {
         }
 
         when (targetName.get()) {
-            "WindowsX64" -> {
+            "WindowsX64", "WindowsArm64" -> {
                 buildJvmJniWrapper(
                     execOperations = execOperations,
                     logger = logger,
@@ -301,12 +296,14 @@ abstract class FfmpegAssembleTask : DefaultTask() {
                 copyWindowsTlsCertificates(
                     logger = logger,
                     msys2Dir = msys2Root,
+                    targetName = targetName.get(),
                     outputDir = outputDirFile,
                 )
                 collectWindowsRuntimeDlls(
                     execOperations = execOperations,
                     logger = logger,
                     msys2Dir = msys2Root,
+                    targetName = targetName.get(),
                     ffmpegLibNames = ffmpegLibNames.get(),
                     outputDir = outputDirFile,
                 )
@@ -362,9 +359,10 @@ abstract class FfmpegAssembleTask : DefaultTask() {
 private fun copyWindowsTlsCertificates(
     logger: Logger,
     msys2Dir: File,
+    targetName: String,
     outputDir: File,
 ) {
-    val certFile = msys2Dir.resolve("ucrt64/etc/ssl/cert.pem")
+    val certFile = msys2Dir.resolve("${windowsMsysRootName(targetName)}/etc/ssl/cert.pem")
     if (!certFile.isFile) return
 
     val targetFile = outputDir.resolve("etc/ssl/cert.pem")
@@ -393,7 +391,7 @@ private fun buildJvmJniWrapper(
 
     val config = readFfmpegConfig(buildDir.resolve("ffbuild/config.mak"))
     val wrapperName = when {
-        targetName == "WindowsX64" -> "ffmpegkitjni.dll"
+        targetName.startsWith("Windows") -> "ffmpegkitjni.dll"
         targetName.startsWith("Macos") -> "libffmpegkitjni.dylib"
         else -> "libffmpegkitjni.so"
     }
@@ -431,7 +429,7 @@ private fun buildJvmJniWrapper(
         .onEach { require(it.isDirectory) { "FFmpeg include directory not found at ${it.absolutePath}" } }
         .joinToString(" ") { "-I${shellQuote(pathForShell(it, windowsMsys))}" }
     val linkerMode = when {
-        targetName == "WindowsX64" -> "-shared"
+        targetName.startsWith("Windows") -> "-shared"
         targetName.startsWith("Macos") -> "-dynamiclib -Wl,-install_name,@loader_path/$wrapperName"
         else -> "-shared"
     }
@@ -444,7 +442,7 @@ private fun buildJvmJniWrapper(
         append("-L${shellQuote(pathForShell(buildDir.resolve("libswscale"), windowsMsys))} ")
         append("-L${shellQuote(pathForShell(buildDir.resolve("libavutil"), windowsMsys))} ")
         append("-lavdevice -lavfilter -lavformat -lavcodec -lswresample -lswscale -lavutil -lm -pthread")
-        if (targetName == "WindowsX64") {
+        if (targetName.startsWith("Windows")) {
             append(" -lstdc++")
         }
     }
@@ -477,7 +475,7 @@ private fun buildJvmJniWrapper(
     execOperations.exec {
         commandLine(shell, "-l", "-c", "cd $buildDirPath && $command")
         if (windowsMsys) {
-            environment("MSYSTEM", "UCRT64")
+            environment("MSYSTEM", windowsMsysRootName(targetName).uppercase())
         }
     }
 
@@ -550,11 +548,12 @@ private fun collectWindowsRuntimeDlls(
     execOperations: ExecOperations,
     logger: Logger,
     msys2Dir: File,
+    targetName: String,
     ffmpegLibNames: List<String>,
     outputDir: File,
 ) {
-    val ucrt64Bin = msys2Dir.resolve("ucrt64/bin")
-    val objdumpExecutable = resolveWindowsObjdump(msys2Dir)
+    val mingwBin = msys2Dir.resolve("${windowsMsysRootName(targetName)}/bin")
+    val objdumpExecutable = resolveWindowsObjdump(msys2Dir, "${windowsMsysRootName(targetName)}/bin")
     val collectedDlls = mutableSetOf<String>()
 
     fun collectDeps(dllFile: File) {
@@ -563,12 +562,12 @@ private fun collectWindowsRuntimeDlls(
             .filter { dllName ->
                 dllName !in collectedDlls &&
                     !isWindowsSystemLibrary(dllName) &&
-                    ucrt64Bin.resolve(dllName).exists() &&
+                    mingwBin.resolve(dllName).exists() &&
                     ffmpegLibNames.none { lib -> dllName.startsWith(lib) }
             }
             .forEach { dllName ->
                 collectedDlls.add(dllName)
-                val src = ucrt64Bin.resolve(dllName)
+                val src = mingwBin.resolve(dllName)
                 src.copyTo(outputDir.resolve(dllName), overwrite = true)
                 collectDeps(src)
             }
@@ -579,3 +578,6 @@ private fun collectWindowsRuntimeDlls(
         logger.lifecycle("Collected external DLLs from MSYS2: ${collectedDlls.sorted().joinToString()}")
     }
 }
+
+private fun windowsMsysRootName(targetName: String): String =
+    if (targetName == "WindowsArm64") "clangarm64" else "ucrt64"

--- a/buildSrc/src/main/kotlin/nativebuild/NativeBuildSupport.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/NativeBuildSupport.kt
@@ -46,6 +46,7 @@ internal val DEFAULT_ANDROID_ABIS: List<AndroidAbi> = listOf(
 
 internal val DEFAULT_DESKTOP_RUNTIME_TARGETS: List<DesktopRuntimeTarget> = listOf(
     DesktopRuntimeTarget("windows", "x64", "WindowsX64"),
+    DesktopRuntimeTarget("windows", "arm64", "WindowsArm64"),
     DesktopRuntimeTarget("linux", "x64", "LinuxX64"),
     DesktopRuntimeTarget("macos", "arm64", "MacosArm64"),
     DesktopRuntimeTarget("macos", "x64", "MacosX64"),

--- a/buildSrc/src/main/kotlin/nativebuild/SharedLibraryManifest.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/SharedLibraryManifest.kt
@@ -51,10 +51,11 @@ internal fun orderLibrariesByPrefixes(
     }
 }
 
-internal fun resolveWindowsObjdump(msys2Dir: File): File =
-    msys2Dir.resolve("ucrt64/bin/objdump.exe").also { objdump ->
+internal fun resolveWindowsObjdump(msys2Dir: File, binDirName: String = "ucrt64/bin"): File =
+    (msys2Dir.resolve("$binDirName/objdump.exe").takeIf(File::isFile)
+        ?: msys2Dir.resolve("$binDirName/llvm-objdump.exe")).also { objdump ->
         require(objdump.isFile) {
-            "GNU objdump was not found at ${objdump.absolutePath}. Ensure MSYS2 UCRT64 binutils is installed."
+            "GNU objdump was not found under ${msys2Dir.resolve(binDirName).absolutePath}."
         }
     }
 

--- a/buildSrc/src/main/kotlin/os.kt
+++ b/buildSrc/src/main/kotlin/os.kt
@@ -43,7 +43,7 @@ fun getArch(): Arch {
 
 fun getOsTriple(): String {
     return when (getOs()) {
-        Os.Windows -> "windows-x64"
+        Os.Windows -> if (getArch() == Arch.AARCH64) "windows-arm64" else "windows-x64"
         Os.MacOS -> if (getArch() == Arch.AARCH64) "macos-arm64" else "macos-x64"
         Os.Linux -> "linux-x64"
         Os.Unknown -> throw UnsupportedOperationException("Unknown OS")


### PR DESCRIPTION
## 摘要

这个 PR 为 mediamp 增加 Windows ARM64 FFmpeg runtime artifact。

新增的 Windows ARM64 job 会使用 MSYS2 CLANGARM64 构建 FFmpeg，上传 `mediamp-ffmpeg-runtime-windows-arm64` artifact，并接入 release workflow，使最终 Maven publication 包含 `windows-arm64` runtime jar。

## 改动

- 在 build / release workflow 中新增 `windows-11-arm` runner。
- Windows ARM64 job 先安装 Microsoft JDK 17，再安装 JBR 21；JDK 17 供 buildSrc/toolchain 使用，JBR 21 保持现有 workflow 的默认运行时。
- desktop runtime targets 增加 `WindowsArm64`。
- Windows FFmpeg target 按 host 架构选择：
  - `WindowsX64` 继续使用 UCRT64。
  - `WindowsArm64` 使用 CLANGARM64。
- 为 Windows FFmpeg builds 增加 per-target MSYS2 package lists。
- 构建并打包 Windows ARM64 JNI wrapper 和 FFmpeg DLLs。
- 从 `clangarm64/bin` 收集 Windows ARM64 runtime dependencies。
- Windows DLL 依赖排序支持从 `clangarm64/bin` 查找 `llvm-objdump.exe`。
- release publish 聚合阶段下载并消费 `mediamp-ffmpeg-runtime-windows-arm64`。

## 验证

已在 Windows ARM64 本机验证：

```powershell
.\gradlew.bat :mediamp-ffmpeg:ffmpegBuildAll :mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64 `
  --no-configuration-cache `
  -Pani.android.abis=arm64-v8a `
  -Pmediamp.ffmpeg.buildvariant=windows
```

生成的 `windows-arm64` runtime jar 包含：

- `ffmpegkitjni.dll`
- `avcodec-62.dll`
- `avformat-62.dll`
- `avutil-60.dll`
- `swresample-6.dll`
- `swscale-9.dll`
- `libcrypto-3-arm64.dll`
- `libssl-3-arm64.dll`
- `etc/ssl/cert.pem`

也验证了：

```powershell
kotlin .github\workflows\src.main.kts
git diff --check
```

## 说明

Windows ARM64 CI job 只构建并上传 FFmpeg runtime artifact。现有 Windows x64、Linux 和 macOS jobs 仍继续覆盖正常 Gradle checks。

Windows x64 保持使用 MSYS2 UCRT64。Windows ARM64 使用 MSYS2 CLANGARM64，因为这是 AArch64 Windows FFmpeg native build 可用的 MinGW/LLVM 环境。

`src.main.kts` 是 workflow 源文件，`build.yml` / `release.yml` 是生成结果；本 PR 同时提交生成后的 YAML。