### PR TITLE
fix: keep subtitle track selection stable across pause/resume/refresh

### DIFF
--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
@@ -78,6 +78,22 @@ internal val commonConfigureFlags: List<String> = buildList {
     add("--enable-decoder=opus")
     add("--enable-decoder=mp3")
     add("--enable-decoder=flac")
+    // Subtitle decoders. The Matroska/mov demuxers still enumerate subtitle streams
+    // without these, so track pickers list tracks that then fail to open — mpv logs
+    // "Could not find subtitle decoder for format 'subrip'" and silently deselects
+    // the track (open-ani/animeko#1128).
+    add("--enable-decoder=ass")
+    add("--enable-decoder=ssa")
+    add("--enable-decoder=srt")
+    add("--enable-decoder=subrip")
+    add("--enable-decoder=text")
+    add("--enable-decoder=webvtt")
+    // configure component names come from ff_<name>_decoder symbols: the MP4 timed-text
+    // decoder is "movtext" here even though `ffmpeg -decoders` lists it as "mov_text"
+    // (unknown --enable-decoder values are silently ignored).
+    add("--enable-decoder=movtext")
+    add("--enable-decoder=pgssub")
+    add("--enable-decoder=dvdsub")
     add("--enable-muxer=mp4")
     add("--enable-muxer=matroska")
     add("--enable-muxer=mpegts")
@@ -89,6 +105,10 @@ internal val commonConfigureFlags: List<String> = buildList {
     add("--enable-demuxer=ogg")
     add("--enable-demuxer=aac")
     add("--enable-demuxer=concat")
+    // External subtitle files (mpv loads them through libavformat).
+    add("--enable-demuxer=ass")
+    add("--enable-demuxer=srt")
+    add("--enable-demuxer=webvtt")
     // Local encrypted HLS still needs the HLS demuxer so FFmpeg can interpret
     // EXT-X-KEY metadata instead of treating segments as plain concatenated TS.
     add("--enable-demuxer=hls")

--- a/mediamp-api/src/commonMain/kotlin/metadata/Track.kt
+++ b/mediamp-api/src/commonMain/kotlin/metadata/Track.kt
@@ -12,21 +12,87 @@ import org.openani.mediamp.InternalMediampApi
 
 public sealed interface Track
 
+/*
+ * Value equality on these types is load-bearing: player backends re-create track
+ * instances on every native tracks-changed callback and compare the new candidate
+ * list against the previous one to decide whether the selection must be reset.
+ * With identity equality that comparison is always `false` for non-empty lists,
+ * which resets the user's subtitle selection on every refresh (open-ani/animeko#1128).
+ */
+
 public class SubtitleTrack @InternalMediampApi constructor(
     public val id: String,
     public val internalId: String,
     public val language: String?,
     public val labels: List<TrackLabel>,
-) : Track
+) : Track {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SubtitleTrack) return false
+        return id == other.id &&
+                internalId == other.internalId &&
+                language == other.language &&
+                labels == other.labels
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + internalId.hashCode()
+        result = 31 * result + (language?.hashCode() ?: 0)
+        result = 31 * result + labels.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "SubtitleTrack(id='$id', internalId='$internalId', language=$language, labels=$labels)"
+    }
+}
 
 public class AudioTrack @InternalMediampApi constructor(
     public val id: String,
     public val internalId: String,
     public val name: String?,
     public val labels: List<TrackLabel>,
-) : Track
+) : Track {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AudioTrack) return false
+        return id == other.id &&
+                internalId == other.internalId &&
+                name == other.name &&
+                labels == other.labels
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + internalId.hashCode()
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + labels.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "AudioTrack(id='$id', internalId='$internalId', name=$name, labels=$labels)"
+    }
+}
 
 public class TrackLabel @InternalMediampApi constructor(
     public val language: String?, // "zh" 这指的是 value 的语言
     public val value: String // "CHS", "简日", "繁日"
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TrackLabel) return false
+        return language == other.language && value == other.value
+    }
+
+    override fun hashCode(): Int {
+        var result = language?.hashCode() ?: 0
+        result = 31 * result + value.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "TrackLabel(language=$language, value='$value')"
+    }
+}

--- a/mediamp-api/src/commonTest/kotlin/metadata/TrackTest.kt
+++ b/mediamp-api/src/commonTest/kotlin/metadata/TrackTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.metadata
+
+import org.openani.mediamp.InternalMediampApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Player backends re-create track instances on every native tracks-changed callback
+ * and compare candidate lists to decide whether to reset the selection, so these
+ * types must have value equality (open-ani/animeko#1128).
+ */
+@OptIn(InternalMediampApi::class)
+class TrackTest {
+    private fun subtitleTrack(
+        id: String = "sub-1",
+        internalId: String = "1",
+        language: String? = "zh",
+        labels: List<TrackLabel> = listOf(TrackLabel("zh", "简日")),
+    ) = SubtitleTrack(id, internalId, language, labels)
+
+    private fun audioTrack(
+        id: String = "audio-1",
+        internalId: String = "1",
+        name: String? = "main",
+        labels: List<TrackLabel> = listOf(TrackLabel(null, "AAC")),
+    ) = AudioTrack(id, internalId, name, labels)
+
+    @Test
+    fun `subtitle tracks with same fields are equal`() {
+        assertEquals(subtitleTrack(), subtitleTrack())
+        assertEquals(subtitleTrack().hashCode(), subtitleTrack().hashCode())
+    }
+
+    @Test
+    fun `subtitle tracks with different fields are not equal`() {
+        assertNotEquals(subtitleTrack(), subtitleTrack(id = "sub-2"))
+        assertNotEquals(subtitleTrack(), subtitleTrack(internalId = "2"))
+        assertNotEquals(subtitleTrack(), subtitleTrack(language = null))
+        assertNotEquals(subtitleTrack(), subtitleTrack(labels = emptyList()))
+    }
+
+    @Test
+    fun `audio tracks with same fields are equal`() {
+        assertEquals(audioTrack(), audioTrack())
+        assertEquals(audioTrack().hashCode(), audioTrack().hashCode())
+    }
+
+    @Test
+    fun `audio tracks with different fields are not equal`() {
+        assertNotEquals(audioTrack(), audioTrack(id = "audio-2"))
+        assertNotEquals(audioTrack(), audioTrack(name = null))
+    }
+
+    @Test
+    fun `subtitle track does not equal audio track with same fields`() {
+        val labels = listOf(TrackLabel("zh", "简日"))
+        assertNotEquals<Track>(
+            SubtitleTrack("x", "1", null, labels),
+            AudioTrack("x", "1", null, labels),
+        )
+    }
+
+    @Test
+    fun `track labels have value equality`() {
+        assertEquals(TrackLabel("zh", "CHS"), TrackLabel("zh", "CHS"))
+        assertEquals(TrackLabel(null, "CHS"), TrackLabel(null, "CHS"))
+        assertNotEquals(TrackLabel("zh", "CHS"), TrackLabel("zh", "CHT"))
+        assertNotEquals(TrackLabel("zh", "CHS"), TrackLabel(null, "CHS"))
+    }
+
+    @Test
+    fun `re-created candidate lists compare equal`() {
+        // This is the exact comparison ExoPlayer/VLC backends perform on refresh.
+        val first = listOf(subtitleTrack(), subtitleTrack(id = "sub-2", internalId = "2"))
+        val second = listOf(subtitleTrack(), subtitleTrack(id = "sub-2", internalId = "2"))
+        assertEquals(first, second)
+    }
+}

--- a/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
@@ -171,10 +171,19 @@ class ExoPlayerMediampPlayer @UiThread constructor(
                         group.getSubtitleTracks()
                     }
                     .toList()
-            // 新的字幕轨道和原来不同时才会更改，同时将 current 设置为新字幕轨道列表的第一个
-            if (newSubtitleTracks != mediaMetadataFeature.subtitleTracks.candidates.value) {
+            // 只有候选列表真正变化时才更新（Track 有值相等语义，重新创建的对象不会误判为变化）。
+            // 变化时按 id 恢复原选择：用户选中的轨道仍存在则保持；用户已关闭字幕则保持关闭；
+            // 只有首次出现候选时才默认选择第一轨 (open-ani/animeko#1128)。
+            val oldSubtitleTracks = mediaMetadataFeature.subtitleTracks.candidates.value
+            if (newSubtitleTracks != oldSubtitleTracks) {
+                val previousSelected = mediaMetadataFeature.subtitleTracks.selected.value
                 mediaMetadataFeature.subtitleTracks.candidates.value = newSubtitleTracks
-                mediaMetadataFeature.subtitleTracks.selected.value = newSubtitleTracks.firstOrNull()
+                mediaMetadataFeature.subtitleTracks.selected.value = when {
+                    oldSubtitleTracks.isEmpty() -> newSubtitleTracks.firstOrNull()
+                    previousSelected == null -> null
+                    else -> newSubtitleTracks.firstOrNull { it.id == previousSelected.id }
+                        ?: newSubtitleTracks.firstOrNull()
+                }
             }
 
             mediaMetadataFeature.audioTracks.candidates.value =

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvMediampPlayerSmokeTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvMediampPlayerSmokeTest.kt
@@ -9,7 +9,9 @@
 package org.openani.mediamp.mpv
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.openani.mediamp.ExperimentalMediampApi
@@ -116,6 +118,28 @@ class MpvMediampPlayerSmokeTest {
     }
 
     /**
+     * Container with two SRT subtitle tracks. SRT requires the FFmpeg subrip decoder,
+     * which the bundled FFmpeg build must include (open-ani/animeko#1128).
+     */
+    private fun generateDualSubtitleVideo(): File? {
+        val tmpDir = File(System.getProperty("java.io.tmpdir"))
+        val target = File(tmpDir, "mediamp-mpv-test-dualsub.mkv")
+        if (target.isFile && target.length() > 0) return target
+        val sub1 = File(tmpDir, "mediamp-mpv-test-sub1.srt")
+        val sub2 = File(tmpDir, "mediamp-mpv-test-sub2.srt")
+        sub1.writeText("1\n00:00:00,500 --> 00:00:09,000\nFirst subtitle track\n")
+        sub2.writeText("1\n00:00:00,500 --> 00:00:09,000\nSecond subtitle track\n")
+        val ok = runFfmpeg(
+            "-f", "lavfi", "-i", "color=c=blue:size=320x240:rate=24:duration=10",
+            "-i", sub1.absolutePath, "-i", sub2.absolutePath,
+            "-map", "0:v", "-map", "1:s", "-map", "2:s",
+            "-c:v", "libx264", "-preset", "ultrafast", "-c:s", "srt",
+            target.absolutePath,
+        )
+        return target.takeIf { ok }
+    }
+
+    /**
      * With vo=libmpv, frames are only consumed when a render context drains them; without
      * one, playback never advances. The native render thread does all rendering; this
      * just configures a headless buffer ring (device ptr 0 = system default MTLDevice on
@@ -213,6 +237,87 @@ class MpvMediampPlayerSmokeTest {
         }
     }
 
+    /**
+     * Selecting a non-default SRT subtitle track must survive pause, resume, and seek,
+     * and turning subtitles off must stick as well.
+     *
+     * Regression test for open-ani/animeko#1128: the bundled FFmpeg used to lack all
+     * subtitle decoders, so libmpv rejected the selection asynchronously via a
+     * "track-list" rewrite; MpvTrackGroup additionally published an optimistic selection
+     * that native state then overwrote, which surfaced in the UI as "subtitles reset
+     * after pausing".
+     */
+    @OptIn(InternalMediampApi::class)
+    @Test
+    fun `subtitle selection persists across pause resume and seek`() {
+        if (!prepareOrSkip()) return
+        val video = generateDualSubtitleVideo()
+            ?: run { skip("ffmpeg unavailable or dual-subtitle video generation failed"); return }
+
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            val renderer = startHeadlessRenderer(player)
+            try {
+                player.setMediaData(UriMediaData(video.absolutePath, emptyMap(), MediaExtraFiles.EMPTY))
+                player.resume()
+                player.playbackState.await(PlaybackState.PLAYING)
+
+                val metadata = assertNotNull(player.features[MediaMetadata])
+                val subtitles = assertNotNull(metadata.subtitleTracks)
+                val candidates = withTimeout(10_000) {
+                    subtitles.candidates.first { it.size == 2 }
+                }
+                val second = candidates.first { it.internalId == "2" }
+                val handle = player.impl as MPVHandle
+
+                assertTrue(subtitles.select(second))
+                // `selected` is confirmed asynchronously from mpv's track-list. It must
+                // converge to the requested track (decode success), not flash and revert.
+                withTimeout(10_000) {
+                    subtitles.selected.collectUntil { it?.internalId == "2" }
+                }
+                assertEquals("2", handle.getPropertyString("sid"))
+
+                suspend fun assertStillSelected(what: String) {
+                    delay(1_000) // time for mpv to emit any track-list rewrites
+                    assertEquals("2", subtitles.selected.value?.internalId, "selection lost $what")
+                    assertEquals("2", handle.getPropertyString("sid"), "native sid lost $what")
+                }
+
+                player.pause()
+                player.playbackState.await(PlaybackState.PAUSED)
+                assertStillSelected("after pause")
+
+                player.resume()
+                player.playbackState.await(PlaybackState.PLAYING)
+                assertStillSelected("after resume")
+
+                player.seekTo(5_000)
+                withTimeout(10_000) {
+                    player.currentPositionMillis.collectUntil { it in 4_500..8_000 }
+                }
+                assertStillSelected("after seek")
+
+                // Turning subtitles off must stick through playback controls too.
+                assertTrue(subtitles.select(null))
+                withTimeout(10_000) {
+                    subtitles.selected.collectUntil { it == null }
+                }
+                player.pause()
+                player.playbackState.await(PlaybackState.PAUSED)
+                delay(1_000)
+                assertEquals(null, subtitles.selected.value, "subtitles re-enabled after pause")
+                assertEquals("no", handle.getPropertyString("sid"))
+
+                player.stopPlayback()
+                player.playbackState.await(PlaybackState.FINISHED)
+            } finally {
+                renderer.close()
+                player.close()
+            }
+        }
+    }
+
     /** Average color of the center 20x20 region of the current frame, read back via [Screenshots]. */
     private suspend fun captureCenterColor(screenshots: Screenshots): Triple<Int, Int, Int> {
         val file = File.createTempFile("mediamp-mpv-shot", ".png")
@@ -245,6 +350,7 @@ class MpvMediampPlayerSmokeTest {
             while (true) {
                 val color = captureCenterColor(screenshots)
                 if (predicate(color)) return@withTimeout color
+                System.err.println("[SmokeTest] awaiting $what, sampled $color")
                 last = color
                 kotlinx.coroutines.delay(200)
             }

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvPlayerFeatures.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvPlayerFeatures.kt
@@ -127,9 +127,13 @@ internal class MpvTrackGroup<T : Track>(
     override val candidates: MutableStateFlow<List<T>> = MutableStateFlow(emptyList())
 
     override fun select(track: T?): Boolean {
-        if (!selectTrack(track)) return false
-        selected.value = track
-        return true
+        // Do not write `selected` optimistically here. mpv may reject the selection
+        // asynchronously (e.g. no decoder for the track's codec), in which case an
+        // optimistic value flashes on and is then reverted by the "track-list" change
+        // notification. Native `track-list/*/selected` is the source of truth: a
+        // successful property write triggers a "track-list" event and refreshTracks()
+        // publishes the confirmed selection (open-ani/animeko#1128).
+        return selectTrack(track)
     }
 
     fun update(tracks: List<T>, selectedTrack: T?) {

--- a/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
+++ b/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
@@ -566,10 +566,20 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
                     listOf(TrackLabel(null, it.description())),
                 )
             }
-        // 新的字幕轨道和原来不同时才会更改，同时将 current 设置为新字幕轨道列表的第一个
-        if (mediaMetadata.subtitleTracks.candidates.value != newSubtitleTracks) {
+        // 只有候选列表真正变化时才更新（Track 有值相等语义，重新创建的对象不会误判为变化）。
+        // 变化时按 id 恢复原选择：用户选中的轨道仍存在则保持；用户已关闭字幕则保持关闭；
+        // 只有首次出现候选时才默认选择第一轨 (open-ani/animeko#1128)。
+        // 本函数会在每次进入 playing（含暂停后恢复）时被调用，绝不能无条件重置选择。
+        val oldSubtitleTracks = mediaMetadata.subtitleTracks.candidates.value
+        if (oldSubtitleTracks != newSubtitleTracks) {
+            val previousSelected = mediaMetadata.subtitleTracks.selected.value
             mediaMetadata.subtitleTracks.candidates.value = newSubtitleTracks
-            mediaMetadata.subtitleTracks.selected.value = newSubtitleTracks.firstOrNull()
+            mediaMetadata.subtitleTracks.selected.value = when {
+                oldSubtitleTracks.isEmpty() -> newSubtitleTracks.firstOrNull()
+                previousSelected == null -> null
+                else -> newSubtitleTracks.firstOrNull { it.id == previousSelected.id }
+                    ?: newSubtitleTracks.firstOrNull()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the "subtitle track resets to default/off after pausing" regression reported in open-ani/animeko#1128. The player UI never resets the selection itself — each backend was writing a bogus value back into `TrackGroup.selected`. The root cause differs per backend, so this PR fixes all three:

### mpv (Windows x64, macOS) — missing FFmpeg subtitle decoders

The bundled FFmpeg is built with `--disable-everything` and enabled no subtitle decoder at all. The Matroska/mov demuxers still enumerate subtitle streams, so the UI listed tracks that could never open: selecting an SRT track made libmpv log `Could not find subtitle decoder for format 'subrip'` and deselect it asynchronously via a `track-list` rewrite. Pausing was only time-correlated with the revert.

- `FfmpegTargets.kt`: enable `ass/ssa/srt/subrip/text/webvtt/movtext/pgssub/dvdsub` decoders plus `ass/srt/webvtt` demuxers (external subtitle files). Note: the MP4 timed-text configure component is **`movtext`**, not `mov_text` — FFmpeg's configure silently ignores unknown `--enable-decoder` values (verified against the linked objects).
- `MpvTrackGroup.select()` no longer publishes an optimistic selection. Native `track-list/*/selected` is the source of truth, published by `refreshTracks()`; a selection the backend rejects can no longer flash on and then revert.

### ExoPlayer / VLC — lost value equality on track types

`SubtitleTrack`/`AudioTrack`/`TrackLabel` became plain classes in 09b109d, but both backends still re-create track instances on every native tracks-changed callback and compare candidate lists to decide whether to reset the selection. With identity equality that comparison was always unequal, so every refresh (ExoPlayer's `onTracksChanged` feedback loop; VLC's `reloadSubtitleTracks()` on every `playing`, i.e. every resume) forced `selected = firstOrNull()`.

- Restore value equality via explicit `equals`/`hashCode`/`toString` (binary compatible; no `data class` to avoid exposing `copy`/`componentN`).
- When candidates genuinely change, restore the previous selection by id instead of unconditionally picking the first track; an explicit "off" stays off. Only the first non-empty candidate list applies the default.

## Verification (Windows x64)

- Rebuilt the WindowsX64 runtime; `ffmpeg.exe -decoders` now lists all nine subtitle decoders, `-demuxers` lists ass/srt/webvtt.
- Minimal libmpv probe (MKV with two SRT tracks): `sid=2` logs `Using subtitle decoder srt` and native selection survives pause → resume → pause with zero decoder errors. Before the fix the same probe reproduced the deselection.
- New smoke test `subtitle selection persists across pause resume and seek` drives a real `MpvMediampPlayer` end to end (select second SRT track → pause → resume → seek → off), asserting both the Kotlin flow and native `sid`. Passes.
- New `TrackTest` covers the value-equality contract the backends rely on.
- `:mediamp-api:desktopTest`, `:mediamp-api:assemble` (all targets), `:mediamp-exoplayer:assemble`, `:mediamp-vlc:assemble` pass. `:mediamp-mpv:desktopTest`: 31/32 pass — the one failure is the pre-existing `screenshot pixel verification` test, which fails on Windows because the screenshot readback swaps R/B channels (red frames read as `(0,0,254)`); it has never run on Windows CI (mpv smoke tests are only required on the self-hosted macOS runner) and is unrelated to this change.

## Notes

- The decoder/demuxer flags are in `commonConfigureFlags`, so macOS/Android runtimes pick them up on their next CI build.
- Deeper follow-ups from the investigation are intentionally out of scope: syncing ExoPlayer selection from `Tracks.Group.isTrackSelected`, precise group/index selection, and syncing VLC from `subpictures().track()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
