### PR TITLE
[codex] Fix mediamp playback state and seek handling

### DIFF
--- a/mediamp-api/src/commonMain/kotlin/MediampPlayer.kt
+++ b/mediamp-api/src/commonMain/kotlin/MediampPlayer.kt
@@ -46,8 +46,11 @@ import org.openani.mediamp.source.UriMediaData
  *       |            |           |            |            |          |            |             |
  *       |            |           |            |            |----------+----------->|             |  resume
  *       |            |           |            |            |          |            |             |
- *       |            |           |            |            |          |            |------------>|  (buffering) 
- *       |            |           |            |            |          |            |             |  seekTo/skip
+ *       |            |           |            |            |----------+------------------------->|  resume
+ *       |            |           |            |            |          |            |             |  (buffering)
+ *       |            |           |            |            |          |            |             |
+ *       |            |           |            |            |          |            |------------>|  seekTo/skip
+ *       |            |           |            |            |          |            |             |  (buffering)
  *       |            |           |            |            |          |            |             |  
  *       |            |           |            |            |          |            |<------------|  (buffer complete)
  *       |            |           |            |            |          |            |             |

--- a/mediamp-avkit/src/appleMain/kotlin/AVKitMediampPlayer.kt
+++ b/mediamp-avkit/src/appleMain/kotlin/AVKitMediampPlayer.kt
@@ -90,6 +90,8 @@ public class AVKitMediampPlayer(
     override val currentPositionMillis: MutableStateFlow<Long> = MutableStateFlow(0L)
 
     private var hasPlaybackStarted: Boolean = false
+    private var chaseSeekMillis: Long? = null
+    private var isSeekInProgress: Boolean = false
 
     @OptIn(ExperimentalMediampApi::class)
     private val bufferingFeature = object : Buffering {
@@ -142,6 +144,7 @@ public class AVKitMediampPlayer(
             super.release()
             mediaProperties.value = null
             currentPositionMillis.value = 0L
+            clearChaseSeek()
             bufferingFeature.isBuffering.value = false
             bufferingFeature.bufferedPercentage.value = 0
             hasPlaybackStarted = false
@@ -175,6 +178,7 @@ public class AVKitMediampPlayer(
         bufferingFeature.isBuffering.value = false
         bufferingFeature.bufferedPercentage.value = 0
         currentPositionMillis.value = 0L
+        clearChaseSeek()
         mediaProperties.value = null
 
         val playerItem = when (data) {
@@ -217,6 +221,7 @@ public class AVKitMediampPlayer(
         bufferingFeature.bufferedPercentage.value = 0
         playbackState.value = PlaybackState.FINISHED
         currentPositionMillis.value = 0L
+        clearChaseSeek()
         impl.pause()
         impl.replaceCurrentItemWithPlayerItem(null)
     }
@@ -228,12 +233,9 @@ public class AVKitMediampPlayer(
             // doc says ignore if < READY
             return
         }
-        val item = impl.currentItem ?: return
-        // Convert from ms to CMTime
-        val clamped = positionMillis.coerceAtLeast(0L)
-        val timeSec = clamped.toDouble() / 1000.0
-        val cmTime = platform.CoreMedia.CMTimeMakeWithSeconds(timeSec, preferredTimescale = 600)
-        item.seekToTime(cmTime)
+        val clamped = coercePositionMillis(positionMillis)
+        chaseSeekMillis = clamped
+        trySeekToChasePosition()
         currentPositionMillis.value = clamped
     }
 
@@ -261,6 +263,7 @@ public class AVKitMediampPlayer(
     override fun closeImpl() {
         playbackState.value = PlaybackState.DESTROYED
         removePlayerItemObservers()
+        clearChaseSeek()
 
         timeControlStatusObserver?.let {
             impl.removeObserver(it, OBSERVATION_KEY_TIME_CONTROL_STATUS)
@@ -349,6 +352,69 @@ public class AVKitMediampPlayer(
             title = null, // Could parse from metadata if you wish
             durationMillis = ms,
         )
+        trySeekToChasePosition()
+    }
+
+    private fun coercePositionMillis(positionMillis: Long): Long {
+        val durationMillis = mediaProperties.value?.durationMillis?.takeIf { it > 0 }
+        return if (durationMillis == null) {
+            positionMillis.coerceAtLeast(0)
+        } else {
+            positionMillis.coerceIn(0, durationMillis)
+        }
+    }
+
+    private fun trySeekToChasePosition() {
+        val targetMillis = chaseSeekMillis ?: return
+        if (isSeekInProgress) {
+            return
+        }
+        val item = impl.currentItem ?: return
+        if (item.status != AVPlayerItemStatusReadyToPlay) {
+            return
+        }
+        seekToChasePosition(targetMillis)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun seekToChasePosition(targetMillis: Long) {
+        isSeekInProgress = true
+        val timeSec = targetMillis.toDouble() / 1000.0
+        val cmTime = platform.CoreMedia.CMTimeMakeWithSeconds(timeSec, preferredTimescale = 600)
+        val zeroTolerance = platform.CoreMedia.CMTimeMakeWithSeconds(0.0, preferredTimescale = 600)
+        impl.seekToTime(
+            time = cmTime,
+            toleranceBefore = zeroTolerance,
+            toleranceAfter = zeroTolerance,
+            completionHandler = { finished ->
+                coroutineScope.launch {
+                    handleSeekCompletion(targetMillis, finished)
+                }
+            },
+        )
+    }
+
+    private fun handleSeekCompletion(targetMillis: Long, finished: Boolean) {
+        if (playbackState.value < PlaybackState.READY) {
+            isSeekInProgress = false
+            return
+        }
+
+        isSeekInProgress = false
+        if (chaseSeekMillis == targetMillis) {
+            if (finished) {
+                chaseSeekMillis = null
+                currentPositionMillis.value = targetMillis
+            }
+            return
+        }
+
+        trySeekToChasePosition()
+    }
+
+    private fun clearChaseSeek() {
+        chaseSeekMillis = null
+        isSeekInProgress = false
     }
 
     private suspend fun awaitPlayerItemReady(playerItem: AVPlayerItem) {

--- a/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
+++ b/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
@@ -367,17 +367,19 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
                 data,
                 setPlay = {
                     val lowerHeaders = data.headers.mapKeys { it.key.lowercase() }
-                    player.media().play(
-                        data.uri,
-                        *buildList {
-                            add("http-user-agent=${lowerHeaders["user-agent"] ?: "Mozilla/5.0"}")
-                            val referer = lowerHeaders["referer"]
-                            if (referer != null) {
-                                add("http-referrer=${referer}")
-                            }
-                            addAll(data.options)
-                        }.toTypedArray(),
-                    )
+                    player.submit {
+                        player.media().play(
+                            data.uri,
+                            *buildList {
+                                add("http-user-agent=${lowerHeaders["user-agent"] ?: "Mozilla/5.0"}")
+                                val referer = lowerHeaders["referer"]
+                                if (referer != null) {
+                                    add("http-referrer=${referer}")
+                                }
+                                addAll(data.options)
+                            }.toTypedArray(),
+                        )
+                    }
                     lastMedia = null
                 },
             ).also {
@@ -424,7 +426,15 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
     override fun resumeImpl() {
         when (val state = playbackState.value) {
             PlaybackState.READY -> {
-                openResource.value?.play()
+                val resource = openResource.value ?: return
+                playbackStateMapper.onPlayRequested(state)
+                try {
+                    resource.play()
+                } catch (e: Throwable) {
+                    playbackStateMapper.reset()
+                    playbackState.value = PlaybackState.ERROR
+                    throw e
+                }
 
                 //        player.media().options().add(*arrayOf(":avcodec-hw=none")) // dxva2
                 //        player.controls().play()
@@ -446,7 +456,7 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
             return
         }
         @Suppress("NAME_SHADOWING")
-        val positionMillis = positionMillis.coerceIn(0, mediaProperties.value?.durationMillis ?: 0)
+        val positionMillis = coercePositionMillis(positionMillis)
         if (positionMillis == currentPositionMillis.value) {
             return
         }
@@ -467,8 +477,7 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
         if (playbackState.value == PlaybackState.PAUSED) {
             // 如果是暂停, 上面 positionChanged 事件不会触发, 所以这里手动更新
             // 如果正在播放, 这里不能更新. 否则可能导致进度抖动 1 秒
-            currentPositionMillis.value = (currentPositionMillis.value + deltaMillis)
-                .coerceIn(0, mediaProperties.value?.durationMillis ?: 0)
+            currentPositionMillis.value = coercePositionMillis(currentPositionMillis.value + deltaMillis)
         }
         player.submit {
             setTimeLock.withLock {
@@ -476,6 +485,15 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
             }
         }
         surface.setAllowedDrawFrames(2) // 多渲染一帧, 防止 race 问题
+    }
+
+    private fun coercePositionMillis(positionMillis: Long): Long {
+        val durationMillis = mediaProperties.value?.durationMillis?.takeIf { it > 0 }
+        return if (durationMillis == null) {
+            positionMillis.coerceAtLeast(0)
+        } else {
+            positionMillis.coerceIn(0, durationMillis)
+        }
     }
 
     override fun pauseImpl() {

--- a/mediamp-vlc/src/main/kotlin/internal/VlcPlaybackStateMapper.kt
+++ b/mediamp-vlc/src/main/kotlin/internal/VlcPlaybackStateMapper.kt
@@ -11,10 +11,18 @@ package org.openani.mediamp.vlc.internal
 import org.openani.mediamp.PlaybackState
 
 internal class VlcPlaybackStateMapper {
+    private var hasPlayRequested: Boolean = false
     private var hasPlaybackStarted: Boolean = false
 
     fun reset() {
+        hasPlayRequested = false
         hasPlaybackStarted = false
+    }
+
+    fun onPlayRequested(currentState: PlaybackState) {
+        if (currentState == PlaybackState.READY) {
+            hasPlayRequested = true
+        }
     }
 
     fun onPlaying(currentState: PlaybackState): PlaybackState? {
@@ -22,6 +30,7 @@ internal class VlcPlaybackStateMapper {
             return null
         }
 
+        hasPlayRequested = false
         hasPlaybackStarted = true
         return PlaybackState.PLAYING
     }
@@ -35,12 +44,14 @@ internal class VlcPlaybackStateMapper {
     }
 
     fun onBuffering(currentState: PlaybackState, bufferedPercentage: Float): PlaybackState? {
-        if (!hasPlaybackStarted) {
-            return null
-        }
-
         return if (bufferedPercentage < 100f) {
             when (currentState) {
+                PlaybackState.READY -> if (hasPlayRequested) {
+                    PlaybackState.PAUSED_BUFFERING
+                } else {
+                    null
+                }
+
                 PlaybackState.PLAYING,
                 PlaybackState.PAUSED_BUFFERING,
                 -> PlaybackState.PAUSED_BUFFERING
@@ -48,7 +59,7 @@ internal class VlcPlaybackStateMapper {
                 else -> null
             }
         } else {
-            if (currentState == PlaybackState.PAUSED_BUFFERING) {
+            if (currentState == PlaybackState.PAUSED_BUFFERING && hasPlaybackStarted) {
                 PlaybackState.PLAYING
             } else {
                 null

--- a/mediamp-vlc/src/test/kotlin/VlcPlaybackStateMapperTest.kt
+++ b/mediamp-vlc/src/test/kotlin/VlcPlaybackStateMapperTest.kt
@@ -25,6 +25,28 @@ class VlcPlaybackStateMapperTest {
     }
 
     @Test
+    fun `resume can transition directly from ready to playing`() {
+        val mapper = VlcPlaybackStateMapper()
+
+        mapper.onPlayRequested(PlaybackState.READY)
+
+        assertEquals(PlaybackState.PLAYING, mapper.onPlaying(PlaybackState.READY))
+    }
+
+    @Test
+    fun `initial buffering after resume maps ready to paused buffering until playing callback`() {
+        val mapper = VlcPlaybackStateMapper()
+
+        assertNull(mapper.onBuffering(PlaybackState.READY, 20f))
+
+        mapper.onPlayRequested(PlaybackState.READY)
+
+        assertEquals(PlaybackState.PAUSED_BUFFERING, mapper.onBuffering(PlaybackState.READY, 20f))
+        assertNull(mapper.onBuffering(PlaybackState.PAUSED_BUFFERING, 100f))
+        assertEquals(PlaybackState.PLAYING, mapper.onPlaying(PlaybackState.PAUSED_BUFFERING))
+    }
+
+    @Test
     fun `paused player stays paused during seek buffering`() {
         val mapper = VlcPlaybackStateMapper()
         mapper.onPlaying(PlaybackState.READY)


### PR DESCRIPTION
## Summary
- Fix VLC playback state mapping so the first resume from READY can become PAUSED_BUFFERING only when VLC reports buffering, and PLAYING only when playback actually starts.
- Fix VLC seek clamping so an unknown duration no longer coerces requested seek positions to 0.
- Fix AVKit seek handling by using AVPlayer's completion-based chase seek with zero tolerance instead of a one-shot AVPlayerItem seek.
- Remove the local smoke test artifacts before publishing; the PR contains only implementation changes and mapper unit tests.

## Root Cause
The VLC state mapper did not distinguish an explicit resume request from passive READY state, so initial buffering and playing callbacks could be mapped incorrectly. VLC seek also clamped against duration 0 when metadata was not ready, dropping saved progress seeks to the beginning.

For AVKit, the one-shot `seekToTime` call did not use the precise tolerance/completion API. AVPlayer seek is asynchronous and can be interrupted by newer seeks, so the implementation now follows the completion-based chase-seek pattern.

## Validation
- `./gradlew.bat :mediamp-avkit:check` passed on Windows. iOS native compile/test tasks were skipped by Gradle because the Apple targets with cinterop are disabled on `mingw_x64`.
- `./gradlew.bat :mediamp-vlc:test '-Pversion.name=0.1.0-dev-codex'` passed. The version override avoids a local locked `mediamp-api-desktop-0.1.0-dev-667.jar` left by prior desktop validation.
- Earlier manual smoke validation covered VLC desktop playback progress and Android Exo playback state behavior; smoke test sources were removed from this PR.
