### PR TITLE
FramePreview: seek-bar thumbnail extraction for mpv, VLC and ExoPlayer

### DIFF
--- a/mediamp-api/src/commonMain/kotlin/features/FramePreview.kt
+++ b/mediamp-api/src/commonMain/kotlin/features/FramePreview.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.features
+
+/**
+ * An optional feature of the [org.openani.mediamp.MediampPlayer] that extracts video frames at
+ * arbitrary positions of the currently playing media, without affecting playback.
+ *
+ * The typical use case is showing a thumbnail preview above the seek bar while the user hovers
+ * or drags it.
+ *
+ * Implementations usually run a second lightweight decoder over the same media source, so the
+ * first call after a media change can be slow (hundreds of milliseconds). Callers should throttle
+ * requests and treat `null` results as "preview unavailable" rather than errors.
+ */
+public interface FramePreview : Feature {
+    /**
+     * Extracts a video frame near [positionMillis] (implementations may snap to a nearby keyframe),
+     * scaled down to fit within [maxWidth] x [maxHeight] while keeping the aspect ratio.
+     *
+     * Returns `null` if there is no media playing, the media has no video track, or the frame
+     * cannot be decoded in a reasonable time (e.g. the data at [positionMillis] is not downloaded yet).
+     *
+     * This function is safe to call concurrently; requests are serialized internally and a newer
+     * request may cause an older in-flight one to return `null`.
+     */
+    public suspend fun getPreviewFrame(positionMillis: Long, maxWidth: Int, maxHeight: Int): PreviewFrame?
+
+    public companion object Key : FeatureKey<FramePreview>
+}
+
+/**
+ * A decoded video frame returned by [FramePreview.getPreviewFrame].
+ */
+public class PreviewFrame(
+    /**
+     * The position this frame was decoded for. This is the requested position, not the exact
+     * frame timestamp (implementations may seek to a nearby keyframe).
+     */
+    public val positionMillis: Long,
+    public val width: Int,
+    public val height: Int,
+    /**
+     * Pixels in ARGB_8888 format (one `Int` per pixel, `0xAARRGGBB`), row-major, top-down.
+     * Size is exactly `width * height`.
+     */
+    public val pixels: IntArray,
+)

--- a/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
@@ -48,8 +48,10 @@ import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.InternalForInheritanceMediampApi
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.exoplayer.internal.ExoFramePreview
 import org.openani.mediamp.exoplayer.internal.ExoPlaybackStateMapper
 import org.openani.mediamp.exoplayer.internal.SeekableInputDataSource
+import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.Buffering
 import org.openani.mediamp.features.MediaMetadata
@@ -247,6 +249,7 @@ class ExoPlayerMediampPlayer @UiThread constructor(
     private val playbackSpeed = PlaybackSpeedImpl(exoPlayer)
     private val playbackStateMapper = ExoPlaybackStateMapper()
     private val videoAspectRatio = ExoPlayerVideoAspectRatio()
+    private val framePreview = ExoFramePreview { openResource.value?.mediaData }
 
     override val currentPositionMillis: MutableStateFlow<Long> = MutableStateFlow(0)
 
@@ -256,6 +259,7 @@ class ExoPlayerMediampPlayer @UiThread constructor(
         add(Buffering, buffering)
         add(MediaMetadata, mediaMetadataFeature)
         add(VideoAspectRatio, videoAspectRatio)
+        add(FramePreview.Key, framePreview)
     }
 
     override fun getCurrentMediaProperties(): MediaProperties? {
@@ -291,6 +295,13 @@ class ExoPlayerMediampPlayer @UiThread constructor(
                 currentPositionMillis.value = exoPlayer.currentPosition
                 buffering.bufferedPercentage.value = exoPlayer.bufferedPercentage
                 delay(0.1.seconds) // 10 tps
+            }
+        }
+        backgroundScope.launch {
+            // Tear down the preview decoder when the media changes or playback stops,
+            // so it never outlives the media data it reads from.
+            mediaData.collect {
+                framePreview.onMediaDataChanged(it)
             }
         }
         backgroundScope.launch(Dispatchers.Main) {
@@ -415,6 +426,9 @@ class ExoPlayerMediampPlayer @UiThread constructor(
         exoPlayer.removeListener(mediaListener)
         exoPlayer.stop()
         exoPlayer.release()
+        backgroundScope.launch(kotlinx.coroutines.NonCancellable) {
+            framePreview.closeSuspending()
+        }
     }
 
     private fun Tracks.Group.getSubtitleTracks() = sequence {

--- a/mediamp-exoplayer/src/androidMain/kotlin/internal/ExoFramePreview.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/internal/ExoFramePreview.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer.internal
+
+import android.graphics.Bitmap
+import android.media.MediaDataSource
+import android.media.MediaMetadataRetriever
+import android.os.Build
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.openani.mediamp.ExperimentalMediampApi
+import org.openani.mediamp.features.FramePreview
+import org.openani.mediamp.features.PreviewFrame
+import org.openani.mediamp.io.SeekableInput
+import org.openani.mediamp.source.MediaData
+import org.openani.mediamp.source.SeekableInputMediaData
+import org.openani.mediamp.source.UriMediaData
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * [FramePreview] implementation backed by [MediaMetadataRetriever].
+ *
+ * The retriever decodes independently from ExoPlayer, so extracting a frame never disturbs
+ * playback. Frame requests hit the same media source as playback (a second [SeekableInput] for
+ * torrent-like media); a request at a position whose data is not locally available will block
+ * until the data arrives, so callers should prefer positions that are already downloaded.
+ */
+@OptIn(ExperimentalMediampApi::class)
+internal class ExoFramePreview(
+    /** The media currently playing in the main player, or `null` if none. */
+    private val currentMediaData: () -> MediaData?,
+) : FramePreview {
+    private val mutex = Mutex()
+    private var session: Session? = null
+    private var closed = false
+
+    override suspend fun getPreviewFrame(positionMillis: Long, maxWidth: Int, maxHeight: Int): PreviewFrame? {
+        if (maxWidth <= 0 || maxHeight <= 0) return null
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return null
+        val data = currentMediaData() ?: return null
+        return withContext(Dispatchers.IO) {
+            mutex.withLock {
+                if (closed) return@withLock null
+                val session = obtainSessionLocked(data) ?: return@withLock null
+                try {
+                    session.grabFrame(positionMillis, maxWidth, maxHeight)
+                } catch (e: CancellationException) {
+                    // The caller moved on to a newer position (collectLatest). The session is
+                    // still healthy — do not tear down the retriever on every scrub movement.
+                    throw e
+                } catch (e: Exception) {
+                    discardSessionLocked()
+                    null
+                }
+            }
+        }
+    }
+
+    /** Closes the preview session if the main player's media changed or was stopped. */
+    suspend fun onMediaDataChanged(data: MediaData?) {
+        mutex.withLock {
+            if (session != null && session?.mediaData !== data) {
+                discardSessionLocked()
+            }
+        }
+    }
+
+    suspend fun closeSuspending() {
+        mutex.withLock {
+            if (closed) return
+            closed = true
+            discardSessionLocked()
+        }
+    }
+
+    private suspend fun obtainSessionLocked(data: MediaData): Session? {
+        session?.let { existing ->
+            if (existing.mediaData === data) return existing
+            discardSessionLocked()
+        }
+        return try {
+            // NonCancellable: setDataSource parses the media (expensive shared state); a
+            // cancelled first request must not abort it half-way.
+            withContext(NonCancellable) {
+                Session.create(data)
+            }.also { session = it }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun discardSessionLocked() {
+        session?.close()
+        session = null
+    }
+
+    private class Session private constructor(
+        val mediaData: MediaData,
+        private val retriever: MediaMetadataRetriever,
+        private val input: SeekableInput?,
+    ) : AutoCloseable {
+
+        fun grabFrame(positionMillis: Long, maxWidth: Int, maxHeight: Int): PreviewFrame? {
+            val timeUs = positionMillis.coerceAtLeast(0) * 1000
+            val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                retriever.getScaledFrameAtTime(
+                    timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, maxWidth, maxHeight,
+                )
+            } else {
+                retriever.getFrameAtTime(timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+                    ?.let { full -> scaleToFit(full, maxWidth, maxHeight) }
+            } ?: return null
+
+            return try {
+                val pixels = IntArray(bitmap.width * bitmap.height)
+                bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+                PreviewFrame(positionMillis, bitmap.width, bitmap.height, pixels)
+            } finally {
+                bitmap.recycle()
+            }
+        }
+
+        private fun scaleToFit(bitmap: Bitmap, maxWidth: Int, maxHeight: Int): Bitmap {
+            val scale = minOf(
+                maxWidth.toFloat() / bitmap.width,
+                maxHeight.toFloat() / bitmap.height,
+                1f,
+            )
+            if (scale >= 1f) return bitmap
+            val scaled = Bitmap.createScaledBitmap(
+                bitmap,
+                (bitmap.width * scale).toInt().coerceAtLeast(1),
+                (bitmap.height * scale).toInt().coerceAtLeast(1),
+                true,
+            )
+            if (scaled !== bitmap) bitmap.recycle()
+            return scaled
+        }
+
+        override fun close() {
+            try {
+                retriever.release()
+            } catch (_: Exception) {
+            } finally {
+                try {
+                    input?.close()
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        companion object {
+            suspend fun create(data: MediaData): Session {
+                val retriever = MediaMetadataRetriever()
+                var input: SeekableInput? = null
+                try {
+                    when (data) {
+                        is UriMediaData -> {
+                            val uri = data.uri
+                            if (uri.startsWith("http://") || uri.startsWith("https://")) {
+                                retriever.setDataSource(uri, data.headers)
+                            } else {
+                                retriever.setDataSource(uri.removePrefix("file://"))
+                            }
+                        }
+
+                        is SeekableInputMediaData -> {
+                            if (data.uri.startsWith("file://")) {
+                                retriever.setDataSource(data.uri.removePrefix("file://"))
+                            } else {
+                                val newInput = data.createInput()
+                                input = newInput
+                                val length = data.fileLength() ?: -1
+                                retriever.setDataSource(SeekableInputMediaDataSource(newInput, length))
+                            }
+                        }
+                    }
+                } catch (e: Throwable) {
+                    try {
+                        retriever.release()
+                    } catch (_: Exception) {
+                    }
+                    input?.close()
+                    throw e
+                }
+                return Session(data, retriever, input)
+            }
+        }
+    }
+
+    /** Adapts a [SeekableInput] to the platform [MediaDataSource] (API 23+). */
+    private class SeekableInputMediaDataSource(
+        private val input: SeekableInput,
+        private val length: Long,
+    ) : MediaDataSource() {
+        @Synchronized
+        override fun readAt(position: Long, buffer: ByteArray, offset: Int, size: Int): Int {
+            if (size == 0) return 0
+            if (length in 0..position) return -1
+            input.seekTo(position)
+            return input.read(buffer, offset, size)
+        }
+
+        override fun getSize(): Long = length
+
+        override fun close() {
+            // The SeekableInput is owned and closed by the session.
+        }
+    }
+}

--- a/mediamp-mpv/src/androidMain/kotlin/MpvFramePreview.android.kt
+++ b/mediamp-mpv/src/androidMain/kotlin/MpvFramePreview.android.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv
+
+import org.openani.mediamp.features.FramePreview
+import kotlin.coroutines.CoroutineContext
+
+// Not implemented on Android: the surface-ring readback used for frame extraction is a
+// desktop-only render path. (Android apps typically use the ExoPlayer backend, which has
+// its own FramePreview implementation.)
+internal actual fun createMpvFramePreview(
+    player: JvmMpvMediampPlayer,
+    context: Any,
+    parentCoroutineContext: CoroutineContext,
+): FramePreview? = null

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
@@ -1,0 +1,327 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.openani.mediamp.ExperimentalMediampApi
+import org.openani.mediamp.features.FramePreview
+import org.openani.mediamp.features.PreviewFrame
+import org.openani.mediamp.io.SeekableInput
+import org.openani.mediamp.source.MediaData
+import org.openani.mediamp.source.MediaExtraFiles
+import org.openani.mediamp.source.SeekableInputMediaData
+import org.openani.mediamp.source.UriMediaData
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.imageio.ImageIO
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+internal actual fun createMpvFramePreview(
+    player: JvmMpvMediampPlayer,
+    context: Any,
+    parentCoroutineContext: CoroutineContext,
+): FramePreview? {
+    // The preview decoder is itself an MpvMediampPlayer, which would recursively get its own
+    // (never-used) FramePreview. Cut the recursion at depth 1.
+    if (context is MpvFramePreviewContextMarker) return null
+    return MpvFramePreview(player, context, parentCoroutineContext)
+}
+
+/** Marks the `context` of a preview decoder instance so it does not create nested previews. */
+internal class MpvFramePreviewContextMarker(val delegate: Any)
+
+/**
+ * [FramePreview] implementation backed by a second, headless mpv instance.
+ *
+ * The preview instance loads the same media (a second [SeekableInput] for stream_cb media),
+ * stays paused, and renders into a small native surface ring sized to fit the requested
+ * dimensions; each request is a keyframe seek followed by a surface readback.
+ */
+@OptIn(ExperimentalMediampApi::class)
+internal class MpvFramePreview(
+    private val mainPlayer: JvmMpvMediampPlayer,
+    private val context: Any,
+    private val parentCoroutineContext: CoroutineContext,
+) : FramePreview, AutoCloseable {
+    private val scope = CoroutineScope(
+        parentCoroutineContext + SupervisorJob(parentCoroutineContext[Job.Key]),
+    )
+    private val mutex = Mutex()
+    private var session: PreviewSession? = null
+    private var closed = false
+
+    init {
+        scope.launch {
+            // Tear down the preview decoder when the main player's media changes or stops,
+            // so it never outlives the media data it reads from.
+            mainPlayer.mediaData.collect { data ->
+                mutex.withLock {
+                    if (session != null && session?.originalData !== data) {
+                        discardSessionLocked()
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun getPreviewFrame(positionMillis: Long, maxWidth: Int, maxHeight: Int): PreviewFrame? {
+        if (maxWidth <= 0 || maxHeight <= 0) return null
+        val data = mainPlayer.currentMediaDataOrNull() ?: return null
+        return withContext(Dispatchers.IO) {
+            mutex.withLock {
+                if (closed) return@withLock null
+                val session = obtainSessionLocked(data, maxWidth, maxHeight) ?: return@withLock null
+                try {
+                    session.grabFrame(positionMillis)
+                } catch (e: CancellationException) {
+                    // The caller moved on to a newer position (collectLatest). The session is
+                    // still healthy — destroying it here would tear down and rebuild the whole
+                    // decoder instance on every scrub movement.
+                    throw e
+                } catch (e: Exception) {
+                    // A broken session (e.g. dead mpv instance) should not be reused.
+                    discardSessionLocked()
+                    null
+                }
+            }
+        }
+    }
+
+    private suspend fun obtainSessionLocked(data: MediaData, maxWidth: Int, maxHeight: Int): PreviewSession? {
+        session?.let { existing ->
+            if (existing.originalData === data) return existing
+            discardSessionLocked()
+        }
+        return try {
+            // NonCancellable: session creation is expensive shared state; a cancelled first
+            // request must not abort it half-way (the next request reuses the session).
+            withContext(NonCancellable) {
+                PreviewSession.create(context, parentCoroutineContext, data, maxWidth, maxHeight)
+            }.also { session = it }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun discardSessionLocked() {
+        session?.close()
+        session = null
+    }
+
+    override fun close() {
+        // Called from the main player's closeImpl (main thread): do the actual native teardown
+        // off-thread, serialized behind the mutex against any in-flight grab.
+        scope.launch(NonCancellable) {
+            mutex.withLock {
+                if (closed) return@withLock
+                closed = true
+                discardSessionLocked()
+            }
+            scope.cancel()
+        }
+    }
+
+    private class PreviewSession private constructor(
+        /** The main player's media data; identity-compared to detect media changes. */
+        val originalData: MediaData,
+        private val previewData: MediaData,
+        private val player: MpvMediampPlayer,
+        private val renderCounter: MutableStateFlow<Long>,
+        private val maxWidth: Int,
+        private val maxHeight: Int,
+    ) : AutoCloseable {
+        private var started = false
+
+        suspend fun grabFrame(positionMillis: Long): PreviewFrame? {
+            // NonCancellable: starting (paused load + surface setup) is shared progress that
+            // must survive the cancellation of the request that happened to trigger it.
+            if (!withContext(NonCancellable) { ensureStarted() }) return null
+            val handle = player.handle
+
+            val durationMillis = (handle.getPropertyDouble("duration") * 1000).toLong()
+            val target = if (durationMillis > 0) {
+                positionMillis.coerceIn(0, max(0, durationMillis - 500))
+            } else {
+                max(0, positionMillis)
+            }
+
+            val counterBefore = renderCounter.value
+            if (!handle.command("seek", formatSecondsForMpv(target / 1000.0), "absolute+keyframes")) {
+                return null
+            }
+
+            // Wait until the seek lands: while paused, mpv decodes the target frame, updates
+            // time-pos and pushes a render update.
+            val landed = withTimeoutOrNull(5_000) {
+                while (true) {
+                    val seeking = handle.getPropertyBoolean("seeking")
+                    val timePosMillis = (handle.getPropertyDouble("time-pos") * 1000).toLong()
+                    if (!seeking && abs(timePosMillis - target) < 3_000) break
+                    delay(20)
+                }
+                true
+            } ?: false
+            if (!landed) return null
+
+            // Prefer a frame rendered after the seek. The surface ring only publishes complete
+            // frames, so the first post-seek render is safe to read immediately. When the seek
+            // lands on the keyframe that is already displayed, mpv may not push a new render —
+            // the surface content is still correct, so a timeout here is not an error.
+            withTimeoutOrNull(500) { renderCounter.first { it > counterBefore } }
+
+            val tmp = File.createTempFile("mediamp-mpv-preview", ".png")
+            try {
+                if (!player.dumpSurfaceForDebug(tmp.absolutePath)) return null
+                val image = ImageIO.read(tmp) ?: return null
+                val pixels = IntArray(image.width * image.height)
+                image.getRGB(0, 0, image.width, image.height, pixels, 0, image.width)
+                return PreviewFrame(target, image.width, image.height, pixels)
+            } finally {
+                tmp.delete()
+            }
+        }
+
+        /** Loads the media paused, sizes the surface ring to the video, waits for the first frame. */
+        private suspend fun ensureStarted(): Boolean {
+            if (started) return true
+            val handle = player.handle
+            if (!player.commandLoadFilePaused()) return false
+
+            // Video dimensions become available once the first frame is decoded.
+            val dims = withTimeoutOrNull(10_000) {
+                while (true) {
+                    val w = handle.getPropertyInt("width")
+                    val h = handle.getPropertyInt("height")
+                    if (w > 0 && h > 0) return@withTimeoutOrNull w to h
+                    delay(50)
+                }
+                @Suppress("UNREACHABLE_CODE")
+                null
+            } ?: return false
+
+            val (videoWidth, videoHeight) = dims
+            val scale = min(
+                maxWidth.toFloat() / videoWidth,
+                maxHeight.toFloat() / videoHeight,
+            ).coerceAtMost(1f)
+            val surfaceWidth = max(2, (videoWidth * scale).roundToInt())
+            val surfaceHeight = max(2, (videoHeight * scale).roundToInt())
+            if (!player.requestSurface(surfaceWidth, surfaceHeight, 0L)) return false
+
+            if (withTimeoutOrNull(5_000) { renderCounter.first { it > 0 } } == null) return false
+            started = true
+            return true
+        }
+
+        override fun close() {
+            try {
+                player.setRenderUpdateListener(null)
+                player.releaseSurface()
+                player.releaseRenderContext()
+            } catch (_: Exception) {
+            }
+            try {
+                player.close()
+            } catch (_: Exception) {
+            }
+            (previewData as? NonClosingSeekableInputMediaData)?.closeOpenInputs()
+        }
+
+        companion object {
+            suspend fun create(
+                context: Any,
+                parentCoroutineContext: CoroutineContext,
+                data: MediaData,
+                maxWidth: Int,
+                maxHeight: Int,
+            ): PreviewSession {
+                val previewData: MediaData = when (data) {
+                    is SeekableInputMediaData -> NonClosingSeekableInputMediaData(data)
+                    // UriMediaData is sealed; a fresh copy is safe because its close() is a no-op.
+                    is UriMediaData -> UriMediaData(data.uri, data.headers, data.extraFiles, data.options)
+                }
+                val renderCounter = MutableStateFlow(0L)
+                val player = MpvMediampPlayer(MpvFramePreviewContextMarker(context), parentCoroutineContext)
+                try {
+                    val handle = player.handle
+                    // Keep the preview decoder lightweight: no audio, no subtitles.
+                    handle.setPropertyString("aid", "no")
+                    handle.setPropertyString("sid", "no")
+                    handle.setPropertyBoolean("pause", true)
+                    player.setRenderUpdateListener { renderCounter.update { it + 1 } }
+                    player.setMediaData(previewData)
+                    return PreviewSession(data, previewData, player, renderCounter, maxWidth, maxHeight)
+                } catch (e: Throwable) {
+                    try {
+                        player.close()
+                    } catch (_: Exception) {
+                    }
+                    (previewData as? NonClosingSeekableInputMediaData)?.closeOpenInputs()
+                    throw e
+                }
+            }
+        }
+    }
+
+    /**
+     * Delegates to the main player's media but never closes it (the main player owns it),
+     * and tracks inputs opened for the preview decoder so the session can close them.
+     */
+    private class NonClosingSeekableInputMediaData(
+        private val delegate: SeekableInputMediaData,
+    ) : SeekableInputMediaData {
+        private val openInputs = CopyOnWriteArrayList<SeekableInput>()
+
+        override val uri: String get() = delegate.uri
+        override val extraFiles: MediaExtraFiles get() = delegate.extraFiles
+        override val options: List<String> get() = delegate.options
+        override fun fileLength(): Long? = delegate.fileLength()
+
+        override suspend fun createInput(coroutineContext: CoroutineContext): SeekableInput =
+            delegate.createInput(coroutineContext).also { openInputs.add(it) }
+
+        override fun close() {
+            // no-op: the shared media data is owned by the main player.
+        }
+
+        fun closeOpenInputs() {
+            openInputs.forEach {
+                try {
+                    it.close()
+                } catch (_: Exception) {
+                }
+            }
+            openInputs.clear()
+        }
+    }
+}
+
+private fun formatSecondsForMpv(seconds: Double): String {
+    // mpv parses decimal seconds; String.format would be locale-sensitive.
+    return ((seconds * 1000).toLong() / 1000.0).toBigDecimal().toPlainString()
+}

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.openani.mediamp.ExperimentalMediampApi
+import org.openani.mediamp.features.FramePreview
+import org.openani.mediamp.features.PreviewFrame
+import org.openani.mediamp.io.SeekableInput
+import org.openani.mediamp.source.MediaData
+import org.openani.mediamp.source.MediaExtraFiles
+import org.openani.mediamp.source.SeekableInputMediaData
+import org.openani.mediamp.source.UriMediaData
+import java.io.File
+import java.io.RandomAccessFile
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration test for [MpvFramePreview] against a real libmpv (dev-native JNI build).
+ *
+ * Uses a video that is solid red for 0.0-2.5s and solid blue for 2.5-5.0s, so the extracted
+ * frame's dominant color proves WHICH position was decoded, not just that decoding worked.
+ *
+ * Skipped when the native runtime or ffmpeg is unavailable (same policy as
+ * [MpvMediampPlayerSmokeTest]). Run manually:
+ *   ./gradlew :mediamp-mpv:desktopTest --tests "org.openani.mediamp.mpv.MpvFramePreviewTest"
+ */
+@OptIn(ExperimentalMediampApi::class)
+class MpvFramePreviewTest {
+
+    private fun devNativeDir(): File? =
+        System.getProperty("mediamp.mpv.dev.native.dir")
+            ?.let(::File)
+            ?.takeIf {
+                it.resolve("libmediampv.dylib").isFile || it.resolve("libmediampv.so").isFile ||
+                        it.resolve("mediampv.dll").isFile
+            }
+
+    private fun skip(reason: String): Boolean {
+        System.err.println("[MpvFramePreviewTest] setup skipped: $reason")
+        check(System.getProperty("mediamp.mpv.test.required") != "true") {
+            "mpv frame preview tests are required on this runner but would be skipped: $reason"
+        }
+        return false
+    }
+
+    private fun prepareOrSkip(): Boolean {
+        val osName = System.getProperty("os.name")
+        if (!osName.contains("Mac") && !osName.contains("Windows")) {
+            return skip("no desktop render path on $osName")
+        }
+        val dir = devNativeDir()
+            ?: return skip(
+                "dev native dir not usable " +
+                        "(mediamp.mpv.dev.native.dir=${System.getProperty("mediamp.mpv.dev.native.dir")})",
+            )
+        runCatching { MpvMediampPlayer.prepareLibraries(dir.absolutePath, extractRuntimeLibrary = false) }
+            .onFailure { return skip("prepareLibraries failed: $it") }
+        if (generateColorVideo() == null) return skip("ffmpeg unavailable or color video generation failed")
+        return true
+    }
+
+    @Test
+    fun `preview frames follow requested position - uri media`() {
+        if (!prepareOrSkip()) return
+        runScenario(UriMediaData(generateColorVideo()!!.absolutePath, emptyMap(), MediaExtraFiles.EMPTY))
+    }
+
+    @Test
+    fun `preview frames follow requested position - seekable input media`() {
+        if (!prepareOrSkip()) return
+        runScenario(FileSeekableInputMediaData(generateColorVideo()!!))
+    }
+
+    /**
+     * Regression: the UI drives requests with `collectLatest`, cancelling the in-flight grab on
+     * every scrub movement. Cancellation must NOT tear down the preview session (or the decoder
+     * gets destroyed and rebuilt on every movement and never delivers a frame).
+     */
+    @Test
+    fun `cancelled requests do not destroy the session`() {
+        if (!prepareOrSkip()) return
+        val video = generateColorVideo()!!
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            try {
+                player.setMediaData(UriMediaData(video.absolutePath, emptyMap(), MediaExtraFiles.EMPTY))
+                val preview = assertNotNull(player.features[FramePreview.Key])
+
+                // Storm of quickly-cancelled requests, like fast scrubbing.
+                repeat(6) { i ->
+                    val job = launch { preview.getPreviewFrame(500L * i, 160, 160) }
+                    delay(80)
+                    job.cancel()
+                    job.join()
+                }
+
+                // A subsequent request must still succeed, quickly (session survived).
+                val elapsed = kotlin.system.measureTimeMillis {
+                    val blue = assertNotNull(
+                        preview.getPreviewFrame(4_000, 160, 160),
+                        "no frame after cancellation storm",
+                    )
+                    assertDominantColor(blue, "blue") { r, _, b -> b > 180 && r < 80 }
+                }
+                assertTrue(elapsed < 5_000, "grab after cancellation storm took ${elapsed}ms")
+            } finally {
+                player.close()
+            }
+        }
+    }
+
+    private fun runScenario(mediaData: MediaData) {
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            try {
+                player.setMediaData(mediaData)
+                val preview = assertNotNull(player.features[FramePreview.Key], "FramePreview feature missing")
+
+                // Main player is NOT started: previews must work while the video is merely loaded.
+                val red = assertNotNull(
+                    preview.getPreviewFrame(1_000, 160, 160),
+                    "no frame at 1s",
+                )
+                assertDominantColor(red, "red") { r, _, b -> r > 180 && b < 80 }
+                assertTrue(red.width in 2..160 && red.height in 2..160, "unexpected size ${red.width}x${red.height}")
+
+                val blue = assertNotNull(
+                    preview.getPreviewFrame(4_000, 160, 160),
+                    "no frame at 4s",
+                )
+                assertDominantColor(blue, "blue") { r, _, b -> b > 180 && r < 80 }
+
+                // Scrub back: seeking backwards while paused must work too.
+                val redAgain = assertNotNull(
+                    preview.getPreviewFrame(1_500, 160, 160),
+                    "no frame at 1.5s (backwards seek)",
+                )
+                assertDominantColor(redAgain, "red (backwards)") { r, _, b -> r > 180 && b < 80 }
+            } finally {
+                player.close()
+            }
+        }
+    }
+
+    /** Asserts on the average color of the center 20x20 region. */
+    private fun assertDominantColor(
+        frame: PreviewFrame,
+        what: String,
+        predicate: (r: Int, g: Int, b: Int) -> Boolean,
+    ) {
+        var r = 0L
+        var g = 0L
+        var b = 0L
+        var n = 0
+        val cx = frame.width / 2
+        val cy = frame.height / 2
+        val half = minOf(10, frame.width / 2, frame.height / 2)
+        for (y in cy - half until cy + half) {
+            for (x in cx - half until cx + half) {
+                val argb = frame.pixels[y * frame.width + x]
+                r += (argb shr 16) and 0xFF
+                g += (argb shr 8) and 0xFF
+                b += argb and 0xFF
+                n++
+            }
+        }
+        val avgR = (r / n).toInt()
+        val avgG = (g / n).toInt()
+        val avgB = (b / n).toInt()
+        assertTrue(
+            predicate(avgR, avgG, avgB),
+            "expected $what frame, got avg color ($avgR, $avgG, $avgB) " +
+                    "for ${frame.width}x${frame.height} frame at ${frame.positionMillis}ms",
+        )
+    }
+
+    @OptIn(ExperimentalMediampApi::class)
+    private class FileSeekableInputMediaData(private val file: File) : SeekableInputMediaData {
+        override val uri: String get() = "test://${file.name}"
+        override val extraFiles: MediaExtraFiles get() = MediaExtraFiles.EMPTY
+        override val options: List<String> get() = emptyList()
+        override fun fileLength(): Long = file.length()
+        override fun close() {}
+
+        override suspend fun createInput(coroutineContext: CoroutineContext): SeekableInput {
+            val raf = RandomAccessFile(file, "r")
+            return object : SeekableInput {
+                private val fileSize = raf.length()
+                override val position: Long get() = raf.filePointer
+                override val bytesRemaining: Long get() = fileSize - raf.filePointer
+                override val size: Long get() = fileSize
+                override fun seekTo(position: Long) = raf.seek(position)
+                override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
+                    raf.read(buffer, offset, length)
+
+                override fun close() = raf.close()
+            }
+        }
+    }
+
+    /** 0.0s-2.5s solid red, 2.5s-5.0s solid blue — known pixel content for frame assertions. */
+    private fun generateColorVideo(): File? {
+        val target = File(System.getProperty("java.io.tmpdir"), "mediamp-mpv-frame-preview-colors.mp4")
+        if (target.isFile && target.length() > 0) return target
+        val ffmpeg = findFfmpeg() ?: return null
+        val process = ProcessBuilder(
+            ffmpeg, "-y",
+            "-f", "lavfi", "-i", "color=c=red:size=640x360:rate=30:duration=2.5",
+            "-f", "lavfi", "-i", "color=c=blue:size=640x360:rate=30:duration=2.5",
+            "-filter_complex", "[0:v][1:v]concat=n=2:v=1:a=0,format=yuv420p[v]",
+            "-map", "[v]", "-c:v", "libx264", "-preset", "ultrafast", "-g", "15",
+            target.absolutePath,
+        ).redirectErrorStream(true).start()
+        process.inputStream.readAllBytes()
+        if (!process.waitFor(60, TimeUnit.SECONDS) || process.exitValue() != 0) return null
+        return target
+    }
+
+    private fun findFfmpeg(): String? =
+        listOf("/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg")
+            .firstOrNull { File(it).canExecute() }
+}

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -17,6 +17,7 @@ import org.openani.mediamp.PlaybackState
 import org.openani.mediamp.mpv.internal.MpvPlaybackStateMachine
 import org.openani.mediamp.features.AudioLevelController
 import org.openani.mediamp.features.Buffering
+import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.MediaMetadata
 import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.features.PlayerFeatures
@@ -81,6 +82,7 @@ abstract class JvmMpvMediampPlayer(
     private val screenshots = MpvScreenshots { path -> takeScreenshotImpl(path) }
     private val videoAspectRatio = MpvVideoAspectRatio(handle)
     private val mediaMetadata = MpvMediaMetadata(handle)
+    private val framePreview: FramePreview? = createMpvFramePreview(this, context, parentCoroutineContext)
 
     override val features: PlayerFeatures = buildPlayerFeatures {
         add(PlaybackSpeed.Key, playbackSpeed)
@@ -89,6 +91,7 @@ abstract class JvmMpvMediampPlayer(
         add(Screenshots.Key, screenshots)
         add(VideoAspectRatio.Key, videoAspectRatio)
         add(MediaMetadata, mediaMetadata)
+        framePreview?.let { add(FramePreview.Key, it) }
     }
 
     private val eventListener = object : EventListener {
@@ -397,13 +400,45 @@ abstract class JvmMpvMediampPlayer(
     }
 
     override fun closeImpl() {
+        (framePreview as? AutoCloseable)?.close()
         clearPlaybackSession(resetPosition = true)
         handle.command("stop")
         handle.destroy()
         handle.close()
         playbackState.value = PlaybackState.DESTROYED
     }
+
+    /**
+     * Returns the media currently set via [setMediaData], or `null`.
+     * Used by the frame-preview decoder to mirror the main player's media.
+     */
+    internal fun currentMediaDataOrNull(): MediaData? = openResource.value?.mediaData
+
+    /**
+     * Loads the media previously set via [setMediaData] into mpv with playback paused,
+     * WITHOUT transitioning the public [playbackState]. mpv decodes and displays the first
+     * frame, then stays paused. Used by the frame-preview decoder instance, which drives
+     * the handle directly and never "plays".
+     */
+    internal fun commandLoadFilePaused(): Boolean {
+        val media = openResource.value ?: return false
+        handle.setPropertyBoolean("pause", true)
+        return handle.command("loadfile", media.loadTarget, "replace")
+    }
 }
+
+/**
+ * Creates the platform [FramePreview] implementation for this player, or `null` when the
+ * platform has no frame-preview support (e.g. Android, which uses ExoPlayer in practice).
+ *
+ * Called during the player's construction: implementations must only capture references and
+ * must not call back into [player] until the first frame request.
+ */
+internal expect fun createMpvFramePreview(
+    player: JvmMpvMediampPlayer,
+    context: Any,
+    parentCoroutineContext: CoroutineContext,
+): FramePreview?
 
 private fun formatSeconds(seconds: Double): String {
     // mpv parses decimal seconds; String.format would be locale-sensitive.

--- a/mediamp-vlc/src/main/kotlin/VlcFramePreview.kt
+++ b/mediamp-vlc/src/main/kotlin/VlcFramePreview.kt
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the GNU GENERAL PUBLIC LICENSE version 3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.vlc
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.openani.mediamp.ExperimentalMediampApi
+import org.openani.mediamp.features.FramePreview
+import org.openani.mediamp.features.PreviewFrame
+import org.openani.mediamp.io.SeekableInput
+import org.openani.mediamp.source.MediaData
+import org.openani.mediamp.source.SeekableInputMediaData
+import org.openani.mediamp.source.UriMediaData
+import org.openani.mediamp.vlc.internal.io.SeekableInputCallbackMedia
+import uk.co.caprica.vlcj.factory.MediaPlayerFactory
+import uk.co.caprica.vlcj.player.base.MediaPlayer
+import uk.co.caprica.vlcj.player.embedded.EmbeddedMediaPlayer
+import uk.co.caprica.vlcj.player.embedded.videosurface.CallbackVideoSurface
+import uk.co.caprica.vlcj.player.embedded.videosurface.VideoSurface
+import uk.co.caprica.vlcj.player.embedded.videosurface.VideoSurfaceAdapters
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormat
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormatCallback
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.RenderCallback
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.format.RV32BufferFormat
+import java.nio.ByteBuffer
+import kotlin.concurrent.withLock
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * [FramePreview] implementation backed by a second, headless VLC media player instance.
+ *
+ * The preview player renders into a small callback video surface (VLC scales the frame for us via
+ * the buffer format), plays muted until the first frame arrives, then stays paused; each request
+ * is a seek-while-paused, which makes VLC decode and display the frame at the target position.
+ */
+@OptIn(ExperimentalMediampApi::class)
+internal class VlcFramePreview(
+    /** The media currently playing in the main player, or `null` if none. */
+    private val currentMediaData: () -> MediaData?,
+) : FramePreview {
+    private val mutex = Mutex()
+    private var session: PreviewSession? = null
+    private var factory: MediaPlayerFactory? = null
+    private var closed = false
+
+    override suspend fun getPreviewFrame(positionMillis: Long, maxWidth: Int, maxHeight: Int): PreviewFrame? {
+        if (maxWidth <= 0 || maxHeight <= 0) return null
+        val data = currentMediaData() ?: return null
+        return withContext(Dispatchers.IO) {
+            mutex.withLock {
+                if (closed) return@withLock null
+                val session = obtainSessionLocked(data, maxWidth, maxHeight) ?: return@withLock null
+                try {
+                    session.grabFrame(positionMillis)
+                } catch (e: CancellationException) {
+                    // The caller moved on to a newer position (collectLatest). The session is
+                    // still healthy — do not tear down the decoder on every scrub movement.
+                    throw e
+                } catch (e: Exception) {
+                    // A broken session (e.g. VLC error state) should not be reused.
+                    discardSessionLocked()
+                    null
+                }
+            }
+        }
+    }
+
+    /** Closes the preview session if the main player's media changed or was stopped. */
+    suspend fun onMediaDataChanged(data: MediaData?) {
+        mutex.withLock {
+            if (session != null && session?.mediaData !== data) {
+                discardSessionLocked()
+            }
+        }
+    }
+
+    suspend fun closeSuspending() {
+        mutex.withLock {
+            if (closed) return
+            closed = true
+            discardSessionLocked()
+            factory?.release()
+            factory = null
+        }
+    }
+
+    private suspend fun obtainSessionLocked(data: MediaData, maxWidth: Int, maxHeight: Int): PreviewSession? {
+        session?.let { existing ->
+            if (existing.mediaData === data) return existing
+            discardSessionLocked()
+        }
+        val factory = this.factory ?: VlcMediampPlayer.createPlayerLock.withLock {
+            MediaPlayerFactory("--intf=dummy", "--quiet")
+        }.also { this.factory = it }
+        return try {
+            // NonCancellable: session creation is expensive shared state; a cancelled first
+            // request must not abort it half-way (the next request reuses the session).
+            withContext(NonCancellable) {
+                PreviewSession.create(factory, data, maxWidth, maxHeight)
+            }.also { session = it }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun discardSessionLocked() {
+        session?.close()
+        session = null
+    }
+
+    private class PreviewSession private constructor(
+        val mediaData: MediaData,
+        private val player: EmbeddedMediaPlayer,
+        private val surface: FrameGrabSurface,
+        private val input: SeekableInput?,
+    ) : AutoCloseable {
+        private var started = false
+
+        /** Last time (millis) reported by a libvlc timeChanged event. */
+        private val lastTimeEvent = MutableStateFlow(-1L)
+
+        init {
+            player.events().addMediaPlayerEventListener(
+                object : uk.co.caprica.vlcj.player.base.MediaPlayerEventAdapter() {
+                    override fun timeChanged(mediaPlayer: MediaPlayer, newTime: Long) {
+                        lastTimeEvent.value = newTime
+                    }
+                },
+            )
+        }
+
+        suspend fun grabFrame(positionMillis: Long): PreviewFrame? {
+            // NonCancellable: the initial muted play-until-first-frame is shared progress that
+            // must survive the cancellation of the request that happened to trigger it.
+            if (!withContext(NonCancellable) { ensureStarted() }) return null
+
+            val length = player.status().length()
+            val target = if (length > 0) positionMillis.coerceIn(0, max(0, length - 500)) else max(0, positionMillis)
+
+            // A paused seek makes VLC only re-display the stale pre-seek picture; it does not
+            // decode the target. The reliable recipe (same as vlcj's thumbnailer example):
+            // briefly unpause, seek, wait for a timeChanged event near the target (= demuxer
+            // and decoder actually landed there), take the next displayed frame, pause again.
+            lastTimeEvent.value = -1L // ignore events from before this seek
+            player.submit {
+                player.controls().setTime(target)
+                player.controls().setPause(false)
+            }
+            try {
+                val seekSettled = withTimeoutOrNull(5_000) {
+                    lastTimeEvent.first { it >= 0 && kotlin.math.abs(it - target) < 2_000 }
+                    true
+                } ?: false
+                if (!seekSettled) return null
+
+                // The first frame right after the seek can still be the flushed re-display of the
+                // old picture; frames arriving after the confirmed position are freshly decoded.
+                val frameBefore = surface.frameCounter.value
+                if (!surface.awaitFrameAfter(frameBefore, timeoutMillis = 1_000)) return null
+            } finally {
+                player.submit { player.controls().setPause(true) }
+            }
+            return surface.copyLatestFrame(target)
+        }
+
+        /** Starts muted playback once, waits for the first frame, then pauses. */
+        private suspend fun ensureStarted(): Boolean {
+            if (started) return true
+            player.submit { player.controls().start() }
+            val gotFirstFrame = surface.awaitFrameAfter(0, timeoutMillis = 10_000)
+            if (!gotFirstFrame) return false
+            player.submit { player.controls().setPause(true) }
+            started = true
+            return true
+        }
+
+        override fun close() {
+            try {
+                player.release()
+            } catch (_: Exception) {
+            } finally {
+                try {
+                    input?.close()
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        companion object {
+            /** Media options keeping the preview player lightweight. */
+            private val PREVIEW_OPTIONS = listOf("no-audio", "no-spu")
+
+            suspend fun create(
+                factory: MediaPlayerFactory,
+                data: MediaData,
+                maxWidth: Int,
+                maxHeight: Int,
+            ): PreviewSession {
+                // Open the (possibly slow) input before touching VLC, so a failure here leaks nothing.
+                val input: SeekableInput? = when (data) {
+                    is SeekableInputMediaData -> data.createInput()
+                    is UriMediaData -> null
+                }
+
+                val player = try {
+                    VlcMediampPlayer.createPlayerLock.withLock {
+                        factory.mediaPlayers().newEmbeddedMediaPlayer()
+                    }
+                } catch (e: Throwable) {
+                    input?.close()
+                    throw e
+                }
+                val surface = FrameGrabSurface(maxWidth, maxHeight)
+                player.videoSurface().set(surface)
+                surface.attach(player)
+
+                try {
+                    val prepared = when (data) {
+                        is UriMediaData -> {
+                            val lowerHeaders = data.headers.mapKeys { it.key.lowercase() }
+                            val options = buildList {
+                                addAll(PREVIEW_OPTIONS)
+                                add("http-user-agent=${lowerHeaders["user-agent"] ?: "Mozilla/5.0"}")
+                                lowerHeaders["referer"]?.let { add("http-referrer=$it") }
+                                addAll(data.options)
+                            }
+                            player.media().prepare(data.uri, *options.toTypedArray())
+                        }
+
+                        is SeekableInputMediaData -> {
+                            val media = SeekableInputCallbackMedia(input!!) {}
+                            player.media().prepare(media, *(PREVIEW_OPTIONS + data.options).toTypedArray())
+                        }
+                    }
+                    check(prepared) { "VLC prepare() failed for preview media" }
+                } catch (e: Throwable) {
+                    player.release()
+                    input?.close()
+                    throw e
+                }
+                return PreviewSession(data, player, surface, input)
+            }
+        }
+    }
+
+    /**
+     * A headless callback video surface that keeps only the most recent frame.
+     *
+     * The buffer format requests a downscaled picture from VLC, so decoding cost stays low and
+     * no scaling is needed on our side.
+     */
+    private class FrameGrabSurface(
+        private val maxWidth: Int,
+        private val maxHeight: Int,
+    ) : VideoSurface(VideoSurfaceAdapters.getVideoSurfaceAdapter()) {
+        /** Incremented on every displayed frame. Never reset. */
+        val frameCounter = MutableStateFlow(0L)
+
+        private val lock = Any()
+        private var frameWidth = 0
+        private var frameHeight = 0
+        private var frameBytes: ByteArray? = null
+
+        private val bufferFormatCallback = object : BufferFormatCallback {
+            private var width = 0
+            private var height = 0
+
+            override fun getBufferFormat(sourceWidth: Int, sourceHeight: Int): BufferFormat {
+                val scale = min(
+                    maxWidth.toFloat() / sourceWidth,
+                    maxHeight.toFloat() / sourceHeight,
+                ).coerceAtMost(1f)
+                width = max(2, (sourceWidth * scale).roundToInt())
+                height = max(2, (sourceHeight * scale).roundToInt())
+                return RV32BufferFormat(width, height)
+            }
+
+            override fun allocatedBuffers(buffers: Array<ByteBuffer>) {
+                synchronized(lock) {
+                    frameWidth = width
+                    frameHeight = height
+                    frameBytes = ByteArray(buffers[0].remaining())
+                }
+            }
+        }
+
+        private val renderCallback = object : RenderCallback {
+            override fun display(
+                mediaPlayer: MediaPlayer,
+                nativeBuffers: Array<ByteBuffer>,
+                bufferFormat: BufferFormat,
+            ) {
+                synchronized(lock) {
+                    val bytes = frameBytes ?: return
+                    val buffer = nativeBuffers[0]
+                    buffer.rewind()
+                    if (buffer.remaining() < bytes.size) return
+                    buffer.get(bytes, 0, bytes.size)
+                }
+                frameCounter.value += 1
+            }
+        }
+
+        private val callbackSurface = object : CallbackVideoSurface(
+            bufferFormatCallback,
+            renderCallback,
+            true,
+            VideoSurfaceAdapters.getVideoSurfaceAdapter(),
+        ) {}
+
+        override fun attach(mediaPlayer: MediaPlayer) {
+            callbackSurface.attach(mediaPlayer)
+        }
+
+        suspend fun awaitFrameAfter(count: Long, timeoutMillis: Long): Boolean {
+            return withTimeoutOrNull(timeoutMillis) {
+                frameCounter.first { it > count }
+                true
+            } ?: false
+        }
+
+        /** Converts the latest BGRA frame to a [PreviewFrame], or `null` if none arrived yet. */
+        fun copyLatestFrame(positionMillis: Long): PreviewFrame? {
+            synchronized(lock) {
+                val bytes = frameBytes ?: return null
+                val width = frameWidth
+                val height = frameHeight
+                if (width <= 0 || height <= 0 || frameCounter.value == 0L) return null
+                val pixels = IntArray(width * height)
+                // RV32 is BGRA byte order.
+                var i = 0
+                for (p in pixels.indices) {
+                    val b = bytes[i].toInt() and 0xFF
+                    val g = bytes[i + 1].toInt() and 0xFF
+                    val r = bytes[i + 2].toInt() and 0xFF
+                    val a = bytes[i + 3].toInt() and 0xFF
+                    pixels[p] = (a shl 24) or (r shl 16) or (g shl 8) or b
+                    i += 4
+                }
+                return PreviewFrame(positionMillis, width, height, pixels)
+            }
+        }
+    }
+}

--- a/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
+++ b/mediamp-vlc/src/main/kotlin/VlcMediampPlayer.kt
@@ -38,6 +38,7 @@ import org.openani.mediamp.PlaybackState
 import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.AudioLevelController
 import org.openani.mediamp.features.Buffering
+import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.MediaMetadata
 import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.features.PlayerFeatures
@@ -151,6 +152,7 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
     private val audioLevelController = VlcAudioLevelController(player)
     private val mediaMetadata = VlcMediaMetadata()
     private val videoAspectRatio = VlcVideoAspectRatio()
+    private val framePreview = VlcFramePreview { openResource.value?.mediaData }
 
     @OptIn(ExperimentalMediampApi::class)
     override val features: PlayerFeatures = buildPlayerFeatures {
@@ -160,9 +162,17 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
         add(PlaybackSpeed.Key, playbackSpeed)
         add(MediaMetadata, mediaMetadata)
         add(VideoAspectRatio.Key, videoAspectRatio)
+        add(FramePreview.Key, framePreview)
     }
 
     init {
+        backgroundScope.launch {
+            // Tear down the preview decoder when the media changes or playback stops,
+            // so it never outlives the media data it reads from.
+            mediaData.collect {
+                framePreview.onMediaDataChanged(it)
+            }
+        }
         // NOTE: must not call native player in a event
         player.events().addMediaEventListener(
             object : MediaEventAdapter() {
@@ -550,6 +560,7 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
         lastMedia?.onClose() // 在调用 VLC 之前停止阻塞线程
         lastMedia = null
         backgroundScope.launch(NonCancellable) {
+            framePreview.closeSuspending()
             player.release()
             backgroundScope.cancel()
         }
@@ -596,7 +607,7 @@ public class VlcMediampPlayer(parentCoroutineContext: CoroutineContext) :
     }
 
     public companion object {
-        private val createPlayerLock = ReentrantLock() // 如果同时加载可能会 SIGSEGV
+        internal val createPlayerLock = ReentrantLock() // 如果同时加载可能会 SIGSEGV
 
         public fun prepareLibraries() {
             createPlayerLock.withLock {

--- a/mediamp-vlc/src/test/kotlin/VlcFramePreviewTest.kt
+++ b/mediamp-vlc/src/test/kotlin/VlcFramePreviewTest.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.vlc
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.openani.mediamp.ExperimentalMediampApi
+import org.openani.mediamp.features.FramePreview
+import org.openani.mediamp.features.PreviewFrame
+import org.openani.mediamp.io.SeekableInput
+import org.openani.mediamp.source.MediaData
+import org.openani.mediamp.source.MediaExtraFiles
+import org.openani.mediamp.source.SeekableInputMediaData
+import org.openani.mediamp.source.UriMediaData
+import java.io.File
+import java.io.RandomAccessFile
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration test for [VlcFramePreview] against a real libvlc.
+ *
+ * Uses a video that is solid red for 0.0-2.5s and solid blue for 2.5-5.0s, so the extracted
+ * frame's dominant color proves WHICH position was decoded, not just that decoding worked.
+ *
+ * Requires a real libvlc (e.g. /Applications/VLC.app on macOS) and ffmpeg. Skipped otherwise.
+ * Run manually:
+ *   ./gradlew :mediamp-vlc:test --tests "org.openani.mediamp.vlc.VlcFramePreviewTest"
+ */
+@OptIn(ExperimentalMediampApi::class)
+class VlcFramePreviewTest {
+
+    private fun assumeRealPlaybackEnvironment() {
+        org.junit.Assume.assumeTrue(
+            "ffmpeg not found; skipping real-playback test",
+            findFfmpeg() != null,
+        )
+        org.junit.Assume.assumeTrue(
+            "libvlc not found; skipping real-playback test",
+            runCatching { uk.co.caprica.vlcj.factory.discovery.NativeDiscovery().discover() }.getOrDefault(false),
+        )
+    }
+
+    @Test
+    fun `preview frames follow requested position - uri media`() {
+        assumeRealPlaybackEnvironment()
+        runScenario(UriMediaData("file://${ensureColorVideo().absolutePath}"))
+    }
+
+    @Test
+    fun `preview frames follow requested position - seekable input media`() {
+        assumeRealPlaybackEnvironment()
+        runScenario(FileSeekableInputMediaData(ensureColorVideo()))
+    }
+
+    private fun runScenario(mediaData: MediaData) {
+        val playerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            runBlocking {
+                val player = VlcMediampPlayer(playerScope.coroutineContext)
+                try {
+                    player.setMediaData(mediaData)
+                    val preview = assertNotNull(player.features[FramePreview.Key], "FramePreview feature missing")
+
+                    // Main player is NOT started: previews must work while the video is merely loaded.
+                    val red = assertNotNull(
+                        preview.getPreviewFrame(1_000, 160, 160),
+                        "no frame at 1s",
+                    )
+                    assertDominantColor(red, "red") { r, _, b -> r > 180 && b < 80 }
+                    assertTrue(red.width in 2..160 && red.height in 2..160, "unexpected size ${red.width}x${red.height}")
+
+                    val blue = assertNotNull(
+                        preview.getPreviewFrame(4_000, 160, 160),
+                        "no frame at 4s",
+                    )
+                    assertDominantColor(blue, "blue") { r, _, b -> b > 180 && r < 80 }
+
+                    // Scrub back: seeking backwards while paused must work too.
+                    val redAgain = assertNotNull(
+                        preview.getPreviewFrame(1_500, 160, 160),
+                        "no frame at 1.5s (backwards seek)",
+                    )
+                    assertDominantColor(redAgain, "red (backwards)") { r, _, b -> r > 180 && b < 80 }
+                } finally {
+                    player.close()
+                }
+            }
+        } finally {
+            playerScope.cancel()
+        }
+    }
+
+    /** Asserts on the average color of the center 20x20 region. */
+    private fun assertDominantColor(
+        frame: PreviewFrame,
+        what: String,
+        predicate: (r: Int, g: Int, b: Int) -> Boolean,
+    ) {
+        var r = 0L
+        var g = 0L
+        var b = 0L
+        var n = 0
+        val cx = frame.width / 2
+        val cy = frame.height / 2
+        val half = minOf(10, frame.width / 2, frame.height / 2)
+        for (y in cy - half until cy + half) {
+            for (x in cx - half until cx + half) {
+                val argb = frame.pixels[y * frame.width + x]
+                r += (argb shr 16) and 0xFF
+                g += (argb shr 8) and 0xFF
+                b += argb and 0xFF
+                n++
+            }
+        }
+        val avgR = (r / n).toInt()
+        val avgG = (g / n).toInt()
+        val avgB = (b / n).toInt()
+        assertTrue(
+            predicate(avgR, avgG, avgB),
+            "expected $what frame, got avg color ($avgR, $avgG, $avgB) for ${frame.width}x${frame.height} frame at ${frame.positionMillis}ms",
+        )
+    }
+
+    @OptIn(ExperimentalMediampApi::class)
+    private class FileSeekableInputMediaData(private val file: File) : SeekableInputMediaData {
+        override val uri: String get() = "test://${file.name}"
+        override val extraFiles: MediaExtraFiles get() = MediaExtraFiles()
+        override val options: List<String> get() = emptyList()
+        override fun fileLength(): Long = file.length()
+        override fun close() {}
+
+        override suspend fun createInput(coroutineContext: CoroutineContext): SeekableInput {
+            val raf = RandomAccessFile(file, "r")
+            return object : SeekableInput {
+                private val fileSize = raf.length()
+                override val position: Long get() = raf.filePointer
+                override val bytesRemaining: Long get() = fileSize - raf.filePointer
+                override val size: Long get() = fileSize
+                override fun seekTo(position: Long) = raf.seek(position)
+                override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
+                    raf.read(buffer, offset, length)
+
+                override fun close() = raf.close()
+            }
+        }
+    }
+
+    /** 0.0s-2.5s solid red, 2.5s-5.0s solid blue — known pixel content for frame assertions. */
+    private fun ensureColorVideo(): File {
+        val target = File(System.getProperty("java.io.tmpdir"), "mediamp-vlc-frame-preview-colors.mp4")
+        if (target.isFile && target.length() > 0) return target
+        val ffmpeg = checkNotNull(findFfmpeg()) { "ffmpeg not found" }
+        val process = ProcessBuilder(
+            ffmpeg, "-y",
+            "-f", "lavfi", "-i", "color=c=red:size=640x360:rate=30:duration=2.5",
+            "-f", "lavfi", "-i", "color=c=blue:size=640x360:rate=30:duration=2.5",
+            "-filter_complex", "[0:v][1:v]concat=n=2:v=1:a=0,format=yuv420p[v]",
+            "-map", "[v]", "-c:v", "libx264", "-preset", "ultrafast", "-g", "15",
+            target.absolutePath,
+        ).redirectErrorStream(true).start()
+        process.inputStream.readAllBytes()
+        check(process.waitFor(60, TimeUnit.SECONDS) && process.exitValue() == 0) { "ffmpeg failed" }
+        return target
+    }
+
+    private fun findFfmpeg(): String? =
+        listOf("/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg")
+            .firstOrNull { File(it).canExecute() }
+}


### PR DESCRIPTION
## What

New stable `FramePreview` player feature in `mediamp-api`:

```kotlin
public interface FramePreview : Feature {
    public suspend fun getPreviewFrame(positionMillis: Long, maxWidth: Int, maxHeight: Int): PreviewFrame?
}
```

It extracts a decoded video frame near an arbitrary position of the currently playing media **without affecting playback**, intended for seek-bar hover/drag thumbnail previews (used by open-ani/animeko).

## Implementations

| Backend | Approach |
|---|---|
| **mpv** (desktop) | Second headless `MpvMediampPlayer`, loaded paused (`commandLoadFilePaused()`), rendering into a small native surface ring sized to the video aspect. Per request: `seek absolute+keyframes` → wait `seeking=false` && `time-pos` near target → wait for a post-seek render → `saveSurfacePng` readback. Same pattern as mpv's thumbfast, but in-process. |
| **VLC** | Second headless `EmbeddedMediaPlayer` with a downscaled callback video surface (VLC scales via the buffer format). A paused `setTime` only re-displays the stale picture, so each grab briefly unpauses → seeks → waits for a `timeChanged` event near the target → takes the next displayed frame → pauses (vlcj thumbnailer recipe). |
| **ExoPlayer** | `MediaMetadataRetriever`, wrapping `SeekableInputMediaData` in a `MediaDataSource` so torrent-like custom media works. |

## Lifecycle & correctness

- The preview decoder wraps the shared `MediaData` in a non-closing delegate and opens its **own** input for stream_cb/callback media; the session is torn down on media change and on player close, closing everything it opened.
- **Cancellation-safe**: callers drive this with `collectLatest`, cancelling in-flight grabs on every scrub movement. `CancellationException` is rethrown without discarding the session, and session creation/startup runs `NonCancellable` — without this, every scrub movement destroyed and rebuilt the decoder instance (found in real-app verification; covered by a cancellation-storm regression test).

## Tests

- `MpvFramePreviewTest` (real libmpv, dev natives) and `VlcFramePreviewTest` (real libvlc): decode a red/blue two-segment video and assert the **dominant color** of extracted frames — proving *which* position was decoded — over URI and seekable-input paths, including backwards seeks.
- `cancelled requests do not destroy the session` regression test.
- Full `:mediamp-mpv:desktopTest` and `:mediamp-vlc:test` suites pass; all targets (desktop/Android/iOS) compile.

Verified end-to-end in the Animeko desktop app on both the mpv and VLC backends (screenshots in the companion animeko PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)