### PR TITLE
feat(mpv): add Linux OpenGL playback support

### DIFF
--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
@@ -260,6 +260,23 @@ internal fun FfmpegBuildContext.linuxX64Target(): FfmpegBuildTarget = FfmpegBuil
     configureFlags = listOf(
         "--arch=x86_64",
         "--target-os=linux",
+        // mpv's `hwdec=nvdec` uses the ordinary software decoders with FFmpeg's
+        // NVDEC hwaccels. CUDA/NVDEC driver libraries are loaded dynamically at
+        // runtime; ffnvcodec headers are a build-only dependency.
+        "--enable-ffnvcodec",
+        "--enable-nvdec",
+        "--enable-hwaccel=h264_nvdec",
+        "--enable-hwaccel=hevc_nvdec",
+        "--enable-hwaccel=vp9_nvdec",
+        "--enable-hwaccel=av1_nvdec",
+        // Intel and AMD share FFmpeg's VAAPI hwdevice. mediamp deliberately uses
+        // mpv's vaapi-copy path with the GLX renderer; direct DMA-BUF/EGL import is
+        // a separate capability and is not claimed by this build.
+        "--enable-vaapi",
+        "--enable-hwaccel=h264_vaapi",
+        "--enable-hwaccel=hevc_vaapi",
+        "--enable-hwaccel=vp9_vaapi",
+        "--enable-hwaccel=av1_vaapi",
     ) + opensslHttpTlsFlags + linuxRuntimeSearchPathFlags,
     libExtension = "so",
     jniWrapperName = "libffmpegkitjni.so",

--- a/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
@@ -216,9 +216,20 @@ internal fun MpvBuildContext.linuxX64Target(): MpvBuildTarget = MpvBuildTarget(
     mesonOptions = commonMesonOptions + listOf(
         "-Dgl=enabled",
         "-Dgl-x11=enabled",
+        // Keep the existing libmpv EGL-X11 build capability. mediamp's Compose surface
+        // bridge implemented in this module supports GLX only; it does not use EGL.
         "-Degl=enabled",
         "-Degl-x11=enabled",
         "-Dx11=enabled",
+        // Override the conservative common defaults for Linux. This compiles mpv's
+        // CUDA hwdevice and CUDA/OpenGL mapper so NVDEC frames can be registered
+        // directly in the GLX producer context without a CPU frame copy.
+        "-Dcuda-hwaccel=enabled",
+        "-Dcuda-interop=enabled",
+        // Enables Intel/AMD VAAPI device creation and the explicit vaapi-copy
+        // fallback. Direct VAAPI/OpenGL import is not used by the GLX producer.
+        "-Dvaapi=enabled",
+        "-Dvaapi-x11=enabled",
         "-Dd3d11=disabled",
         "-Ddirect3d=disabled",
         "-Dwasapi=disabled",
@@ -229,7 +240,9 @@ internal fun MpvBuildContext.linuxX64Target(): MpvBuildTarget = MpvBuildTarget(
     jni = MpvJniToolchain(
         compilerCommand = jniCompilerFallback(this, default = "g++"),
         compilerArgs = listOf("-pthread", CPP_STANDARD_FLAG, "-fPIC", "-shared"),
-        linkerArgs = listOf("-pthread", "-Wl,-rpath,\$ORIGIN"),
+        // GLX producer context/pbuffer bridge (glx_context_provider.cpp). libmpv's GL
+        // renderer resolves entry points through libGL/dl, while debug PNG output uses zlib.
+        linkerArgs = listOf("-pthread", "-Wl,-rpath,\$ORIGIN", "-lGL", "-lX11", "-ldl", "-lz"),
         outputFileName = "libmediampv.so",
         sourceExtensions = setOf("cpp"),
         useJdkIncludes = true,

--- a/ci-helper/install-mpv-deps-ubuntu.sh
+++ b/ci-helper/install-mpv-deps-ubuntu.sh
@@ -21,6 +21,8 @@ sudo apt-get install -y --no-install-recommends \
     ninja-build \
     patchelf \
     pkg-config \
+    libffmpeg-nvenc-dev \
+    libva-dev \
     libass-dev \
     libplacebo-dev \
     libasound2-dev \

--- a/mediamp-mpv-demo/build.gradle.kts
+++ b/mediamp-mpv-demo/build.gradle.kts
@@ -55,15 +55,16 @@ tasks.matching { it.name == "run" }.configureEach {
     dependsOn(compileNativeBridge)
 }
 
-// Production mediamp-mpv path (Windows D3D11 / macOS Metal) against a locally
+// Production mediamp-mpv path (Windows D3D11 / macOS Metal / Linux GLX) against a locally
 // assembled runtime: ./gradlew :mediamp-mpv-demo:runD3D11 [-Pvideo=/path/to.mp4]
 tasks.register<JavaExec>("runD3D11") {
     group = "mediamp"
-    description = "Run the production mediamp-mpv demo (D3D11 on Windows, Metal on macOS)"
+    description = "Run the production mediamp-mpv demo (D3D11 on Windows, Metal on macOS, GLX on Linux)"
     mainClass = "org.openani.mediamp.mpvdemo.MpvD3D11MainKt"
     classpath = sourceSets["main"].runtimeClasspath
     val runtimeTarget = when {
         System.getProperty("os.name").contains("Windows") -> "WindowsX64"
+        System.getProperty("os.name").contains("Linux") -> "LinuxX64"
         System.getProperty("os.arch") == "aarch64" -> "MacosArm64"
         else -> "MacosX64"
     }

--- a/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/MpvD3D11Main.kt
+++ b/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/MpvD3D11Main.kt
@@ -34,8 +34,8 @@ import org.openani.mediamp.source.UriMediaData
 
 /**
  * Smoke-test entry for the production mediamp-mpv render path (Windows D3D11 / macOS
- * Metal): the real [MpvMediampPlayer] + [MpvMediampPlayerSurface], loading the native
- * runtime from a local mpv assemble output.
+ * Metal / Linux GLX): the real [MpvMediampPlayer] + [MpvMediampPlayerSurface], loading
+ * the native runtime from a local mpv assemble output.
  *
  * Run: ./gradlew :mediamp-mpv-demo:runD3D11 [-Pvideo=/path/to.mp4]
  * Plays mpv's built-in lavfi test source when no video is given.
@@ -45,13 +45,20 @@ fun main(args: Array<String>) {
         ?: System.getProperty("mpvdemo.video")
         ?: "av://lavfi:testsrc2=size=1280x720:rate=60"
 
+    val hostRuntimeTask = when {
+        System.getProperty("os.name").contains("Windows") -> "mpvAssembleWindowsX64"
+        System.getProperty("os.name").contains("Linux") -> "mpvAssembleLinuxX64"
+        System.getProperty("os.arch") == "aarch64" -> "mpvAssembleMacosArm64"
+        else -> "mpvAssembleMacosX64"
+    }
     val runtimeDir = requireNotNull(System.getProperty("mediamp.mpv.runtime.dir")) {
-        "mediamp.mpv.runtime.dir must point at the mpv runtime (run :mediamp-mpv:mpvAssembleWindowsX64 first)"
+        "mediamp.mpv.runtime.dir must point at an assembled mpv runtime " +
+            "(run :mediamp-mpv:$hostRuntimeTask first)"
     }
     MpvMediampPlayer.prepareLibraries(runtimeDir, extractRuntimeLibrary = false)
 
     singleWindowApplication(
-        title = "mediamp mpv D3D11",
+        title = "mediamp mpv production renderer (D3D11 / Metal / GLX)",
         state = WindowState(size = DpSize(1280.dp, 800.dp)),
     ) {
         val player = remember { MpvMediampPlayer(Any(), Dispatchers.Default) }
@@ -91,7 +98,7 @@ fun main(args: Array<String>) {
             Box(Modifier.fillMaxSize().background(Color.Black)) {
                 MpvMediampPlayerSurface(player, Modifier.fillMaxSize())
                 DemoOverlay(
-                    title = "mediamp-mpv production path (D3D11/Metal)",
+                    title = "mediamp-mpv production path (D3D11/Metal/GLX)",
                     statusLine = loadError
                         ?: "state: $playbackState   uri: $videoUri",
                     statusOk = loadError == null && playbackState == org.openani.mediamp.PlaybackState.PLAYING,

--- a/mediamp-mpv/src/cpp/glx_context_provider.cpp
+++ b/mediamp-mpv/src/cpp/glx_context_provider.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include <dlfcn.h>
+
+#include <GL/glx.h>
+#include <GL/glxext.h>
+#include <X11/Xlib.h>
+
+#include <memory>
+
+#include "glx_context_provider.h"
+#include "log.h"
+
+namespace {
+
+constexpr int kContextAttributes[] = {
+    GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
+    GLX_CONTEXT_MINOR_VERSION_ARB, 3,
+    GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+    None,
+};
+
+constexpr int kFramebufferAttributes[] = {
+    GLX_X_RENDERABLE, True,
+    GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
+    GLX_RENDER_TYPE, GLX_RGBA_BIT,
+    GLX_RED_SIZE, 8,
+    GLX_GREEN_SIZE, 8,
+    GLX_BLUE_SIZE, 8,
+    GLX_ALPHA_SIZE, 8,
+    None,
+};
+
+constexpr int kPbufferAttributes[] = {
+    GLX_PBUFFER_WIDTH, 1,
+    GLX_PBUFFER_HEIGHT, 1,
+    None,
+};
+
+using create_context_attribs_fn = GLXContext (*) (
+    Display *, GLXFBConfig, GLXContext, Bool, const int *);
+
+create_context_attribs_fn get_create_context_attribs() {
+    return reinterpret_cast<create_context_attribs_fn>(
+        glXGetProcAddressARB(reinterpret_cast<const GLubyte *>("glXCreateContextAttribsARB")));
+}
+
+} // namespace
+
+namespace mediampv {
+
+glx_context_provider::glx_context_provider(
+    Display *display,
+    GLXContext context,
+    GLXPbuffer drawable,
+    uint64_t environment_identity)
+    : display_(display),
+      context_(context),
+      drawable_(drawable),
+      environment_identity_(environment_identity) {}
+
+glx_context_provider::~glx_context_provider() {
+    destroy();
+}
+
+glx_context_provider *glx_context_provider::create(
+    const glx_render_environment &environment, std::string *error) {
+    if (!environment.display || !environment.share_context) {
+        if (error) *error = "GLX render environment requires a live Display and share context";
+        return nullptr;
+    }
+    if (environment.identity == 0) {
+        if (error) *error = "GLX render environment identity must be non-zero";
+        return nullptr;
+    }
+
+    // Skiko and mediamp use the same Xlib Display. Lock it for the complete setup so
+    // another thread cannot interleave a GLX request on this connection. We do not call
+    // XInitThreads here: it has to run before any Xlib use, which is Skiko's decision.
+    XLockDisplay(environment.display);
+    int config_count = 0;
+    GLXFBConfig *configs = glXChooseFBConfig(
+        environment.display, environment.screen, kFramebufferAttributes, &config_count);
+    if (!configs || config_count == 0) {
+        if (configs) XFree(configs);
+        XUnlockDisplay(environment.display);
+        if (error) *error = "no GLX RGBA pbuffer framebuffer configuration is available";
+        return nullptr;
+    }
+
+    int shared_config_id = 0;
+    glXQueryContext(
+        environment.display, environment.share_context,
+        GLX_FBCONFIG_ID, &shared_config_id);
+    GLXFBConfig selected_config = configs[0];
+    for (int i = 0; i < config_count && shared_config_id != 0; ++i) {
+        int candidate_id = 0;
+        glXGetFBConfigAttrib(environment.display, configs[i], GLX_FBCONFIG_ID, &candidate_id);
+        if (candidate_id == shared_config_id) {
+            selected_config = configs[i];
+            break;
+        }
+    }
+    GLXPbuffer pbuffer = glXCreatePbuffer(environment.display, selected_config, kPbufferAttributes);
+    if (!pbuffer) {
+        XFree(configs);
+        XUnlockDisplay(environment.display);
+        if (error) *error = "glXCreatePbuffer failed";
+        return nullptr;
+    }
+
+    auto create_context_attribs = get_create_context_attribs();
+    if (!create_context_attribs) {
+        glXDestroyPbuffer(environment.display, pbuffer);
+        XFree(configs);
+        XUnlockDisplay(environment.display);
+        if (error) *error = "GLX_ARB_create_context is unavailable; OpenGL 3.3 sharing is required";
+        return nullptr;
+    }
+
+    // The pbuffer is only a drawable for context B. The supplied context A is solely a
+    // share-list source and remains current/owned by Skiko on its own render thread.
+    GLXContext context = create_context_attribs(
+        environment.display, selected_config, environment.share_context, True, kContextAttributes);
+    XFree(configs);
+    XUnlockDisplay(environment.display);
+    if (!context) {
+        // GLX context creation failed. The environment might be stale or from another
+        // screen/share group; callers must rediscover it instead of retrying blindly.
+        XLockDisplay(environment.display);
+        glXDestroyPbuffer(environment.display, pbuffer);
+        XUnlockDisplay(environment.display);
+        if (error) *error = "glXCreateContextAttribsARB(3.3 core, shared) failed";
+        return nullptr;
+    }
+
+    auto *provider = new glx_context_provider(
+        environment.display, context, pbuffer, environment.identity);
+    LOGI("created shared GLX producer context=%p pbuffer=%lu environment=%llu",
+         static_cast<void *>(context), static_cast<unsigned long>(pbuffer),
+         static_cast<unsigned long long>(environment.identity));
+    return provider;
+}
+
+bool glx_context_provider::make_current() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!context_ || !drawable_) return fail_locked("GLX producer context is destroyed");
+
+    const auto current_thread = std::this_thread::get_id();
+    if (owner_bound_ && owner_thread_ != current_thread) {
+        return fail_locked("GLX producer context cannot move to another thread");
+    }
+
+    XLockDisplay(display_);
+    const Bool made_current = glXMakeContextCurrent(display_, drawable_, drawable_, context_);
+    XUnlockDisplay(display_);
+    if (!made_current) return fail_locked("glXMakeContextCurrent for producer context failed");
+
+    owner_thread_ = current_thread;
+    owner_bound_ = true;
+    current_on_owner_ = true;
+    return true;
+}
+
+bool glx_context_provider::clear_current() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!context_) return true;
+    if (!owner_bound_ || owner_thread_ != std::this_thread::get_id()) {
+        return fail_locked("only the GLX producer owner thread may clear its context");
+    }
+
+    XLockDisplay(display_);
+    const Bool cleared = glXMakeContextCurrent(display_, None, None, nullptr);
+    XUnlockDisplay(display_);
+    if (!cleared) return fail_locked("glXMakeContextCurrent clear failed");
+    current_on_owner_ = false;
+    return true;
+}
+
+bool glx_context_provider::destroy() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!context_ && !drawable_) return true;
+    if (current_on_owner_) {
+        if (owner_thread_ != std::this_thread::get_id() || glXGetCurrentContext() != context_) {
+            return fail_locked(
+                "GLX producer context is still current; clear it on the render thread before teardown");
+        }
+        XLockDisplay(display_);
+        const Bool cleared = glXMakeContextCurrent(display_, None, None, nullptr);
+        XUnlockDisplay(display_);
+        if (!cleared) return fail_locked("glXMakeContextCurrent clear during teardown failed");
+        current_on_owner_ = false;
+    }
+
+    // The native render thread must call clear_current() before it exits. Destruction is
+    // intentionally performed only after that thread has joined; GLX cannot safely
+    // destroy a context that is still current on another thread.
+    XLockDisplay(display_);
+    if (context_) glXDestroyContext(display_, context_);
+    if (drawable_) glXDestroyPbuffer(display_, drawable_);
+    XUnlockDisplay(display_);
+    context_ = nullptr;
+    drawable_ = 0;
+    return true;
+}
+
+void *glx_context_provider::get_proc_address(const char *name) const {
+    if (!name || !*name) return nullptr;
+    if (auto proc = glXGetProcAddressARB(reinterpret_cast<const GLubyte *>(name))) {
+        return reinterpret_cast<void *>(proc);
+    }
+    // Some core entry points are exported by libGL but are intentionally omitted from
+    // glXGetProcAddressARB on older GLX implementations.
+    static void *const lib_gl = dlopen("libGL.so.1", RTLD_LAZY | RTLD_LOCAL);
+    return lib_gl ? dlsym(lib_gl, name) : nullptr;
+}
+
+std::string glx_context_provider::last_error() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return last_error_;
+}
+
+bool glx_context_provider::fail_locked(const char *message) {
+    set_error_locked(message);
+    LOGE("%s", message);
+    return false;
+}
+
+void glx_context_provider::set_error_locked(const char *message) {
+    last_error_ = message ? message : "unknown GLX provider error";
+}
+
+} // namespace mediampv
+
+#endif // defined(__linux__) && !defined(__ANDROID__)

--- a/mediamp-mpv/src/cpp/include/glx_context_provider.h
+++ b/mediamp-mpv/src/cpp/include/glx_context_provider.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#ifndef MEDIAMP_GLX_CONTEXT_PROVIDER_H
+#define MEDIAMP_GLX_CONTEXT_PROVIDER_H
+
+#ifdef __linux__
+
+#include <GL/glx.h>
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace mediampv {
+
+/**
+ * The OpenGL environment borrowed from Skiko's live Linux OpenGL redrawer.
+ *
+ * display and share_context remain Skiko-owned for the provider's whole lifetime. The
+ * provider never makes share_context current and never closes display. identity is a
+ * caller-supplied stable token for the Skiko GLX environment: a changed token means the
+ * share group must be treated as a new device generation.
+ */
+struct glx_render_environment final {
+    Display *display = nullptr;
+    GLXContext share_context = nullptr;
+    int screen = 0;
+    uint64_t identity = 0;
+};
+
+/**
+ * Creates the mediamp producer GLX context (context B) in Skiko's share group (context
+ * A). Context B has a private 1x1 pbuffer and is intentionally usable only from one
+ * native render thread. Textures created while B is current are share-group objects;
+ * FBOs created there stay B-local and must not be used by the Skiko consumer context.
+ */
+class glx_context_provider final {
+public:
+    static glx_context_provider *create(
+        const glx_render_environment &environment, std::string *error = nullptr);
+
+    ~glx_context_provider();
+
+    glx_context_provider(const glx_context_provider &) = delete;
+    glx_context_provider &operator=(const glx_context_provider &) = delete;
+
+    /** Makes B current on its sole native render thread. */
+    bool make_current();
+    /** Clears B from its owner thread before that thread exits. */
+    bool clear_current();
+    /** Destroys B and its pbuffer after the owner thread has stopped. Idempotent. */
+    bool destroy();
+
+    /** Suitable for mpv_opengl_init_params::get_proc_address. */
+    void *get_proc_address(const char *name) const;
+
+    uint64_t environment_identity() const { return environment_identity_; }
+    GLXContext context() const { return context_; }
+    GLXPbuffer drawable() const { return drawable_; }
+    std::string last_error() const;
+
+private:
+    glx_context_provider(
+        Display *display,
+        GLXContext context,
+        GLXPbuffer drawable,
+        uint64_t environment_identity);
+
+    bool fail_locked(const char *message);
+    void set_error_locked(const char *message);
+
+    mutable std::mutex mutex_;
+    Display *display_ = nullptr;       // borrowed from Skiko; never XCloseDisplay'd here
+    GLXContext context_ = nullptr;
+    GLXPbuffer drawable_ = 0;
+    uint64_t environment_identity_ = 0;
+    std::thread::id owner_thread_;
+    bool owner_bound_ = false;
+    bool current_on_owner_ = false;
+    std::string last_error_;
+};
+
+} // namespace mediampv
+
+#endif // __linux__
+
+#endif // MEDIAMP_GLX_CONTEXT_PROVIDER_H

--- a/mediamp-mpv/src/cpp/include/mpv_handle_t.h
+++ b/mediamp-mpv/src/cpp/include/mpv_handle_t.h
@@ -34,6 +34,10 @@ struct ID3D12Resource;
 
 namespace mediampv {
 
+#ifdef __linux__
+class glx_context_provider;
+#endif
+
 class mpv_handle_t final {
 public:
     explicit mpv_handle_t(JNIEnv *env, jobject app_context) {
@@ -123,6 +127,21 @@ public:
     bool ack_retired_buffers();
 
     bool has_metal_surface();
+    bool save_surface_png(const char *path);
+#endif
+
+#ifdef __linux__
+    // Context A is Skiko-owned. These borrowed GLX inputs create producer context B
+    // in A's share group; a new identity rebuilds the complete native GL environment.
+    bool attach_opengl_render_environment(
+        int64_t display_ptr, int64_t share_context_ptr, int screen, uint64_t identity);
+    bool create_render_context();
+    bool destroy_render_context();
+    bool set_surface_config(int width, int height, int64_t ignored_device_ptr = 0);
+    uint64_t get_frame_state();
+    int64_t get_buffer_texture(int index); // GLuint texture name, not an FBO.
+    bool ack_retired_buffers();
+    bool has_opengl_surface();
     bool save_surface_png(const char *path);
 #endif
 
@@ -267,6 +286,61 @@ private:
     void drain_one_frame();
 #endif
 
+#ifdef __linux__
+    mpv_render_context *render_context_ = nullptr;
+    glx_context_provider *glx_provider_ = nullptr;
+
+    // Textures are share-group objects; these FBOs are context-B-local producer targets.
+    static constexpr int kOpenGLBufferCount = 3;
+    struct opengl_buffer {
+        uint32_t texture = 0; // GL_TEXTURE_2D / GL_RGBA8
+        uint32_t fbo = 0;
+    };
+    opengl_buffer buffers_[kOpenGLBufferCount];
+    opengl_buffer retired_buffers_[kOpenGLBufferCount];
+    bool has_retired_buffers_ = false;
+    bool buffers_allocated_ = false;
+    int buffer_width_ = 0, buffer_height_ = 0;
+    uint32_t buffer_generation_ = 0;
+    uint64_t frame_serial_ = 0;
+    int latest_index_ = -1;
+    std::atomic<uint64_t> frame_state_{0xFull << 44};
+
+    int64_t pending_display_ptr_ = 0;
+    int64_t pending_share_context_ptr_ = 0;
+    int pending_screen_ = 0;
+    uint64_t pending_environment_identity_ = 0;
+    bool environment_attached_ = false;
+    bool config_pending_ = false;
+    int pending_width_ = 0, pending_height_ = 0;
+    bool retire_ack_pending_ = false;
+    bool render_pending_ = false;
+    bool render_quit_ = false;
+    bool render_initialized_ = false;
+    bool render_initialize_ok_ = false;
+    std::string screenshot_path_;
+    bool screenshot_pending_ = false;
+    bool screenshot_finished_ = false;
+    bool screenshot_ok_ = false;
+    std::mutex render_mutex_;
+    std::condition_variable render_cv_;
+    void *render_thread_ = nullptr; // std::thread*, owned by render_glx.cpp
+
+    void signal_render_update();
+    void start_render_thread();
+    void stop_render_thread();
+    void render_thread_loop();
+    bool create_mpv_render_context_on_render_thread();
+    void destroy_mpv_render_context_on_render_thread();
+    bool apply_config_locked();
+    bool allocate_buffer(opengl_buffer &buffer, int width, int height);
+    void destroy_buffer_ring(opengl_buffer *ring);
+    void publish_state_locked();
+    bool render_into(const opengl_buffer &buffer);
+    void drain_one_frame();
+    bool write_surface_png_on_render_thread(const char *path);
+#endif
+
     std::shared_ptr<mediampv::compatible_thread> event_thread_;
     std::atomic_bool event_loop_request_exit{false};
     bool stream_protocol_registered_ = false;
@@ -289,6 +363,9 @@ private:
     void cleanup_render_resources();
 #endif
 #ifdef __APPLE__
+    void cleanup_render_resources();
+#endif
+#ifdef __linux__
     void cleanup_render_resources();
 #endif
 };

--- a/mediamp-mpv/src/cpp/jni.cpp
+++ b/mediamp-mpv/src/cpp/jni.cpp
@@ -4,6 +4,16 @@
 #include <vector>
 #include <jni.h>
 #include <cstdio>
+#if defined(__linux__) && !defined(__ANDROID__)
+#define GL_GLEXT_PROTOTYPES 1
+#include <dlfcn.h>
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <GL/glx.h>
+#include <X11/Xlib.h>
+#include <jawt.h>
+#include <jawt_md.h>
+#endif
 #include "mpv_handle_t.h"
 #include "method_cache.h"
 
@@ -102,6 +112,20 @@ extern "C" {
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nAckRetiredBuffersMacos)(JNIEnv *env, jclass clazz, jlong ptr);
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasMetalSurface)(JNIEnv *env, jclass clazz, jlong ptr);
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePng)(JNIEnv *env, jclass clazz, jlong ptr, jstring path);
+#endif
+
+#if defined(__linux__) && !defined(__ANDROID__)
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nAttachRenderEnvironmentOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jobject component, jlong share_context, jlong drawable, jlong window);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nCreateRenderContextOpenGL)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nDestroyRenderContextOpenGL)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSetSurfaceConfigOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jint width, jint height, jlong consumer_environment_ptr);
+	JNIEXPORT jlong JNICALL FN_DESKTOP(nGetFrameStateOpenGL)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jlong JNICALL FN_DESKTOP(nGetBufferTextureOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jint index);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nAckRetiredBuffersOpenGL)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasOpenGLSurface)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jstring path);
+	JNIEXPORT jint JNICALL FN_DESKTOP(nCreateOpenGLConsumerFbo)(JNIEnv *env, jclass clazz, jlong texture_name);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nDeleteOpenGLConsumerFbo)(JNIEnv *env, jclass clazz, jint fbo);
 #endif
 
 	/**
@@ -479,6 +503,135 @@ JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePng)(JNIEnv * env, jclass claz
         return JNI_FALSE;
     }
     return instance->save_surface_png(path_chars.get());
+}
+
+#endif
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nAttachRenderEnvironmentOpenGL)(
+        JNIEnv *env, jclass, jlong ptr, jobject component,
+        jlong share_context, jlong drawable, jlong window) {
+    auto *instance = get_instance(ptr);
+    if (!instance || !component || !share_context || !drawable) return JNI_FALSE;
+
+    // Resolve JAWT lazily so the JNI wrapper does not acquire a deployment-time
+    // dependency on one particular JDK installation path.
+    using jawt_get_awt_fn = jboolean (JNICALL *)(JNIEnv *, JAWT *);
+    static void *const jawt_library = dlopen("libjawt.so", RTLD_NOW | RTLD_LOCAL);
+    static auto get_awt = reinterpret_cast<jawt_get_awt_fn>(
+        dlsym(RTLD_DEFAULT, "JAWT_GetAWT"));
+    if (!get_awt && jawt_library) {
+        get_awt = reinterpret_cast<jawt_get_awt_fn>(dlsym(jawt_library, "JAWT_GetAWT"));
+    }
+    if (!get_awt) return JNI_FALSE;
+
+    JAWT awt{};
+    awt.version = JAWT_VERSION_1_4;
+    if (get_awt(env, &awt) == JNI_FALSE) return JNI_FALSE;
+    JAWT_DrawingSurface *surface = awt.GetDrawingSurface(env, component);
+    if (!surface) return JNI_FALSE;
+    const jint lock_result = surface->Lock(surface);
+    if ((lock_result & JAWT_LOCK_ERROR) != 0) {
+        awt.FreeDrawingSurface(surface);
+        return JNI_FALSE;
+    }
+    JAWT_DrawingSurfaceInfo *surface_info = surface->GetDrawingSurfaceInfo(surface);
+    auto *x11 = surface_info
+        ? static_cast<JAWT_X11DrawingSurfaceInfo *>(surface_info->platformInfo)
+        : nullptr;
+    const bool matches_live_layer = x11 && x11->display &&
+        static_cast<jlong>(x11->drawable) == drawable;
+    const int screen = matches_live_layer ? DefaultScreen(x11->display) : 0;
+    // Skiko 0.9.37.4 stores LinuxOpenGLRedrawer.context as a native GLXContext*
+    // allocation. Its own makeCurrent/destroyContext JNI entry points dereference that
+    // slot before calling GLX; mirror that ABI here instead of passing the slot address
+    // to the driver as though it were a GLXContext.
+    auto *share_context_slot = reinterpret_cast<GLXContext *>(
+        static_cast<uintptr_t>(share_context));
+    const GLXContext actual_share_context = share_context_slot ? *share_context_slot : nullptr;
+    const uint64_t identity =
+        static_cast<uint64_t>(share_context) ^
+        (static_cast<uint64_t>(drawable) << 17) ^
+        (static_cast<uint64_t>(window) << 33);
+    const bool attached = matches_live_layer && actual_share_context && identity != 0 &&
+        instance->attach_opengl_render_environment(
+            reinterpret_cast<int64_t>(x11->display),
+            reinterpret_cast<int64_t>(actual_share_context), screen, identity);
+    if (surface_info) surface->FreeDrawingSurfaceInfo(surface_info);
+    surface->Unlock(surface);
+    awt.FreeDrawingSurface(surface);
+    return attached ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nCreateRenderContextOpenGL)(JNIEnv *, jclass, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance && instance->create_render_context() ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nDestroyRenderContextOpenGL)(JNIEnv *, jclass, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance && instance->destroy_render_context() ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nSetSurfaceConfigOpenGL)(
+        JNIEnv *, jclass, jlong ptr, jint width, jint height, jlong) {
+    auto *instance = get_instance(ptr);
+    return instance && instance->set_surface_config(width, height) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jlong JNICALL FN_DESKTOP(nGetFrameStateOpenGL)(JNIEnv *, jclass, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance ? static_cast<jlong>(instance->get_frame_state())
+                    : static_cast<jlong>(0xFULL << 44);
+}
+
+JNIEXPORT jlong JNICALL FN_DESKTOP(nGetBufferTextureOpenGL)(JNIEnv *, jclass, jlong ptr, jint index) {
+    auto *instance = get_instance(ptr);
+    return instance ? static_cast<jlong>(instance->get_buffer_texture(index)) : 0;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nAckRetiredBuffersOpenGL)(JNIEnv *, jclass, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance && instance->ack_retired_buffers() ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasOpenGLSurface)(JNIEnv *, jclass, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance && instance->has_opengl_surface() ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngOpenGL)(JNIEnv *env, jclass, jlong ptr, jstring path) {
+    auto *instance = get_instance(ptr);
+    if (!instance) return JNI_FALSE;
+    scoped_utf_chars path_chars(env, path);
+    return path_chars.valid() && instance->save_surface_png(path_chars.get()) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jint JNICALL FN_DESKTOP(nCreateOpenGLConsumerFbo)(JNIEnv *, jclass, jlong texture_name) {
+    if (!texture_name || !glXGetCurrentContext()) return 0;
+    GLint previous_fbo = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previous_fbo);
+    GLuint fbo = 0;
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+        static_cast<GLuint>(texture_name), 0);
+    const bool complete = glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+    glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previous_fbo));
+    if (!complete || glGetError() != GL_NO_ERROR) {
+        if (fbo) glDeleteFramebuffers(1, &fbo);
+        return 0;
+    }
+    return static_cast<jint>(fbo);
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nDeleteOpenGLConsumerFbo)(JNIEnv *, jclass, jint fbo) {
+    if (fbo <= 0 || !glXGetCurrentContext()) return JNI_FALSE;
+    const GLuint name = static_cast<GLuint>(fbo);
+    glDeleteFramebuffers(1, &name);
+    return glGetError() == GL_NO_ERROR ? JNI_TRUE : JNI_FALSE;
 }
 
 #endif

--- a/mediamp-mpv/src/cpp/mpv_handle_t.cpp
+++ b/mediamp-mpv/src/cpp/mpv_handle_t.cpp
@@ -378,7 +378,7 @@ bool mpv_handle_t::initialize() {
 void mpv_handle_t::on_render_update(void *context) {
     auto *instance = static_cast<mpv_handle_t *>(context);
     if (!instance) return;
-#if defined(__APPLE__) || defined(_WIN32)
+#if defined(__APPLE__) || defined(_WIN32) || defined(__linux__)
     // The render thread consumes the update and calls notify_render_update() only
     // after the frame is actually in a shared buffer, so consumers never wake up to
     // a stale buffer.
@@ -725,7 +725,7 @@ bool mpv_handle_t::destroy(JNIEnv *env) {
 
     attached_jni_env attached_env(env ? nullptr : jvm_);
     JNIEnv *cleanup_env = env ? env : attached_env.env;
-#if defined(_WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__) || defined(__linux__)
     // Stop the render thread FIRST: it calls notify_render_update() (which touches
     // render_update_listener_) on every frame, so no callback may still be running
     // when we delete that global ref below.

--- a/mediamp-mpv/src/cpp/render_glx.cpp
+++ b/mediamp-mpv/src/cpp/render_glx.cpp
@@ -1,0 +1,534 @@
+/*
+ * Linux OpenGL producer path. Context B is a GLX context in Skiko context A's
+ * share group. B exclusively owns libmpv's OpenGL render context, the producer
+ * FBOs, and all texture allocation/deletion. Only the RGBA8 texture names cross
+ * the share-group boundary; consumer FBOs belong to Skiko's context and are not
+ * created here.
+ */
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#define GL_GLEXT_PROTOTYPES 1
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <GL/glx.h>
+
+#include <mpv/client.h>
+#include <mpv/render.h>
+#include <mpv/render_gl.h>
+#include <zlib.h>
+
+#include <array>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#include "glx_context_provider.h"
+#include "log.h"
+#include "mpv_handle_t.h"
+
+namespace {
+
+void *glx_get_proc_address(void *ctx, const char *name) {
+    auto *provider = static_cast<mediampv::glx_context_provider *>(ctx);
+    return provider ? provider->get_proc_address(name) : nullptr;
+}
+
+void append_u32_be(std::vector<uint8_t> &out, uint32_t value) {
+    out.push_back(static_cast<uint8_t>(value >> 24));
+    out.push_back(static_cast<uint8_t>(value >> 16));
+    out.push_back(static_cast<uint8_t>(value >> 8));
+    out.push_back(static_cast<uint8_t>(value));
+}
+
+void append_png_chunk(
+    std::vector<uint8_t> &out, const char type[4], const uint8_t *data, size_t size) {
+    append_u32_be(out, static_cast<uint32_t>(size));
+    const size_t type_offset = out.size();
+    out.insert(out.end(), type, type + 4);
+    if (size != 0) out.insert(out.end(), data, data + size);
+    const auto checksum = crc32(
+        0L, reinterpret_cast<const Bytef *>(out.data() + type_offset),
+        static_cast<uInt>(4 + size));
+    append_u32_be(out, static_cast<uint32_t>(checksum));
+}
+
+bool write_rgba_png(const char *path, int width, int height, const std::vector<uint8_t> &bottom_up) {
+    if (!path || width <= 0 || height <= 0) return false;
+    const size_t stride = static_cast<size_t>(width) * 4;
+    std::vector<uint8_t> scanlines(static_cast<size_t>(height) * (stride + 1));
+    // glReadPixels is bottom-up; PNG scanlines are top-down.
+    for (int y = 0; y < height; ++y) {
+        auto *dst = scanlines.data() + static_cast<size_t>(y) * (stride + 1);
+        dst[0] = 0; // PNG filter None
+        const auto *src = bottom_up.data() + static_cast<size_t>(height - 1 - y) * stride;
+        std::memcpy(dst + 1, src, stride);
+    }
+    uLongf compressed_size = compressBound(static_cast<uLong>(scanlines.size()));
+    std::vector<uint8_t> compressed(compressed_size);
+    if (compress2(compressed.data(), &compressed_size, scanlines.data(),
+                  static_cast<uLong>(scanlines.size()), Z_BEST_SPEED) != Z_OK) {
+        return false;
+    }
+    compressed.resize(compressed_size);
+
+    std::vector<uint8_t> png;
+    constexpr std::array<uint8_t, 8> signature = {137, 80, 78, 71, 13, 10, 26, 10};
+    png.insert(png.end(), signature.begin(), signature.end());
+    std::array<uint8_t, 13> ihdr{};
+    ihdr[0] = static_cast<uint8_t>(width >> 24);
+    ihdr[1] = static_cast<uint8_t>(width >> 16);
+    ihdr[2] = static_cast<uint8_t>(width >> 8);
+    ihdr[3] = static_cast<uint8_t>(width);
+    ihdr[4] = static_cast<uint8_t>(height >> 24);
+    ihdr[5] = static_cast<uint8_t>(height >> 16);
+    ihdr[6] = static_cast<uint8_t>(height >> 8);
+    ihdr[7] = static_cast<uint8_t>(height);
+    ihdr[8] = 8;  // bits/component
+    ihdr[9] = 6;  // RGBA
+    append_png_chunk(png, "IHDR", ihdr.data(), ihdr.size());
+    append_png_chunk(png, "IDAT", compressed.data(), compressed.size());
+    append_png_chunk(png, "IEND", nullptr, 0);
+
+    FILE *file = std::fopen(path, "wb");
+    if (!file) return false;
+    const bool ok = std::fwrite(png.data(), 1, png.size(), file) == png.size();
+    std::fclose(file);
+    return ok;
+}
+
+} // namespace
+
+namespace mediampv {
+
+bool mpv_handle_t::attach_opengl_render_environment(
+    int64_t display_ptr, int64_t share_context_ptr, int screen, uint64_t identity) {
+    if (!display_ptr || !share_context_ptr || identity == 0) {
+        LOGE("attach_opengl_render_environment requires non-zero display, GLX context, and identity");
+        return false;
+    }
+    bool same_environment = false;
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        same_environment = environment_attached_ &&
+            pending_display_ptr_ == display_ptr &&
+            pending_share_context_ptr_ == share_context_ptr &&
+            pending_screen_ == screen && pending_environment_identity_ == identity;
+        if (same_environment) return true;
+    }
+
+    // A texture name from an old share group is invalid in the new Skiko context.
+    // Stop B before replacing its borrowed A pointers; config dimensions are retained
+    // and replayed after the new mpv context exists.
+    cleanup_render_resources();
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        pending_display_ptr_ = display_ptr;
+        pending_share_context_ptr_ = share_context_ptr;
+        pending_screen_ = screen;
+        pending_environment_identity_ = identity;
+        environment_attached_ = true;
+    }
+    return create_render_context();
+}
+
+bool mpv_handle_t::create_render_context() {
+    if (!handle_) {
+        LOGE("create_render_context(OpenGL): mpv handle is null");
+        return false;
+    }
+    if (render_thread_) return true;
+
+    glx_render_environment environment;
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        if (!environment_attached_) {
+            LOGE("create_render_context(OpenGL) requires a live Skiko GLX environment attachment");
+            return false;
+        }
+        environment.display = reinterpret_cast<Display *>(static_cast<uintptr_t>(pending_display_ptr_));
+        environment.share_context = reinterpret_cast<GLXContext>(static_cast<uintptr_t>(pending_share_context_ptr_));
+        environment.screen = pending_screen_;
+        environment.identity = pending_environment_identity_;
+    }
+    std::string error;
+    glx_provider_ = glx_context_provider::create(environment, &error);
+    if (!glx_provider_) {
+        LOGE("cannot create shared GLX producer context: %s", error.c_str());
+        return false;
+    }
+    start_render_thread();
+    std::unique_lock<std::mutex> lock(render_mutex_);
+    render_cv_.wait(lock, [this] { return render_initialized_; });
+    const bool initialized = render_initialize_ok_;
+    lock.unlock();
+    if (!initialized) cleanup_render_resources();
+    return initialized;
+}
+
+bool mpv_handle_t::destroy_render_context() {
+    cleanup_render_resources();
+    return true;
+}
+
+bool mpv_handle_t::set_surface_config(int width, int height, int64_t) {
+    if (!render_thread_) return false;
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        pending_width_ = width;
+        pending_height_ = height;
+        config_pending_ = true; // newest request replaces an unprocessed resize
+    }
+    render_cv_.notify_all();
+    return true;
+}
+
+uint64_t mpv_handle_t::get_frame_state() {
+    return frame_state_.load(std::memory_order_acquire);
+}
+
+int64_t mpv_handle_t::get_buffer_texture(int index) {
+    std::lock_guard<std::mutex> lock(render_mutex_);
+    if (!buffers_allocated_ || index < 0 || index >= kOpenGLBufferCount) return 0;
+    return static_cast<int64_t>(buffers_[index].texture);
+}
+
+bool mpv_handle_t::ack_retired_buffers() {
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        retire_ack_pending_ = true;
+    }
+    render_cv_.notify_all();
+    return true;
+}
+
+bool mpv_handle_t::has_opengl_surface() {
+    std::lock_guard<std::mutex> lock(render_mutex_);
+    return buffers_allocated_;
+}
+
+void mpv_handle_t::signal_render_update() {
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        render_pending_ = true;
+    }
+    render_cv_.notify_all();
+}
+
+void mpv_handle_t::start_render_thread() {
+    if (render_thread_) return;
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        render_quit_ = false;
+        render_initialized_ = false;
+        render_initialize_ok_ = false;
+    }
+    render_thread_ = new std::thread([this] { render_thread_loop(); });
+}
+
+void mpv_handle_t::stop_render_thread() {
+    if (!render_thread_) return;
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        render_quit_ = true;
+    }
+    render_cv_.notify_all();
+    auto *thread = static_cast<std::thread *>(render_thread_);
+    if (thread->joinable()) thread->join();
+    delete thread;
+    render_thread_ = nullptr;
+}
+
+bool mpv_handle_t::create_mpv_render_context_on_render_thread() {
+    mpv_opengl_init_params gl_init_params{
+        .get_proc_address = glx_get_proc_address,
+        .get_proc_address_ctx = glx_provider_,
+    };
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_API_TYPE, const_cast<char *>(MPV_RENDER_API_TYPE_OPENGL)},
+        {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
+        {MPV_RENDER_PARAM_INVALID, nullptr},
+    };
+    const int result = mpv_render_context_create(&render_context_, handle_, params);
+    if (result < 0) {
+        render_context_ = nullptr;
+        LOGE("mpv_render_context_create(OpenGL) failed: %s", mpv_error_string(result));
+        return false;
+    }
+    LOGI("mpv GL producer: %s / %s", glGetString(GL_VERSION), glGetString(GL_RENDERER));
+    mpv_render_context_set_update_callback(render_context_, &mpv_handle_t::on_render_update, this);
+    return true;
+}
+
+void mpv_handle_t::destroy_mpv_render_context_on_render_thread() {
+    if (!render_context_) return;
+    mpv_render_context_set_update_callback(render_context_, nullptr, nullptr);
+    mpv_render_context_free(render_context_);
+    render_context_ = nullptr;
+}
+
+void mpv_handle_t::render_thread_loop() {
+    JNIEnv *thread_env = nullptr;
+    const bool attached = jvm_ &&
+        jvm_->AttachCurrentThread(reinterpret_cast<void **>(&thread_env), nullptr) == JNI_OK;
+    const bool context_current = glx_provider_ && glx_provider_->make_current();
+    const bool initialized = context_current && create_mpv_render_context_on_render_thread();
+    {
+        std::lock_guard<std::mutex> lock(render_mutex_);
+        render_initialize_ok_ = initialized;
+        render_initialized_ = true;
+    }
+    render_cv_.notify_all();
+    if (!initialized) {
+        if (context_current) glx_provider_->clear_current();
+        if (attached) jvm_->DetachCurrentThread();
+        return;
+    }
+
+    std::unique_lock<std::mutex> lock(render_mutex_);
+    while (!render_quit_) {
+        render_cv_.wait(lock, [this] {
+            return render_quit_ || render_pending_ || config_pending_ || retire_ack_pending_ ||
+                screenshot_pending_;
+        });
+        if (render_quit_) break;
+
+        if (retire_ack_pending_) {
+            retire_ack_pending_ = false;
+            if (has_retired_buffers_) {
+                destroy_buffer_ring(retired_buffers_);
+                has_retired_buffers_ = false;
+            }
+        }
+        bool configured = false;
+        // Exactly one retired generation is retained. Keep coalescing rapid resize
+        // requests until the consumer releases it; never overwrite live GL textures.
+        if (config_pending_ && !has_retired_buffers_) {
+            config_pending_ = false;
+            configured = apply_config_locked();
+        }
+        if (screenshot_pending_) {
+            const std::string path = screenshot_path_;
+            screenshot_pending_ = false;
+            lock.unlock();
+            const bool saved = write_surface_png_on_render_thread(path.c_str());
+            lock.lock();
+            screenshot_ok_ = saved;
+            screenshot_finished_ = true;
+            render_cv_.notify_all();
+            continue;
+        }
+        const bool want_render = render_pending_;
+        render_pending_ = false;
+        if (!buffers_allocated_) {
+            if (want_render) {
+                lock.unlock();
+                drain_one_frame();
+                lock.lock();
+            }
+            continue;
+        }
+        bool has_new_frame = false;
+        if (want_render) {
+            has_new_frame = (mpv_render_context_update(render_context_) & MPV_RENDER_UPDATE_FRAME) != 0;
+        }
+        if (!has_new_frame && !configured) continue;
+        const int next = (latest_index_ + 1) % kOpenGLBufferCount;
+        const opengl_buffer target = buffers_[next];
+        lock.unlock();
+        const bool rendered = render_into(target);
+        lock.lock();
+        if (rendered) {
+            latest_index_ = next;
+            ++frame_serial_;
+            publish_state_locked();
+            lock.unlock();
+            notify_render_update(); // release-store has completed before this JNI callback
+            lock.lock();
+        }
+    }
+    // Teardown must run in B's owner thread while B is current.
+    if (has_retired_buffers_) destroy_buffer_ring(retired_buffers_);
+    if (buffers_allocated_) destroy_buffer_ring(buffers_);
+    has_retired_buffers_ = false;
+    buffers_allocated_ = false;
+    latest_index_ = -1;
+    buffer_width_ = buffer_height_ = 0;
+    ++buffer_generation_;
+    publish_state_locked();
+    destroy_mpv_render_context_on_render_thread();
+    lock.unlock();
+    glx_provider_->clear_current();
+    if (attached) jvm_->DetachCurrentThread();
+}
+
+bool mpv_handle_t::apply_config_locked() {
+    const int width = pending_width_, height = pending_height_;
+    if (width <= 0 || height <= 0) {
+        // releaseSurface() first drops consumer FBO/surface references. This explicit
+        // deactivation is therefore allowed to discard both generations immediately.
+        if (has_retired_buffers_) destroy_buffer_ring(retired_buffers_);
+        if (buffers_allocated_) destroy_buffer_ring(buffers_);
+        has_retired_buffers_ = buffers_allocated_ = false;
+        latest_index_ = -1;
+        buffer_width_ = buffer_height_ = 0;
+        ++buffer_generation_;
+        publish_state_locked();
+        return false;
+    }
+    if (buffers_allocated_ && width == buffer_width_ && height == buffer_height_) return false;
+    if (buffers_allocated_) {
+        for (int i = 0; i < kOpenGLBufferCount; ++i) {
+            retired_buffers_[i] = buffers_[i];
+            buffers_[i] = opengl_buffer{};
+        }
+        has_retired_buffers_ = true;
+        buffers_allocated_ = false;
+    }
+    bool ok = true;
+    for (auto &buffer : buffers_) ok = ok && allocate_buffer(buffer, width, height);
+    if (!ok) {
+        LOGE("OpenGL producer ring allocation failed (%dx%d)", width, height);
+        destroy_buffer_ring(buffers_);
+        latest_index_ = -1;
+        buffer_width_ = buffer_height_ = 0;
+        ++buffer_generation_;
+        publish_state_locked();
+        return false;
+    }
+    buffers_allocated_ = true;
+    buffer_width_ = width;
+    buffer_height_ = height;
+    latest_index_ = -1;
+    ++buffer_generation_;
+    publish_state_locked();
+    LOGI("OpenGL producer ring allocated %dx%d generation=%u", width, height, buffer_generation_);
+    return true;
+}
+
+bool mpv_handle_t::allocate_buffer(opengl_buffer &buffer, int width, int height) {
+    glGenTextures(1, &buffer.texture);
+    glBindTexture(GL_TEXTURE_2D, buffer.texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glGenFramebuffers(1, &buffer.fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, buffer.fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, buffer.texture, 0);
+    const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        LOGE("OpenGL producer FBO incomplete: 0x%x", status);
+        if (buffer.fbo) glDeleteFramebuffers(1, &buffer.fbo);
+        if (buffer.texture) glDeleteTextures(1, &buffer.texture);
+        buffer = opengl_buffer{};
+        return false;
+    }
+    return glGetError() == GL_NO_ERROR;
+}
+
+void mpv_handle_t::destroy_buffer_ring(opengl_buffer *ring) {
+    for (int i = 0; i < kOpenGLBufferCount; ++i) {
+        if (ring[i].fbo) glDeleteFramebuffers(1, &ring[i].fbo);
+        if (ring[i].texture) glDeleteTextures(1, &ring[i].texture);
+        ring[i] = opengl_buffer{};
+    }
+}
+
+void mpv_handle_t::publish_state_locked() {
+    const uint64_t index = latest_index_ < 0 ? 0xFULL : static_cast<uint64_t>(latest_index_);
+    frame_state_.store(
+        (static_cast<uint64_t>(buffer_generation_ & 0xFFFFu) << 48) |
+        (index << 44) |
+        (static_cast<uint64_t>(buffer_width_ & 0x3FFF) << 30) |
+        (static_cast<uint64_t>(buffer_height_ & 0x3FFF) << 16) |
+        (frame_serial_ & 0xFFFFu), std::memory_order_release);
+}
+
+bool mpv_handle_t::render_into(const opengl_buffer &buffer) {
+    if (!render_context_ || !buffer.fbo) return false;
+    mpv_opengl_fbo fbo{static_cast<int>(buffer.fbo), buffer_width_, buffer_height_, 0};
+    int flip_y = 1;
+    // Keep the published texture and debug PNG top-down. The OpenGL consumer describes
+    // the FBO to Skia with a bottom-left origin; changing both ends would double-flip it.
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
+        {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+        {MPV_RENDER_PARAM_INVALID, nullptr},
+    };
+    const int result = mpv_render_context_render(render_context_, params);
+    // mpv does not promise useful alpha for opaque video. RGBA_8888 Skia sampling is
+    // premultiplied, so normalize alpha before this texture is made visible to A.
+    glBindFramebuffer(GL_FRAMEBUFFER, buffer.fbo);
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    // glFlush merely submits work. Publication after glFinish is the first-version
+    // producer completion protocol and prevents Skia from sampling partial writes.
+    glFinish();
+    return result >= 0 && glGetError() == GL_NO_ERROR;
+}
+
+void mpv_handle_t::drain_one_frame() {
+    if (!render_context_) return;
+    mpv_render_context_update(render_context_);
+    int skip = 1;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_SKIP_RENDERING, &skip},
+        {MPV_RENDER_PARAM_INVALID, nullptr},
+    };
+    mpv_render_context_render(render_context_, params);
+}
+
+bool mpv_handle_t::write_surface_png_on_render_thread(const char *path) {
+    if (!buffers_allocated_ || latest_index_ < 0 || !path) return false;
+    const opengl_buffer &buffer = buffers_[latest_index_];
+    std::vector<uint8_t> pixels(static_cast<size_t>(buffer_width_) * buffer_height_ * 4);
+    glBindFramebuffer(GL_FRAMEBUFFER, buffer.fbo);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(0, 0, buffer_width_, buffer_height_, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (glGetError() != GL_NO_ERROR) return false;
+    const bool ok = write_rgba_png(path, buffer_width_, buffer_height_, pixels);
+    if (!ok) LOGE("save_surface_png failed for %s", path);
+    return ok;
+}
+
+bool mpv_handle_t::save_surface_png(const char *path) {
+    if (!path || !render_thread_) return false;
+    std::unique_lock<std::mutex> lock(render_mutex_);
+    if (!buffers_allocated_ || latest_index_ < 0 || screenshot_pending_) return false;
+    screenshot_path_ = path;
+    screenshot_pending_ = true;
+    screenshot_finished_ = false;
+    render_cv_.notify_all();
+    render_cv_.wait(lock, [this] { return screenshot_finished_ || render_quit_; });
+    return screenshot_finished_ && screenshot_ok_;
+}
+
+void mpv_handle_t::cleanup_render_resources() {
+    stop_render_thread();
+    if (glx_provider_) {
+        if (!glx_provider_->destroy()) LOGE("GLX producer teardown failed: %s", glx_provider_->last_error().c_str());
+        delete glx_provider_;
+        glx_provider_ = nullptr;
+    }
+    std::lock_guard<std::mutex> lock(render_mutex_);
+    render_context_ = nullptr;
+    has_retired_buffers_ = buffers_allocated_ = false;
+    latest_index_ = -1;
+    buffer_width_ = buffer_height_ = 0;
+    ++buffer_generation_;
+    publish_state_locked();
+}
+
+} // namespace mediampv
+
+#endif // defined(__linux__) && !defined(__ANDROID__)

--- a/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
@@ -9,10 +9,13 @@
 
 package org.openani.mediamp.mpv
 
+import java.awt.Component
 import org.openani.mediamp.InternalMediampApi
 
-// macOS render path (render_macos.mm): a native render thread drives mpv into a ring
-// of IOSurface-backed FBOs, each also wrapped as an MTLTexture for Skia.
+// Desktop surface-ring render paths. Each native render thread drives mpv into a ring
+// of GPU textures that the platform-specific Kotlin backend wraps for Skia. The native
+// implementation owns the producer context and textures; Skia only borrows consumer
+// views of them.
 
 @InternalMediampApi
 external fun nCreateRenderContextMacos(ptr: Long): Boolean
@@ -92,6 +95,74 @@ external fun nHasD3D11Surface(ptr: Long): Boolean
 @InternalMediampApi
 external fun nSaveSurfacePngD3D11(ptr: Long, path: String): Boolean
 
+// OpenGL render path (Linux/GLX): a native render thread
+// render into shared GL_TEXTURE_2D objects. The `consumerEnvironmentPtr` is an opaque
+// native description of Skiko's live GLX environment, not a producer FBO or a texture
+// ID. It is supplied only after the Compose consumer has attached a live OpenGL context.
+//
+// These declarations are the Kotlin/native contract for the later native renderer. The
+// native code resolves the matching Display through JAWT without retaining the component.
+
+/**
+ * Attaches the live Skiko GLX share context before creating libmpv's OpenGL render
+ * context. [component] is Skiko's AWT HardwareLayer; native code uses JAWT only while
+ * this call is active to obtain the matching X11 Display. It must not retain the Java
+ * object. [shareContext], [drawable], and [window] are GLX/X11 identities observed from
+ * the same live LinuxOpenGLRedrawer. A changed identity requires a fresh attachment.
+ */
+@InternalMediampApi
+external fun nAttachRenderEnvironmentOpenGL(
+    ptr: Long,
+    component: Component,
+    shareContext: Long,
+    drawable: Long,
+    window: Long,
+): Boolean
+
+@InternalMediampApi
+external fun nCreateRenderContextOpenGL(ptr: Long): Boolean
+
+@InternalMediampApi
+external fun nDestroyRenderContextOpenGL(ptr: Long): Boolean
+
+@InternalMediampApi
+external fun nSetSurfaceConfigOpenGL(
+    ptr: Long,
+    width: Int,
+    height: Int,
+    consumerEnvironmentPtr: Long,
+): Boolean
+
+/** Packed frame state: generation(16) | latestIndex(4, 0xF = none) | width(14) | height(14) | serial(16). */
+@InternalMediampApi
+external fun nGetFrameStateOpenGL(ptr: Long): Long
+
+/** Shared GL_TEXTURE_2D name of ring buffer [index], or 0 when no active ring exists. */
+@InternalMediampApi
+external fun nGetBufferTextureOpenGL(ptr: Long, index: Int): Long
+
+/** Signals that Skia no longer references the retired shared-texture generation. */
+@InternalMediampApi
+external fun nAckRetiredBuffersOpenGL(ptr: Long): Boolean
+
+@InternalMediampApi
+external fun nHasOpenGLSurface(ptr: Long): Boolean
+
+/** Saves the latest producer texture through native debug readback. */
+@InternalMediampApi
+external fun nSaveSurfacePngOpenGL(ptr: Long, path: String): Boolean
+
+/**
+ * Creates a consumer-context FBO and attaches [textureName]. This must be called only
+ * while Skiko's GLX context is current. The producer owns the texture; Kotlin owns and
+ * later deletes the returned FBO in the same consumer context.
+ */
+@InternalMediampApi
+external fun nCreateOpenGLConsumerFbo(textureName: Long): Int
+
+/** Deletes a consumer FBO previously returned by [nCreateOpenGLConsumerFbo]. */
+@InternalMediampApi
+external fun nDeleteOpenGLConsumerFbo(fbo: Int): Boolean
 @OptIn(InternalMediampApi::class)
 internal actual fun attachSurface(ptr: Long, surface: Any): Boolean {
     error("only implemented on Android")

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.PreviewFrame
@@ -31,6 +33,7 @@ import org.openani.mediamp.source.MediaData
 import org.openani.mediamp.source.MediaExtraFiles
 import org.openani.mediamp.source.SeekableInputMediaData
 import org.openani.mediamp.source.UriMediaData
+import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.imageio.ImageIO
@@ -117,11 +120,14 @@ internal class MpvFramePreview(
             if (existing.originalData === data) return existing
             discardSessionLocked()
         }
+        // A new Linux preview player needs a GLX environment before vo=libmpv can load.
+        val renderEnvironment = (mainPlayer as? MpvMediampPlayer)?.currentOpenGLRenderEnvironment()
+        if (hostOs == OS.Linux && renderEnvironment == null) return null
         return try {
             // NonCancellable: session creation is expensive shared state; a cancelled first
             // request must not abort it half-way (the next request reuses the session).
             withContext(NonCancellable) {
-                PreviewSession.create(context, parentCoroutineContext, data, maxWidth, maxHeight)
+                PreviewSession.create(context, parentCoroutineContext, data, maxWidth, maxHeight, renderEnvironment)
             }.also { session = it }
         } catch (e: Exception) {
             null
@@ -259,6 +265,7 @@ internal class MpvFramePreview(
                 data: MediaData,
                 maxWidth: Int,
                 maxHeight: Int,
+                renderEnvironment: OpenGLRenderEnvironment?,
             ): PreviewSession {
                 val previewData: MediaData = when (data) {
                     is SeekableInputMediaData -> NonClosingSeekableInputMediaData(data)
@@ -268,6 +275,12 @@ internal class MpvFramePreview(
                 val renderCounter = MutableStateFlow(0L)
                 val player = MpvMediampPlayer(MpvFramePreviewContextMarker(context), parentCoroutineContext)
                 try {
+                    if (hostOs == OS.Linux) {
+                        checkNotNull(renderEnvironment) { "Linux frame preview requires the main player's GLX environment" }
+                        check(player.attachOpenGLRenderEnvironment(renderEnvironment)) {
+                            "Could not attach the main player's GLX environment to the preview decoder"
+                        }
+                    }
                     val handle = player.handle
                     // Keep the preview decoder lightweight: no audio, no subtitles.
                     handle.setPropertyString("aid", "no")

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
@@ -19,6 +19,8 @@ import org.openani.mediamp.mpv.internal.D3D11SurfaceRingBackend
 import org.openani.mediamp.mpv.internal.MacosSurfaceRingBackend
 import org.openani.mediamp.mpv.internal.MpvSurfaceRing
 import org.openani.mediamp.mpv.internal.MpvSurfaceRingBackend
+import org.openani.mediamp.mpv.internal.OpenGLSurfaceRingBackend
+import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
 import kotlin.coroutines.CoroutineContext
 
 @OptIn(InternalMediampApi::class)
@@ -27,24 +29,29 @@ actual class MpvMediampPlayer(
     parentCoroutineContext: CoroutineContext,
 ) : JvmMpvMediampPlayer(context, parentCoroutineContext) {
 
-    // Native surface-ring render path: macOS renders through Metal/IOSurface
-    // (render_macos.mm), Windows through D3D11/D3D12 shared textures
-    // (render_d3d11.cpp). The consumer state machine is shared (MpvSurfaceRing).
+    // Native surface-ring render path: macOS renders through Metal/IOSurface,
+    // Windows through D3D11/D3D12 shared textures, and Linux through shared GL textures.
+    // The consumer state machine is shared by all three backends (MpvSurfaceRing).
     private val ringBackend: MpvSurfaceRingBackend? = when (hostOs) {
         OS.MacOS -> MacosSurfaceRingBackend
         OS.Windows -> D3D11SurfaceRingBackend
-        else -> null // TODO: Linux render path
+        OS.Linux -> OpenGLSurfaceRingBackend
+        else -> null
     }
     private val surfaceRing: MpvSurfaceRing? = ringBackend?.let { MpvSurfaceRing(handle.ptr, it) }
+    private var attachedOpenGLEnvironment: OpenGLRenderEnvironment? = null
 
     init {
-        // With vo=libmpv, mpv refuses to start the video track when no render context
-        // exists at loadfile time ("no audio or video data played"). Both desktop
-        // render contexts own their device (offscreen CGL context on macOS, our own
-        // ID3D11Device on Windows) and do not depend on any window, so create them
-        // eagerly to remove the ordering dependency on the Compose surface. This also
-        // starts the native render thread that drives all frame rendering.
-        createRenderContext()
+        if (hostOs == org.jetbrains.skiko.OS.Linux) {
+            // Prefer the two Linux paths mediamp validates: NVIDIA can keep decoded
+            // frames on-GPU through CUDA/OpenGL, while Intel/AMD use stable VAAPI
+            // decode with a system-memory copy. Only then try mpv's safe auto list.
+            check(handle.setPropertyString("hwdec", "nvdec,vaapi-copy,auto-safe"))
+        }
+        // macOS and Windows own their producer device. Linux must first attach the live
+        // Skiko GLX environment, otherwise `vo=libmpv` would be asked to load before its
+        // required render context can exist.
+        if (hostOs != org.jetbrains.skiko.OS.Linux) createRenderContext()
     }
 
     /** Creates the native render context and starts the render thread. Idempotent. */
@@ -53,6 +60,51 @@ actual class MpvMediampPlayer(
 
     internal fun releaseRenderContext(): Boolean =
         ringBackend?.destroyRenderContext(handle.ptr) ?: false
+
+    /**
+     * Attaches Skiko's current GLX share environment. A new identity is a device
+     * recreation: native code must discard its old producer context/share group before
+     * the next `createRenderContext`, and the ring recreates its consumer wrappers on
+     * the next published generation.
+     */
+    internal fun attachOpenGLRenderEnvironment(environment: OpenGLRenderEnvironment): Boolean {
+        if (hostOs != org.jetbrains.skiko.OS.Linux) return false
+        if (attachedOpenGLEnvironment?.identity == environment.identity) {
+            return createRenderContext().also { if (it) renderContextBecameReady() }
+        }
+        if (attachedOpenGLEnvironment != null) {
+            // mpv's render.h states that freeing mpv_render_context while video is active
+            // forcibly disables video. Replacing Skiko's GLX share group therefore cannot
+            // be handled by merely destroying and recreating context B: recovery would
+            // require a separately verified video-output reload that preserves position,
+            // pause state, selected track, and hwdec state.
+            check(!hasActivePlaybackSession()) {
+                "Skiko replaced its GLX share context during active playback. " +
+                    "Transparent mpv video-output recovery is not supported."
+            }
+            // The native OpenGL renderer owns its GLX context and must release it before
+            // accepting a new Skiko share context. The old GLX context owns its stale
+            // FBOs; closing Skia wrappers below makes their texture references disappear.
+            surfaceRing?.invalidateForRenderEnvironmentChange()
+            releaseRenderContext()
+        }
+        val attached = (ringBackend as OpenGLSurfaceRingBackend)
+            .attachRenderEnvironment(handle.ptr, environment)
+        if (attached) {
+            attachedOpenGLEnvironment = environment
+            if (createRenderContext()) renderContextBecameReady()
+        }
+        return attached
+    }
+
+    override fun ensureRenderContextForLoad(): Boolean = when (hostOs) {
+        org.jetbrains.skiko.OS.Linux -> attachedOpenGLEnvironment != null && createRenderContext()
+        // Eager platforms keep the established load behavior even when a headless CI
+        // environment cannot create an accelerated producer context.
+        else -> true
+    }
+
+    internal fun currentOpenGLRenderEnvironment(): OpenGLRenderEnvironment? = attachedOpenGLEnvironment
 
     /** See [MpvSurfaceRing.requestSurface]. */
     internal fun requestSurface(width: Int, height: Int, devicePtr: Long): Boolean =

--- a/mediamp-mpv/src/desktopMain/kotlin/compose/MpvMediampPlayerSurface.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/compose/MpvMediampPlayerSurface.desktop.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.window.LocalWindow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.SamplingMode
 import org.jetbrains.skiko.OS
@@ -36,8 +37,11 @@ import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.MPVLog
 import org.openani.mediamp.mpv.MpvMediampPlayer
+import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
+import org.openani.mediamp.mpv.utils.OpenGLRenderSnapshot
 import org.openani.mediamp.mpv.utils.SkiaDirectXInterop
 import org.openani.mediamp.mpv.utils.SkiaMetalInterop
+import org.openani.mediamp.mpv.utils.SkiaOpenGLInterop
 import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
 import org.openani.mediamp.mpv.utils.findSkiaLayer
 import kotlin.time.Duration.Companion.milliseconds
@@ -48,13 +52,13 @@ actual fun MpvMediampPlayerSurface(
     modifier: Modifier,
 ) {
     when (hostOs) {
-        OS.MacOS, OS.Windows -> MpvMediampPlayerSurfaceRing(player, modifier)
-        else -> Box(modifier) // TODO: Linux render path
+        OS.MacOS, OS.Windows, OS.Linux -> MpvMediampPlayerSurfaceRing(player, modifier)
+        else -> Box(modifier)
     }
 }
 
 /**
- * Shared surface-ring render path (macOS Metal + Windows D3D11):
+ * Shared surface-ring render path (macOS Metal, Windows D3D11, Linux OpenGL/GLX):
  *
  * A native render thread drives mpv into a triple-buffered ring of GPU textures that
  * are simultaneously visible to Skia's own render device — IOSurfaces wrapped as
@@ -84,6 +88,7 @@ private fun MpvMediampPlayerSurfaceRing(
             when (hostOs) {
                 OS.MacOS -> SkiaMetalInterop(layer)
                 OS.Windows -> SkiaDirectXInterop(layer)
+                OS.Linux -> SkiaOpenGLInterop(layer)
                 else -> null
             }
         }
@@ -92,16 +97,47 @@ private fun MpvMediampPlayerSurfaceRing(
     }
     val frameTick = remember { mutableLongStateOf(0L) }
     val canvasSize = remember { mutableStateOf(IntSize.Zero) }
-    // The render context itself is created eagerly by the player (it must exist before
-    // loadfile); this composable only owns the surface config and the frame listener.
+    // macOS/Windows create their producer context eagerly. Linux intentionally waits for
+    // the live LinuxOpenGLRedrawer so `vo=libmpv` never sees loadfile before GLX sharing
+    // has been attached.
     var renderContextReady by remember(player) { mutableStateOf(false) }
     val loggedStates = remember(player) { mutableSetOf<String>() }
     fun logOnce(state: String, level: Int = MPVLog.DEBUG) {
         if (loggedStates.add(state)) MPVLog.log(level, state)
     }
+    // Linux re-checks the live GLX identity because Skiko may replace its redrawer.
+    fun ensureRenderContext(environment: OpenGLRenderEnvironment? = null): Boolean {
+        if (hostOs != OS.Linux) return renderContextReady
+        environment ?: return false
+        if (renderContextReady &&
+            player.currentOpenGLRenderEnvironment()?.identity == environment.identity
+        ) {
+            return true
+        }
+        val ready = runCatching {
+            player.attachOpenGLRenderEnvironment(environment)
+        }.onFailure {
+            MPVLog.error("Linux GLX render context unavailable; video stays black", it)
+        }.getOrDefault(false)
+        if (ready && !renderContextReady) {
+            player.setRenderUpdateListener { frameTick.longValue++ }
+            renderContextReady = true
+        }
+        return ready
+    }
+
+    fun currentOpenGLSnapshot(): OpenGLRenderSnapshot? {
+        if (hostOs != OS.Linux) return null
+        val glInterop = interop as? SkiaOpenGLInterop ?: return null
+        val snapshot = runCatching { glInterop.renderSnapshot() }
+            .onFailure { MPVLog.error("Linux GLX render context unavailable; video stays black", it) }
+            .getOrNull() ?: return null
+        return snapshot.takeIf { ensureRenderContext(it.environment) }
+    }
 
     DisposableEffect(player) {
-        renderContextReady = player.createRenderContext() // no-op if already created
+        // Linux creates its shared context later, from the live redrawer in Canvas.
+        renderContextReady = hostOs != OS.Linux && player.createRenderContext()
         if (renderContextReady) {
             player.setRenderUpdateListener { frameTick.longValue++ }
         }
@@ -112,7 +148,8 @@ private fun MpvMediampPlayerSurfaceRing(
         }
     }
 
-    // Buffer-ring sizing: the first layout configures immediately; later size changes
+    // Linux waits for GLX attachment; Metal/D3D keep their existing readiness retry.
+    // The first ready layout configures immediately; later size changes
     // (window resize, overlay-driven relayout) settle for 150ms first. The reallocation
     // itself happens between frames on the native render thread, and the draw pass
     // letterboxes whatever the ring currently contains, so resizes cost no visible
@@ -123,6 +160,9 @@ private fun MpvMediampPlayerSurfaceRing(
         snapshotFlow { canvasSize.value }
             .filter { it.width > 0 && it.height > 0 }
             .collectLatest { size ->
+                if (hostOs == OS.Linux) {
+                    snapshotFlow { renderContextReady }.first { it }
+                }
                 if (configured) delay(150.milliseconds)
                 while (true) {
                     val devicePtr = runCatching { deviceInterop.renderDevicePtr }.getOrNull()
@@ -132,7 +172,8 @@ private fun MpvMediampPlayerSurfaceRing(
                         configured = true
                         break
                     }
-                    delay(50.milliseconds) // Skiko redrawer not up yet; retry shortly
+                    if (hostOs == OS.Linux) break
+                    delay(50.milliseconds)
                 }
             }
     }
@@ -140,15 +181,25 @@ private fun MpvMediampPlayerSurfaceRing(
     Canvas(modifier.onSizeChanged { canvasSize.value = it }) {
         frameTick.longValue // subscribe: redraw whenever mpv publishes a new frame
 
-        if (!renderContextReady) {
-            logOnce("render context not ready")
-            return@Canvas
-        }
         if (interop == null) {
             logOnce("skia interop unavailable; video stays black (frames are drained)", MPVLog.ERROR)
             return@Canvas
         }
-        val directContext = interop.directContext
+        val openGLSnapshot = currentOpenGLSnapshot()
+        val renderReady = if (hostOs == OS.Linux) {
+            openGLSnapshot != null
+        } else {
+            renderContextReady
+        }
+        if (!renderReady) {
+            logOnce("render context not ready")
+            return@Canvas
+        }
+        val directContext = if (hostOs == OS.Linux) {
+            openGLSnapshot?.directContext
+        } else {
+            interop.directContext
+        }
         if (directContext == null) {
             logOnce("DirectContext not initialized yet")
             return@Canvas
@@ -158,11 +209,19 @@ private fun MpvMediampPlayerSurfaceRing(
         if (width <= 0 || height <= 0) return@Canvas
         // Skiko can recreate its redrawer (and render device) at runtime; the ring's
         // textures must live on Skia's current device.
-        runCatching { interop.renderDevicePtr }.getOrNull()?.let {
+        val renderDevicePtr = openGLSnapshot?.environment?.shareContext
+            ?: runCatching { interop.renderDevicePtr }.getOrNull()
+        renderDevicePtr?.let {
             player.refreshDeviceIfChanged(it)
         }
 
-        logOnce("rendering ${width}x${height} via ${if (hostOs == OS.MacOS) "Metal" else "D3D12"} surface", MPVLog.INFO)
+        val renderer = when (hostOs) {
+            OS.MacOS -> "Metal"
+            OS.Windows -> "D3D12"
+            OS.Linux -> "OpenGL/GLX"
+            else -> "unknown"
+        }
+        logOnce("rendering ${width}x${height} via $renderer surface", MPVLog.INFO)
         // Draw through Compose so the op survives RenderNode display-list recording
         // (raw nativeCanvas draws are dropped there). The image is a Skia-owned texture:
         // snapshots of the BRT-wrapped surface itself do not render. The frame normally

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
@@ -12,6 +12,7 @@ import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.ColorSpace
 import org.jetbrains.skia.ContentChangeMode
 import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.Surface
@@ -21,37 +22,69 @@ import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.MPVLog
 import org.openani.mediamp.mpv.nAckRetiredBuffersD3D11
 import org.openani.mediamp.mpv.nAckRetiredBuffersMacos
+import org.openani.mediamp.mpv.nAckRetiredBuffersOpenGL
 import org.openani.mediamp.mpv.nCreateRenderContextD3D11
 import org.openani.mediamp.mpv.nCreateRenderContextMacos
+import org.openani.mediamp.mpv.nCreateRenderContextOpenGL
+import org.openani.mediamp.mpv.nCreateOpenGLConsumerFbo
+import org.openani.mediamp.mpv.nDeleteOpenGLConsumerFbo
 import org.openani.mediamp.mpv.nDestroyRenderContextD3D11
 import org.openani.mediamp.mpv.nDestroyRenderContextMacos
+import org.openani.mediamp.mpv.nDestroyRenderContextOpenGL
 import org.openani.mediamp.mpv.nGetBufferTextureD3D11
 import org.openani.mediamp.mpv.nGetBufferTextureMacos
+import org.openani.mediamp.mpv.nGetBufferTextureOpenGL
 import org.openani.mediamp.mpv.nGetFrameStateD3D11
 import org.openani.mediamp.mpv.nGetFrameStateMacos
+import org.openani.mediamp.mpv.nGetFrameStateOpenGL
 import org.openani.mediamp.mpv.nHasD3D11Surface
 import org.openani.mediamp.mpv.nHasMetalSurface
+import org.openani.mediamp.mpv.nHasOpenGLSurface
 import org.openani.mediamp.mpv.nSaveSurfacePng
 import org.openani.mediamp.mpv.nSaveSurfacePngD3D11
+import org.openani.mediamp.mpv.nSaveSurfacePngOpenGL
 import org.openani.mediamp.mpv.nSetSurfaceConfigD3D11
 import org.openani.mediamp.mpv.nSetSurfaceConfigMacos
+import org.openani.mediamp.mpv.nSetSurfaceConfigOpenGL
+import org.openani.mediamp.mpv.nAttachRenderEnvironmentOpenGL
+import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
 
 internal const val SURFACE_RING_BUFFER_COUNT = 3
+
+/** A Skia descriptor plus any GPU resource created in the consumer context. */
+internal class MpvConsumerRenderTarget(
+    val skiaRenderTarget: BackendRenderTarget,
+    private val releaseOwnedResource: () -> Unit = {},
+) {
+    fun close() {
+        try {
+            skiaRenderTarget.close()
+        } finally {
+            releaseOwnedResource()
+        }
+    }
+
+    /** Closes the Skia descriptor after its consumer context has already been lost. */
+    fun abandon() {
+        skiaRenderTarget.close()
+    }
+}
 
 /**
  * Platform half of the native surface-ring render path: the JNI entry points plus how
  * a ring buffer's native texture is wrapped for Skia. The consumer state machine on top
- * ([MpvSurfaceRing]) is identical on macOS (Metal/IOSurface, render_macos.mm) and
- * Windows (D3D11/D3D12 shared textures, render_d3d11.cpp).
+ * ([MpvSurfaceRing]) is capability-based: Metal/IOSurface on macOS, D3D11/D3D12 shared
+ * textures on Windows, and shared OpenGL textures on Linux/GLX.
  */
 internal interface MpvSurfaceRingBackend {
     fun createRenderContext(ptr: Long): Boolean
     fun destroyRenderContext(ptr: Long): Boolean
 
     /**
-     * [devicePtr] is the consumer-side render device: an MTLDevice pointer on macOS, a
-     * pointer to Skiko's native DirectXDevice struct on Windows; 0 requests a
-     * consumer-less (headless) ring.
+     * [devicePtr] is the consumer-side render device: an MTLDevice pointer on macOS or a
+     * pointer to Skiko's native DirectXDevice struct on Windows. OpenGL attaches its GLX
+     * environment separately and ignores this value. 0 requests a consumer-less ring
+     * where that platform supports one.
      */
     fun setSurfaceConfig(ptr: Long, width: Int, height: Int, devicePtr: Long): Boolean
     fun getFrameState(ptr: Long): Long
@@ -60,8 +93,9 @@ internal interface MpvSurfaceRingBackend {
     fun hasSurface(ptr: Long): Boolean
     fun saveSurfacePng(ptr: Long, path: String): Boolean
 
-    fun makeRenderTarget(width: Int, height: Int, texturePtr: Long): BackendRenderTarget
+    fun makeConsumerRenderTarget(width: Int, height: Int, texturePtr: Long): MpvConsumerRenderTarget
     val wrapColorFormat: SurfaceColorFormat
+    val skiaSurfaceOrigin: SurfaceOrigin get() = SurfaceOrigin.TOP_LEFT
 }
 
 @OptIn(InternalMediampApi::class)
@@ -77,8 +111,8 @@ internal object MacosSurfaceRingBackend : MpvSurfaceRingBackend {
     override fun hasSurface(ptr: Long) = nHasMetalSurface(ptr)
     override fun saveSurfacePng(ptr: Long, path: String) = nSaveSurfacePng(ptr, path)
 
-    override fun makeRenderTarget(width: Int, height: Int, texturePtr: Long): BackendRenderTarget =
-        BackendRenderTarget.makeMetal(width, height, texturePtr)
+    override fun makeConsumerRenderTarget(width: Int, height: Int, texturePtr: Long) =
+        MpvConsumerRenderTarget(BackendRenderTarget.makeMetal(width, height, texturePtr))
 
     override val wrapColorFormat: SurfaceColorFormat get() = SurfaceColorFormat.BGRA_8888
 }
@@ -98,7 +132,7 @@ internal object D3D11SurfaceRingBackend : MpvSurfaceRingBackend {
     override fun hasSurface(ptr: Long) = nHasD3D11Surface(ptr)
     override fun saveSurfacePng(ptr: Long, path: String) = nSaveSurfacePngD3D11(ptr, path)
 
-    override fun makeRenderTarget(width: Int, height: Int, texturePtr: Long): BackendRenderTarget =
+    override fun makeConsumerRenderTarget(width: Int, height: Int, texturePtr: Long) = MpvConsumerRenderTarget(
         BackendRenderTarget.makeDirect3D(
             width = width,
             height = height,
@@ -107,12 +141,74 @@ internal object D3D11SurfaceRingBackend : MpvSurfaceRingBackend {
             sampleCnt = 1,
             levelCnt = 1,
         )
+    )
 
     // RGB_888x would sidestep the alpha channel entirely, but Skia's D3D backend
     // refuses to wrap render targets with a non-renderable color type (returns null),
     // so wrap as RGBA_8888. mpv's d3d11 renderer writes alpha=1 for opaque video
     // (verified by the demo pixel readback), so premultiplied sampling is safe.
     override val wrapColorFormat: SurfaceColorFormat get() = SurfaceColorFormat.RGBA_8888
+}
+
+/**
+ * Contract half of the shared-texture OpenGL backend. The producer FBO is context-local
+ * to the native GLX context, so [nGetBufferTextureOpenGL] returns a shared texture name,
+ * not an FBO. Consumer FBOs are created while Skiko's context is current before calling
+ * `BackendRenderTarget.makeGL`. They are not share-group objects: they
+ * are created and deleted by JNI while Skiko context A is current, while the producer
+ * remains the sole owner of the shared texture names.
+ */
+@OptIn(InternalMediampApi::class)
+internal object OpenGLSurfaceRingBackend : MpvSurfaceRingBackend {
+    override fun createRenderContext(ptr: Long) = nCreateRenderContextOpenGL(ptr)
+    override fun destroyRenderContext(ptr: Long) = nDestroyRenderContextOpenGL(ptr)
+    override fun setSurfaceConfig(ptr: Long, width: Int, height: Int, devicePtr: Long) =
+        nSetSurfaceConfigOpenGL(ptr, width, height, devicePtr)
+
+    override fun getFrameState(ptr: Long) = nGetFrameStateOpenGL(ptr)
+    override fun getBufferTexture(ptr: Long, index: Int) = nGetBufferTextureOpenGL(ptr, index)
+    override fun ackRetiredBuffers(ptr: Long) = nAckRetiredBuffersOpenGL(ptr)
+    override fun hasSurface(ptr: Long) = nHasOpenGLSurface(ptr)
+    override fun saveSurfacePng(ptr: Long, path: String) = nSaveSurfacePngOpenGL(ptr, path)
+
+    fun attachRenderEnvironment(ptr: Long, environment: OpenGLRenderEnvironment): Boolean =
+        nAttachRenderEnvironmentOpenGL(
+            ptr,
+            environment.component,
+            environment.shareContext,
+            environment.drawable,
+            environment.window,
+        )
+
+    override fun makeConsumerRenderTarget(
+        width: Int,
+        height: Int,
+        texturePtr: Long,
+    ): MpvConsumerRenderTarget {
+        val fbo = nCreateOpenGLConsumerFbo(texturePtr)
+        check(fbo != 0) { "Could not create consumer FBO for shared OpenGL texture $texturePtr" }
+        return try {
+            // Unlike Metal/D3D, this wrapper also owns the consumer-context FBO.
+            MpvConsumerRenderTarget(
+                BackendRenderTarget.makeGL(
+                    width = width,
+                    height = height,
+                    sampleCnt = 1,
+                    stencilBits = 0,
+                    fbId = fbo,
+                    fbFormat = FramebufferFormat.GR_GL_RGBA8,
+                ),
+            ) {
+                check(nDeleteOpenGLConsumerFbo(fbo)) { "Could not delete OpenGL consumer FBO $fbo" }
+            }
+        } catch (failure: Throwable) {
+            nDeleteOpenGLConsumerFbo(fbo)
+            throw failure
+        }
+    }
+
+    override val wrapColorFormat: SurfaceColorFormat get() = SurfaceColorFormat.RGBA_8888
+    override val skiaSurfaceOrigin: SurfaceOrigin get() = SurfaceOrigin.BOTTOM_LEFT
 }
 
 /**
@@ -126,7 +222,7 @@ internal class MpvSurfaceRing(
     private val backend: MpvSurfaceRingBackend,
 ) {
     private val wrappedSurfaces = arrayOfNulls<Surface>(SURFACE_RING_BUFFER_COUNT)
-    private val wrappedTargets = arrayOfNulls<BackendRenderTarget>(SURFACE_RING_BUFFER_COUNT)
+    private val consumerTargets = arrayOfNulls<MpvConsumerRenderTarget>(SURFACE_RING_BUFFER_COUNT)
     private var blitSurface: Surface? = null
     private var wrappedGeneration = -1
     private var surfaceContext: DirectContext? = null
@@ -163,6 +259,24 @@ internal class MpvSurfaceRing(
         if (requestedWidth > 0 && devicePtr != requestedDevicePtr) {
             requestSurface(requestedWidth, requestedHeight, devicePtr)
         }
+    }
+
+    /**
+     * Drops consumer-side Skia objects before the producer replaces its GLX share group.
+     * A replaced GLX context destroys its context-local FBOs itself; their shared texture
+     * names must never be reused by the new context.
+     */
+    fun invalidateForRenderEnvironmentChange() {
+        cachedFrame?.close()
+        cachedFrame = null
+        cachedState = 0L
+        // The old context may already be gone. Its context-local FBOs are then reclaimed
+        // with it; never issue glDeleteFramebuffer through the new Skiko context because
+        // the same numeric name could belong to an unrelated new object.
+        abandonWraps()
+        surfaceContext = null
+        backend.ackRetiredBuffers(handlePtr)
+        requestedDevicePtr = 0L
     }
 
     /**
@@ -221,13 +335,14 @@ internal class MpvSurfaceRing(
         height: Int,
         directContext: DirectContext,
     ): Boolean {
-        if (surfaceContext !== directContext) {
+        val contextChanged = surfaceContext !== null && surfaceContext !== directContext
+        if (contextChanged) {
             // Images from a dead/replaced DirectContext must not be drawn again.
             cachedFrame?.close()
             cachedFrame = null
             cachedState = 0L
         }
-        closeWraps()
+        if (contextChanged) abandonWraps() else closeWraps()
         // Our references to the previous generation are gone; the render thread may
         // free those buffers now.
         backend.ackRetiredBuffers(handlePtr)
@@ -239,23 +354,23 @@ internal class MpvSurfaceRing(
                 closeWraps()
                 return false
             }
-            val target = backend.makeRenderTarget(width, height, texture)
+            val consumerTarget = backend.makeConsumerRenderTarget(width, height, texture)
             val surface = runCatching {
                 Surface.makeFromBackendRenderTarget(
                     context = directContext,
-                    rt = target,
-                    origin = SurfaceOrigin.TOP_LEFT,
+                    rt = consumerTarget.skiaRenderTarget,
+                    origin = backend.skiaSurfaceOrigin,
                     colorFormat = backend.wrapColorFormat,
                     colorSpace = ColorSpace.sRGB,
                 )
             }.onFailure { logOnce("wrapping buffer $i as Skia surface failed", MPVLog.ERROR, it) }.getOrNull()
             if (surface == null) {
                 logOnce("Surface.makeFromBackendRenderTarget returned null (format=${backend.wrapColorFormat})", MPVLog.ERROR)
-                target.close()
+                consumerTarget.close()
                 closeWraps()
                 return false
             }
-            wrappedTargets[i] = target
+            consumerTargets[i] = consumerTarget
             wrappedSurfaces[i] = surface
         }
         // A GPU (render-target) blit surface: the blit is GPU->GPU and its snapshot is
@@ -284,11 +399,25 @@ internal class MpvSurfaceRing(
     }
 
     private fun closeWraps() {
+        clearWraps(abandonOwnedResources = false)
+    }
+
+    // The old GL context reclaims its context-local FBOs; deleting their numeric names
+    // through the new context could delete unrelated objects.
+    private fun abandonWraps() {
+        clearWraps(abandonOwnedResources = true)
+    }
+
+    private fun clearWraps(abandonOwnedResources: Boolean) {
         for (i in 0 until SURFACE_RING_BUFFER_COUNT) {
             wrappedSurfaces[i]?.close()
             wrappedSurfaces[i] = null
-            wrappedTargets[i]?.close()
-            wrappedTargets[i] = null
+            if (abandonOwnedResources) {
+                consumerTargets[i]?.abandon()
+            } else {
+                consumerTargets[i]?.close()
+            }
+            consumerTargets[i] = null
         }
         blitSurface?.close()
         blitSurface = null

--- a/mediamp-mpv/src/desktopMain/kotlin/utils/SkiaOpenGLInterop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/utils/SkiaOpenGLInterop.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.utils
+
+import java.awt.Component
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skiko.SkiaLayer
+
+/**
+ * The GLX identities that must belong to one live Skiko redrawer. Native code obtains
+ * the corresponding `Display*` through JAWT from [component] during attachment; it must
+ * not retain the Java component. The values are deliberately not a raw native pointer:
+ * their lifetime is tied to [SkiaOpenGLInterop] and changes with redrawer recreation.
+ */
+internal data class OpenGLRenderEnvironment(
+    val component: Component,
+    val shareContext: Long,
+    val drawable: Long,
+    val window: Long,
+) {
+    init {
+        require(shareContext != 0L) { "Skiko LinuxOpenGLRedrawer has no GLX context yet" }
+        require(drawable != 0L) { "Skiko HardwareLayer has no X11 drawable yet" }
+    }
+
+    /** Stable only for the lifetime of this GLX share group. */
+    val identity: OpenGLRenderEnvironmentIdentity
+        get() = OpenGLRenderEnvironmentIdentity(shareContext)
+}
+
+internal data class OpenGLRenderEnvironmentIdentity(
+    val shareContext: Long,
+)
+
+/** Values read from one live redrawer for use during a single draw. */
+internal data class OpenGLRenderSnapshot(
+    val environment: OpenGLRenderEnvironment,
+    val directContext: DirectContext?,
+)
+
+/**
+ * Reflective access to Skiko 0.9.37.4's Linux GLX redrawer. Skiko has no public API for
+ * its GLX context or DirectContext, so this probes the live redrawer on every access and
+ * caches reflection metadata only by redrawer class. Do not cache returned contexts or
+ * environments: a redrawer replacement is a device-generation change.
+ *
+ * In Skiko 0.9.37.4 the reflected `context: Long` is a native `GLXContext*` storage
+ * address, not the GLXContext value itself. Native attachment deliberately performs the
+ * same single dereference as Skiko's makeCurrent/destroyContext JNI implementations.
+ */
+internal class SkiaOpenGLInterop(private val layer: SkiaLayer) : SkiaRenderDeviceInterop {
+    private val getRedrawerMethod: Method = SkiaLayer::class.java.getMethod("getRedrawer\$skiko")
+    private val getBackedLayerMethod: Method = SkiaLayer::class.java.getMethod("getBackedLayer\$skiko")
+    private val getContentHandleMethod: Method = SkiaLayer::class.java.getMethod("getContentHandle")
+    private val getWindowHandleMethod: Method = SkiaLayer::class.java.getMethod("getWindowHandle")
+
+    private class RedrawerAccess(redrawerClass: Class<*>) {
+        val contextHandlerField: Field = redrawerClass.getDeclaredField("contextHandler")
+            .apply { isAccessible = true }
+        val glxContextField: Field = redrawerClass.getDeclaredField("context")
+            .apply { isAccessible = true }
+        val directContextField: Field = Class.forName("org.jetbrains.skiko.context.ContextHandler")
+            .getDeclaredField("context")
+            .apply { isAccessible = true }
+
+        init {
+            check(contextHandlerField.type.name == "org.jetbrains.skiko.context.OpenGLContextHandler") {
+                "Unexpected LinuxOpenGLRedrawer.contextHandler type ${contextHandlerField.type.name}; " +
+                    "Skiko 0.9.37.4 OpenGL interop layout changed."
+            }
+            check(glxContextField.type == java.lang.Long.TYPE) {
+                "Unexpected LinuxOpenGLRedrawer.context type ${glxContextField.type}; expected long GLXContext."
+            }
+            check(DirectContext::class.java.isAssignableFrom(directContextField.type)) {
+                "Unexpected ContextHandler.context type ${directContextField.type}; expected DirectContext."
+            }
+        }
+    }
+
+    private var cachedAccess: RedrawerAccess? = null
+    private var cachedAccessClass: Class<*>? = null
+
+    private fun currentRedrawer(): Any {
+        val redrawer = getRedrawerMethod.invoke(layer) ?: error(
+            "SkiaLayer has no redrawer yet. Attach the player after the Compose window is visible."
+        )
+        check(redrawer.javaClass.name == LINUX_OPENGL_REDRAWER) {
+            "Unsupported Skiko redrawer ${redrawer.javaClass.name}. Linux mpv texture sharing " +
+                "requires Skiko's LinuxOpenGLRedrawer (GLX/X11). The active renderer is likely " +
+                "software; remove SKIKO_RENDER_API/skiko.renderApi software overrides and run Compose " +
+                "through X11 or XWayland."
+        }
+        return redrawer
+    }
+
+    private fun accessFor(redrawer: Any): RedrawerAccess {
+        val clazz = redrawer.javaClass
+        cachedAccess?.let { if (cachedAccessClass == clazz) return it }
+        return RedrawerAccess(clazz).also {
+            cachedAccess = it
+            cachedAccessClass = clazz
+        }
+    }
+
+    private fun renderEnvironment(redrawer: Any, access: RedrawerAccess): OpenGLRenderEnvironment {
+        val component = getBackedLayerMethod.invoke(layer) as? Component ?: error(
+            "SkiaLayer backedLayer is not an AWT Component; cannot obtain the GLX Display through JAWT."
+        )
+        return OpenGLRenderEnvironment(
+            component = component,
+            shareContext = access.glxContextField.getLong(redrawer),
+            drawable = getContentHandleMethod.invoke(layer) as Long,
+            window = getWindowHandleMethod.invoke(layer) as Long,
+        )
+    }
+
+    /** A live snapshot for native share-context creation. */
+    fun renderEnvironment(): OpenGLRenderEnvironment {
+        val redrawer = currentRedrawer()
+        return renderEnvironment(redrawer, accessFor(redrawer))
+    }
+
+    /** GLX and Skia values from the same redrawer, valid for the current draw only. */
+    fun renderSnapshot(): OpenGLRenderSnapshot {
+        val redrawer = currentRedrawer()
+        val access = accessFor(redrawer)
+        return OpenGLRenderSnapshot(
+            environment = renderEnvironment(redrawer, access),
+            directContext = access.directContextField
+                .get(access.contextHandlerField.get(redrawer)) as DirectContext?,
+        )
+    }
+
+    /** The GLX-context identity, suitable for detecting redrawer/share-group recreation. */
+    override val renderDevicePtr: Long
+        get() = renderEnvironment().shareContext
+
+    /** Skia's live GrDirectContext; null before its first render. */
+    override val directContext: DirectContext?
+        get() {
+            val redrawer = currentRedrawer()
+            val access = accessFor(redrawer)
+            return access.directContextField.get(access.contextHandlerField.get(redrawer)) as DirectContext?
+        }
+
+    companion object {
+        private const val LINUX_OPENGL_REDRAWER = "org.jetbrains.skiko.redrawer.LinuxOpenGLRedrawer"
+    }
+}

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvZeroConfigTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvZeroConfigTest.kt
@@ -78,7 +78,21 @@ class MpvZeroConfigTest {
                         extraFiles = MediaExtraFiles.EMPTY,
                     ),
                 )
-                player.resume()
+                if (System.getProperty("os.name").contains("Linux", ignoreCase = true)) {
+                    // Linux public playback intentionally waits for a live Skiko GLX
+                    // environment before loadfile. This zero-config case only probes the
+                    // bundled runtime's HTTP/header support against an intentional 404;
+                    // the real public playback path is covered by the GLX validation lane.
+                    assertTrue(
+                        player.handle.command(
+                            "loadfile",
+                            "http://127.0.0.1:${server.address.port}/video.mp4",
+                            "replace",
+                        ),
+                    )
+                } else {
+                    player.resume()
+                }
 
                 val didOpenHttpStream = withContext(Dispatchers.IO) {
                     requestSeen.await(10, TimeUnit.SECONDS)

--- a/mediamp-mpv/src/desktopTest/kotlin/SkikoLinuxOpenGLReflectionLayoutTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/SkikoLinuxOpenGLReflectionLayoutTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SkikoLinuxOpenGLReflectionLayoutTest {
+    @Test
+    fun `Skiko Linux OpenGL reflection layout matches the production provider`() {
+        val result = probeSkikoLinuxOpenGLReflectionLayout()
+        System.err.println("[LinuxOpenGLValidation] Skiko reflection preflight: ${result.message}")
+        assertTrue(result.compatible, "Skiko 0.9.37.4 reflection layout changed: ${result.message}")
+    }
+}
+
+private data class ReflectionLayoutResult(val compatible: Boolean, val message: String)
+
+/** Checks the private Skiko layout without initializing SkiaLayer or opening a GLX context. */
+private fun probeSkikoLinuxOpenGLReflectionLayout(): ReflectionLayoutResult {
+    val classLoader = SkikoLinuxOpenGLReflectionLayoutTest::class.java.classLoader
+    val layer = runCatching { Class.forName("org.jetbrains.skiko.SkiaLayer", false, classLoader) }
+        .getOrElse { return ReflectionLayoutResult(false, "SkiaLayer is not on the classpath: $it") }
+    val redrawer = runCatching {
+        Class.forName("org.jetbrains.skiko.redrawer.LinuxOpenGLRedrawer", false, classLoader)
+    }.getOrElse { return ReflectionLayoutResult(false, "LinuxOpenGLRedrawer is not on the classpath: $it") }
+    val redrawerGetter = layer.methods.firstOrNull { it.name == "getRedrawer\$skiko" && it.parameterCount == 0 }
+        ?: return ReflectionLayoutResult(false, "SkiaLayer.getRedrawer\$skiko() is missing")
+    val contextHandler = generateSequence(redrawer) { it.superclass }
+        .flatMap { it.declaredFields.asSequence() }
+        .firstOrNull { it.name == "contextHandler" }
+        ?: return ReflectionLayoutResult(false, "LinuxOpenGLRedrawer.contextHandler is missing")
+    val context = generateSequence(contextHandler.type) { it.superclass }
+        .flatMap { it.declaredFields.asSequence() }
+        .firstOrNull { it.name == "context" }
+        ?: return ReflectionLayoutResult(false, "${contextHandler.type.name}.context is missing")
+
+    return ReflectionLayoutResult(
+        compatible = true,
+        message = "${redrawer.name}; ${redrawerGetter.name}; ${contextHandler.type.name}.${context.name}",
+    )
+}

--- a/mediamp-mpv/src/desktopTest/kotlin/utils/OpenGLRenderEnvironmentTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/utils/OpenGLRenderEnvironmentTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.utils
+
+import java.awt.Canvas
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+
+class OpenGLRenderEnvironmentTest {
+    @Test
+    fun `environment identity tracks the GLX share group and drawable`() {
+        val component = Canvas()
+        val first = OpenGLRenderEnvironment(component, shareContext = 11, drawable = 22, window = 33)
+        val same = OpenGLRenderEnvironment(component, shareContext = 11, drawable = 22, window = 33)
+        val recreated = OpenGLRenderEnvironment(component, shareContext = 44, drawable = 22, window = 33)
+
+        assertEquals(first.identity, same.identity)
+        assertNotEquals(first.identity, recreated.identity)
+    }
+
+    @Test
+    fun `environment rejects a redrawer that has not created a GLX context or drawable`() {
+        val component = Canvas()
+
+        assertFailsWith<IllegalArgumentException> {
+            OpenGLRenderEnvironment(component, shareContext = 0, drawable = 1, window = 1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            OpenGLRenderEnvironment(component, shareContext = 1, drawable = 0, window = 1)
+        }
+    }
+}

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -68,6 +68,11 @@ abstract class JvmMpvMediampPlayer(
     internal val handle by lazy { MPVHandle(context) }
     private val stateMachine = MpvPlaybackStateMachine()
 
+    // Linux may resume before Skiko exposes its GLX share context. Preserve that load
+    // until surface attachment; eager macOS/Windows contexts never use this state.
+    private val pendingLoadLock = Any()
+    private var pendingPlaybackLoad: MPVPlayerData? = null
+
     override val impl: Any get() = handle
 
     private val _currentPositionMillis: MutableStateFlow<Long> = MutableStateFlow(0L)
@@ -234,8 +239,8 @@ abstract class JvmMpvMediampPlayer(
             }
 
             is Platform.Linux -> {
-                // vo=libmpv defers GL context creation to the render API (the desktop render
-                // path is not implemented on Linux yet); ao is picked at playback time.
+                // The desktop GLX bridge creates libmpv's OpenGL render context only after
+                // Skiko exposes its live share context; ao is picked at playback time.
                 handle.option("ao", "pulse,alsa")
                 handle.option("vo", "libmpv")
             }
@@ -312,8 +317,44 @@ abstract class JvmMpvMediampPlayer(
         return detachSurface(handle.ptr)
     }
 
+    /**
+     * Linux overrides this because its GLX context is unavailable before surface attach.
+     * `vo=libmpv` requires it before `loadfile`; false defers the load while staying READY.
+     */
+    protected open fun ensureRenderContextForLoad(): Boolean = true
+
+    /** Linux rejects GLX share-group replacement while this playback session is active. */
+    protected fun hasActivePlaybackSession(): Boolean = stateMachine.playbackSessionActive
+
+    /** Completes a Linux load deferred until GLX attach; shares a lock with [resumeImpl]. */
+    protected fun renderContextBecameReady() {
+        synchronized(pendingLoadLock) {
+            val pending = pendingPlaybackLoad ?: return
+            pendingPlaybackLoad = null
+            if (openResource.value !== pending) return
+            loadForPlayback(pending)
+        }
+    }
+
+    // Clear deferred Linux loads on replace/stop/close so a later GLX attach cannot
+    // resurrect a cancelled request.
+    private fun cancelPendingPlaybackLoad() {
+        synchronized(pendingLoadLock) { pendingPlaybackLoad = null }
+    }
+
+    // Shared by the eager path and Linux's deferred path so state transitions stay equal.
+    private fun loadForPlayback(media: MPVPlayerData): Boolean {
+        handle.setPropertyBoolean("pause", false)
+        if (!handle.command("loadfile", media.loadTarget, "replace")) return false
+        stateMachine.onPlaybackStarted()
+        playbackState.value = PlaybackState.PLAYING
+        return true
+    }
+
     override suspend fun setMediaDataImpl(data: MediaData): MPVPlayerData = when (data) {
         is UriMediaData -> {
+            // Do not let a later Linux GLX attach load the resource being replaced.
+            cancelPendingPlaybackLoad()
             clearPlaybackSession(resetPosition = true)
             handle.command("stop")
             handle.command("playlist-clear")
@@ -328,6 +369,8 @@ abstract class JvmMpvMediampPlayer(
         }
 
         is SeekableInputMediaData -> {
+            // Do not let a later Linux GLX attach load the resource being replaced.
+            cancelPendingPlaybackLoad()
             clearPlaybackSession(resetPosition = true)
             handle.command("stop")
             handle.command("playlist-clear")
@@ -349,10 +392,15 @@ abstract class JvmMpvMediampPlayer(
         when (playbackState.value) {
             PlaybackState.READY -> {
                 val media = openResource.value ?: return
-                handle.setPropertyBoolean("pause", false)
-                if (handle.command("loadfile", media.loadTarget, "replace")) {
-                    stateMachine.onPlaybackStarted()
-                    playbackState.value = PlaybackState.PLAYING
+                // Atomic with renderContextBecameReady(): GLX may become ready between
+                // the check and recording the pending load, which would lose the wake-up.
+                synchronized(pendingLoadLock) {
+                    if (!ensureRenderContextForLoad()) {
+                        pendingPlaybackLoad = media
+                        return
+                    }
+                    pendingPlaybackLoad = null
+                    loadForPlayback(media)
                 }
             }
 
@@ -394,12 +442,16 @@ abstract class JvmMpvMediampPlayer(
     }
 
     override fun stopPlaybackImpl() {
+        // Linux may still have a load waiting for GLX attach.
+        cancelPendingPlaybackLoad()
         handle.command("stop")
         clearPlaybackSession(resetPosition = true)
         playbackState.value = PlaybackState.FINISHED
     }
 
     override fun closeImpl() {
+        // Prevent a late Linux GLX attach from loading into a closing player.
+        cancelPendingPlaybackLoad()
         (framePreview as? AutoCloseable)?.close()
         clearPlaybackSession(resetPosition = true)
         handle.command("stop")
@@ -422,6 +474,8 @@ abstract class JvmMpvMediampPlayer(
      */
     internal fun commandLoadFilePaused(): Boolean {
         val media = openResource.value ?: return false
+        // Linux frame previews also require GLX attach before vo=libmpv can load.
+        if (!ensureRenderContextForLoad()) return false
         handle.setPropertyBoolean("pause", true)
         return handle.command("loadfile", media.loadTarget, "replace")
     }


### PR DESCRIPTION
## Summary

Add Linux x64 playback support to the desktop `mediamp-mpv` backend.

The Linux implementation follows the existing macOS and Windows surface-ring architecture:

```text
libmpv Render API
  → dedicated producer GPU context
  → triple-buffered shared textures
  → Skia external render targets
  → one GPU blit into a Skia-owned surface
  → cached Skia Image
  → Compose Canvas
```

On Linux, mediamp creates a dedicated GLX producer context in the same OpenGL share group as Skiko’s live GLX context. libmpv renders into three shared RGBA textures. Compose wraps those textures with context-local consumer FBOs and draws the latest frame through the existing `MpvSurfaceRing` consumer.

The steady frame path performs no GPU-to-CPU readback, JVM pixel copy, `BufferedImage` conversion, or CPU-to-GPU upload. It still includes one GPU-to-GPU blit into a Skia-owned surface before Compose draws the cached image.

This change also completes the Linux runtime build, runtime JAR packaging, and zero-config native loading paths. The resulting artifacts have been published to Maven Local and consumed by Animeko for integration testing.

## Supported environment

The first Linux backend supports:

- Linux x64;
- X11;
- Wayland sessions through XWayland;
- Compose Multiplatform’s Skiko OpenGL renderer;
- NVIDIA NVDEC through CUDA/OpenGL interop;
- Intel and AMD VAAPI hardware decoding through `vaapi-copy`;
- software decoding as the final fallback.

Native Wayland presentation is not included. Compose Multiplatform 1.10.1 / Skiko 0.9.37.4 uses GLX for its Linux AWT renderer, including under XWayland.

## Rendering architecture

Skiko owns the consumer context and mediamp owns the producer context:

```text
context A: Skiko GLX context
  - owned by Skiko
  - current on the Compose render thread
  - owns the consumer FBOs and Skia wrappers

context B: mediamp GLX context
  - created in context A’s share group
  - current only on the native mpv render thread
  - owns libmpv’s OpenGL render context
  - owns the source textures and producer FBOs
```

Only texture storage is shared between the contexts. Each context creates its own FBO because framebuffer objects are treated as context-local resources.

Each ring generation contains:

- three shared RGBA8 textures;
- three producer FBOs in context B;
- three consumer FBOs in context A;
- one Skia-owned blit surface.

The native render thread calls `mpv_render_context_render()`, waits for completion with `glFinish()`, publishes the packed ring state with release semantics, and notifies the Kotlin consumer.

Compose reads the state with acquire semantics. When the state and `DirectContext` are unchanged, it reuses the cached Skia image instead of wrapping or blitting the source texture again. Overlay-only Compose redraws therefore do not repeat the video-frame blit.

## Linux lifecycle

Unlike the macOS and Windows producer devices, the Linux producer context cannot be created before a live Skiko GLX context exists.

Media loading is deferred until the Compose surface attaches its current OpenGL render environment:

```text
create player
  → wait for a live Skiko GLX redrawer
  → attach Display / screen / share-context identity
  → create shared producer context
  → create libmpv OpenGL render context
  → allow loadfile
```

This preserves libmpv’s `vo=libmpv` requirement that a usable render context exists before video loading begins.

The attachment is idempotent while the GLX environment identity is unchanged. If Skiko replaces its share context before playback, mediamp tears down the previous producer environment and creates a new generation.

Replacing the share group during active playback currently fails explicitly. Freeing an active `mpv_render_context` disables video, so transparent recovery would require a separately validated video-output reload protocol that preserves position, pause state, track selection, and hardware-decoding state.

With no active surface, render updates are drained through libmpv’s skip-rendering path. Playback timing can continue without allocating full-size output textures.

## Frame production

The native render thread owns all producer OpenGL operations:

```text
mpv render update
  → apply pending surface configuration
  → select the next ring slot
  → render into its producer FBO
  → glFinish()
  → publish generation, slot, dimensions, and serial
  → notify the Compose consumer
```

A slot is never published before its producer writes have completed. `glFinish()` blocks the native producer thread rather than the Compose render thread.

When no surface is active, the same render thread drains pending frames with `MPV_RENDER_PARAM_SKIP_RENDERING`.

## Frame consumption

The Compose render thread consumes the latest published slot:

```text
read packed frame state
  → reuse the cached image if nothing changed
  → recreate wrappers if generation or DirectContext changed
  → attach the shared texture to a consumer FBO
  → wrap it as a Skia BackendRenderTarget and Surface
  → notify Skia about external content changes
  → blit into a Skia-owned surface
  → snapshot and cache the Skia Image
  → draw through Compose
```

The source texture remains owned by the native ring. Skia receives a non-owning render-target description and does not delete the shared texture.

The consumer explicitly deletes its context-local FBOs. Closing a Skia `BackendRenderTarget` does not release those native OpenGL resources.

## Surface resize and ownership

Resize uses the same active/retired generation model as the existing desktop backends:

1. Compose posts the latest requested size.
2. The native render thread moves the active texture ring into retired storage.
3. A new ring is allocated without modifying textures still visible to Skia.
4. Compose keeps the last cached frame until the new generation publishes its first frame.
5. The consumer closes the old source surfaces, backend render targets, and consumer FBOs.
6. The consumer acknowledges retirement.
7. The producer thread deletes the retired textures and producer FBOs.

Rapid resize requests are coalesced while one retired generation is waiting for acknowledgement. The implementation never overwrites a retired ring that the consumer may still reference.

`BackendRenderTarget` and Skia `Surface` objects do not own the native OpenGL FBO or source texture. Consumer FBO deletion and producer texture deletion therefore remain explicit and occur in their owning contexts.

## Hardware decoding

Linux uses the following mpv preference order:

```text
nvdec,vaapi-copy,auto-safe
```

### NVIDIA

The Linux build enables FFmpeg NVDEC and mpv’s CUDA/OpenGL mapper.

The NVIDIA path is:

```text
NVDEC frame
  → CUDA/OpenGL interop
  → mpv OpenGL renderer
  → mediamp shared texture ring
```

This keeps decoded frames off the CPU before mpv renders them into the output ring.

The complete Compose presentation path still performs the normal Skia GPU blit, so this should be described as zero-copy hardware-frame interop with no CPU frame copy, rather than an end-to-end zero-copy renderer.

### Intel and AMD

The Linux build enables VAAPI and its X11 device path. Intel and AMD use `vaapi-copy`:

```text
VAAPI decode
  → system-memory copy
  → mpv OpenGL upload and render
  → mediamp shared texture ring
```

This is not a zero-copy decode path, but it preserves hardware decoding and avoids depending on EGL presentation.

Direct VAAPI DMA-BUF import was investigated against the GLX producer. mpv’s mapper normally requires a current EGL context and display. Supplying a display-only EGL environment allowed the mapper to reach `eglCreateImageKHR(EGL_LINUX_DMA_BUF_EXT)`, but Mesa 26.1.4 consistently crashed inside `libgallium` before returning an EGL error. The same Intel hardware and media worked with a conventional X11/EGL mpv context.

The direct VAAPI experiment is not included. Supporting it safely would require either a driver fix or a separately designed DMA-BUF importer, such as a `GL_EXT_memory_object_fd` path.

AMD uses the same standard libva `vaapi-copy` path as Intel, but has not yet been exercised on physical AMD hardware.

## Color and presentation

The producer renders into RGBA8 textures. Linux wraps those textures with:

```text
SurfaceColorFormat.RGBA_8888
SurfaceOrigin.BOTTOM_LEFT
```

The bottom-left Skia origin matches the OpenGL render target and preserves the same top-left video orientation exposed by the macOS and Windows backends.

An asymmetric four-color reference frame was used to detect vertical inversion, channel swaps, stale frames, and invalid alpha. The original OpenGL output appeared vertically inverted until the Skia wrapper was changed to `BOTTOM_LEFT`; no second flip is applied elsewhere in the pipeline.

The output bridge retains the existing SDR contract and mpv tone-mapping configuration. HDR content is rendered into the current 8-bit sRGB/BT.709 target rather than exposed as an HDR Compose surface.

## Build and runtime packaging

The Linux FFmpeg build enables:

- NVDEC support for H.264, HEVC, VP9, and AV1;
- VAAPI support for H.264, HEVC, VP9, and AV1;
- the NVIDIA codec headers required by FFmpeg’s NVDEC integration.

The Linux mpv build enables:

- OpenGL;
- GLX/X11;
- EGL-X11 build capability required by upstream Linux components;
- CUDA hardware decoding and CUDA/OpenGL interop;
- VAAPI and VAAPI-X11.

The Compose presentation bridge itself remains GLX-only. Enabling mpv’s EGL build capability does not add EGL presentation or native Wayland support to mediamp.

The JNI bridge links against the Linux GLX/X11 system interfaces and uses `$ORIGIN` runtime lookup. The runtime JAR contains the assembled JNI, mpv, FFmpeg, and bundled codec/render dependencies.

GPU and window-system drivers remain system dependencies, including:

- X11 or XWayland;
- GLX and OpenGL;
- NVIDIA CUDA/NVDEC driver libraries when using NVIDIA;
- libva and a suitable VAAPI driver when using Intel or AMD.

The Linux runtime publication uses the same Gradle publication model as the existing desktop runtimes. This change has verified the generated artifacts through Maven Local only; no Linux artifact from this branch has been uploaded to Maven Central.

The production demo now selects the assembled `LinuxX64` runtime through the existing `runD3D11` task. The task name is retained for compatibility even though it now exercises the production renderer on Linux, macOS, and Windows.

## Validation

The following local checks completed successfully:

```text
./gradlew :mediamp-mpv:desktopTest
./gradlew :mediamp-mpv-demo:compileKotlin
./gradlew :mediamp-mpv:mpvAssembleLinuxX64
./gradlew :mediamp-mpv:mpvRuntimeJarLinuxX64
./gradlew :mediamp-mpv:zeroConfigTest
./gradlew :mediamp-mpv:publishToMavenLocal
```

The retained desktop tests cover:

- OpenGL render-environment value semantics;
- the private Skiko reflection layout used to find the live redrawer and `DirectContext`;
- zero-config runtime extraction and JNI loading;
- existing shared player and surface-ring behavior.

Manual validation used the production Compose surface rather than a separate renderer.

### NVIDIA

Tested on an NVIDIA GeForce RTX 4060 Laptop GPU:

- forced `hwdec=nvdec`;
- observed `hwdec-current=nvdec`;
- verified HEVC playback through the production Compose/GLX surface;
- verified that mpv selected its CUDA/OpenGL interop path.

### Intel

Tested on the Intel UHD Graphics integrated GPU in an Intel Core i7-12650H (Alder Lake GT2):

- forced `hwdec=vaapi-copy`;
- observed `hwdec-current=vaapi-copy`;
- verified HEVC playback through the production Compose/GLX surface;
- verified the default hardware-decoding policy falls through from unavailable NVDEC to `vaapi-copy`.

### Downstream integration

The Maven Local artifacts were consumed by Animeko and exercised with real HEVC playback through the production Compose surface.

## Known limitations

- Native Wayland rendering is not supported; Wayland desktops require XWayland.
- Skiko’s GLX context and `DirectContext` are private implementation details in the current Skiko version. Reflection metadata is isolated in `SkiaOpenGLInterop` and covered by a layout compatibility test.
- Replacing the Skiko GLX share group during active playback fails explicitly rather than attempting an unverified mpv video-output reload.
- Intel and AMD use `vaapi-copy`, not direct VAAPI DMA-BUF import.
- AMD VAAPI decoding is implemented through the standard libva path but has not been tested on AMD hardware.
- The output path avoids CPU frame copies after mpv renders the frame but still performs one Skia GPU blit for each newly published video frame.
- Remote Maven Central publication has not been tested for the Linux runtime artifacts.
