### PR TITLE
mpv FramePreview: direct pixel readback, minimal preview decoder, seek/contract fixes

### DIFF
--- a/mediamp-mpv/src/cpp/include/mpv_handle_t.h
+++ b/mediamp-mpv/src/cpp/include/mpv_handle_t.h
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include <jni.h>
 #include <mpv/client.h>
 #include <mpv/render_gl.h>
@@ -95,6 +96,9 @@ public:
 
     bool has_d3d11_surface();
     bool save_surface_png(const char *path);
+    // Copies the latest rendered frame as ARGB_8888 ints (0xAARRGGBB, row-major,
+    // top-down) with alpha forced opaque. Returns false when no frame is available.
+    bool read_surface_pixels(std::vector<uint32_t> &out_pixels, int &out_width, int &out_height);
 #endif
 
 #ifdef __APPLE__
@@ -124,6 +128,9 @@ public:
 
     bool has_metal_surface();
     bool save_surface_png(const char *path);
+    // Copies the latest rendered frame as ARGB_8888 ints (0xAARRGGBB, row-major,
+    // top-down) with alpha forced opaque. Returns false when no frame is available.
+    bool read_surface_pixels(std::vector<uint32_t> &out_pixels, int &out_width, int &out_height);
 #endif
 
     struct seekable_stream_entry;
@@ -210,6 +217,9 @@ private:
     bool render_into(const d3d11_buffer &buffer);
     void drain_one_frame();
     bool wait_for_gpu();  // End(flush_query_) + poll; render thread only
+    // Staging-texture readback of the latest frame; shared by save_surface_png and
+    // read_surface_pixels. Assumes render_mutex_ is held.
+    bool read_frame_argb_locked(std::vector<uint32_t> &out_pixels, int &out_width, int &out_height);
 #endif
 
 #ifdef __APPLE__

--- a/mediamp-mpv/src/cpp/jni.cpp
+++ b/mediamp-mpv/src/cpp/jni.cpp
@@ -17,6 +17,32 @@ mediampv::mpv_handle_t *get_instance(jlong ptr) {
     return reinterpret_cast<mediampv::mpv_handle_t *>(static_cast<uintptr_t>(ptr));
 }
 
+#if defined(_WIN32) || defined(__APPLE__)
+// Shared body of nReadSurfacePixels{D3D11,Macos}: returns the latest frame as an ARGB
+// jintArray and writes [width, height] into dims, or null when no frame is available.
+jintArray read_surface_pixels_to_java(JNIEnv *env, jlong ptr, jintArray dims) {
+    auto *instance = get_instance(ptr);
+    if (!instance || !dims || env->GetArrayLength(dims) < 2) {
+        return nullptr;
+    }
+    std::vector<uint32_t> pixels;
+    int width = 0, height = 0;
+    if (!instance->read_surface_pixels(pixels, width, height) || pixels.empty()) {
+        return nullptr;
+    }
+    jintArray result = env->NewIntArray(static_cast<jsize>(pixels.size()));
+    if (!result) {
+        return nullptr; // OOM; exception pending
+    }
+    env->SetIntArrayRegion(
+        result, 0, static_cast<jsize>(pixels.size()),
+        reinterpret_cast<const jint *>(pixels.data()));
+    const jint dims_out[2] = {width, height};
+    env->SetIntArrayRegion(dims, 0, 2, dims_out);
+    return result;
+}
+#endif
+
 struct scoped_utf_chars final {
     scoped_utf_chars(JNIEnv *env, jstring string)
             : env(env), string(string), chars(string ? env->GetStringUTFChars(string, nullptr) : nullptr) {}
@@ -91,6 +117,7 @@ extern "C" {
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nAckRetiredBuffersD3D11)(JNIEnv *env, jclass clazz, jlong ptr);
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasD3D11Surface)(JNIEnv *env, jclass clazz, jlong ptr);
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngD3D11)(JNIEnv *env, jclass clazz, jlong ptr, jstring path);
+	JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsD3D11)(JNIEnv *env, jclass clazz, jlong ptr, jintArray dims);
 #endif
 
 #ifdef __APPLE__
@@ -102,6 +129,7 @@ extern "C" {
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nAckRetiredBuffersMacos)(JNIEnv *env, jclass clazz, jlong ptr);
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasMetalSurface)(JNIEnv *env, jclass clazz, jlong ptr);
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePng)(JNIEnv *env, jclass clazz, jlong ptr, jstring path);
+	JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsMacos)(JNIEnv *env, jclass clazz, jlong ptr, jintArray dims);
 #endif
 
 	/**
@@ -428,6 +456,10 @@ JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngD3D11)(JNIEnv * env, jclass
     return instance->save_surface_png(path_chars.get());
 }
 
+JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsD3D11)(JNIEnv * env, jclass clazz, jlong ptr, jintArray dims) {
+    return read_surface_pixels_to_java(env, ptr, dims);
+}
+
 #endif
 
 #ifdef __APPLE__
@@ -479,6 +511,10 @@ JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePng)(JNIEnv * env, jclass claz
         return JNI_FALSE;
     }
     return instance->save_surface_png(path_chars.get());
+}
+
+JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsMacos)(JNIEnv * env, jclass clazz, jlong ptr, jintArray dims) {
+    return read_surface_pixels_to_java(env, ptr, dims);
 }
 
 #endif

--- a/mediamp-mpv/src/cpp/render_d3d11.cpp
+++ b/mediamp-mpv/src/cpp/render_d3d11.cpp
@@ -23,7 +23,7 @@
 //
 // mpv leaves the alpha channel undefined for opaque video (see render_macos.mm); the
 // consumer ignores it by wrapping the texture with an opaque color type (RGB_888X), and
-// the PNG readback forces alpha to 255. No native alpha-fix pass is needed.
+// the CPU readbacks (PNG/pixels) force alpha to 255. No native alpha-fix pass is needed.
 
 #ifdef _WIN32
 
@@ -615,15 +615,15 @@ void mpv_handle_t::cleanup_render_resources() {
     safe_release(d3d_device_);
 }
 
-// Writes the latest rendered frame (RGBA shared texture) as PNG via a staging-texture
-// readback and WIC. Independent of mpv's screenshot pipeline, which cannot convert
-// hwdec (d3d11va) frames without zimg. Holds render_mutex_ for the whole save so the
+// Staging-texture readback of the latest rendered frame (RGBA shared texture) into
+// ARGB_8888 ints (0xAARRGGBB, which is BGRA byte order in little-endian memory) with
+// alpha forced opaque (mpv leaves it undefined). The caller holds render_mutex_ so the
 // render thread cannot cycle the ring back onto this buffer mid-read; the immediate
 // context is multithread-protected, so using it here while the render thread renders
 // is safe.
-bool mpv_handle_t::save_surface_png(const char *path) {
-    std::lock_guard<std::mutex> guard(render_mutex_);
-    if (!buffers_allocated_ || latest_index_ < 0 || !path || !d3d_device_ || !d3d_context_) {
+bool mpv_handle_t::read_frame_argb_locked(
+    std::vector<uint32_t> &out_pixels, int &out_width, int &out_height) {
+    if (!buffers_allocated_ || latest_index_ < 0 || !d3d_device_ || !d3d_context_) {
         return false;
     }
     ID3D11Texture2D *source = buffers_[latest_index_].texture;
@@ -651,16 +651,40 @@ bool mpv_handle_t::save_surface_png(const char *path) {
     }
 
     const UINT width = desc.Width, height = desc.Height;
-    // RGBA rows with alpha forced opaque (mpv leaves alpha undefined).
-    std::vector<uint8_t> pixels((size_t) width * height * 4);
+    out_pixels.resize((size_t) width * height);
     for (UINT y = 0; y < height; ++y) {
         const auto *src = (const uint8_t *) mapped.pData + (size_t) y * mapped.RowPitch;
-        uint8_t *dst = pixels.data() + (size_t) y * width * 4;
-        memcpy(dst, src, (size_t) width * 4);
-        for (UINT x = 0; x < width; ++x) dst[x * 4 + 3] = 0xFF;
+        uint32_t *dst = out_pixels.data() + (size_t) y * width;
+        for (UINT x = 0; x < width; ++x) {
+            dst[x] = 0xFF000000u | ((uint32_t) src[x * 4] << 16) |
+                ((uint32_t) src[x * 4 + 1] << 8) | src[x * 4 + 2];
+        }
     }
     d3d_context_->Unmap(staging, 0);
     staging->Release();
+    out_width = (int) width;
+    out_height = (int) height;
+    return true;
+}
+
+bool mpv_handle_t::read_surface_pixels(
+    std::vector<uint32_t> &out_pixels, int &out_width, int &out_height) {
+    std::lock_guard<std::mutex> guard(render_mutex_);
+    return read_frame_argb_locked(out_pixels, out_width, out_height);
+}
+
+// Writes the latest rendered frame as PNG via the staging-texture readback and WIC.
+// Independent of mpv's screenshot pipeline, which cannot convert hwdec (d3d11va)
+// frames without zimg. render_mutex_ is only held for the readback; the encode works
+// on our own copy.
+bool mpv_handle_t::save_surface_png(const char *path) {
+    if (!path) return false;
+    std::vector<uint32_t> pixels;
+    int width = 0, height = 0;
+    {
+        std::lock_guard<std::mutex> guard(render_mutex_);
+        if (!read_frame_argb_locked(pixels, width, height)) return false;
+    }
 
     scoped_co_init com;
     if (!com.usable) {
@@ -685,10 +709,13 @@ bool mpv_handle_t::save_surface_png(const char *path) {
         if (FAILED(encoder->Initialize(stream, WICBitmapEncoderNoCache))) break;
         if (FAILED(encoder->CreateNewFrame(&frame, nullptr))) break;
         if (FAILED(frame->Initialize(nullptr))) break;
-        if (FAILED(frame->SetSize(width, height))) break;
-        WICPixelFormatGUID format = GUID_WICPixelFormat32bppRGBA;
+        if (FAILED(frame->SetSize((UINT) width, (UINT) height))) break;
+        // ARGB ints are BGRA bytes in little-endian memory.
+        WICPixelFormatGUID format = GUID_WICPixelFormat32bppBGRA;
         if (FAILED(frame->SetPixelFormat(&format))) break;
-        if (FAILED(frame->WritePixels(height, width * 4, (UINT) pixels.size(), pixels.data()))) break;
+        if (FAILED(frame->WritePixels(
+                (UINT) height, (UINT) width * 4, (UINT) (pixels.size() * 4),
+                reinterpret_cast<BYTE *>(pixels.data())))) break;
         if (FAILED(frame->Commit())) break;
         if (FAILED(encoder->Commit())) break;
         ok = true;

--- a/mediamp-mpv/src/cpp/render_macos.mm
+++ b/mediamp-mpv/src/cpp/render_macos.mm
@@ -501,6 +501,37 @@ void mpv_handle_t::cleanup_render_resources() {
     }
 }
 
+// Copies the latest rendered frame (BGRA IOSurface) into ARGB_8888 ints. BGRA words
+// read as little-endian uint32 are already 0xAARRGGBB; alpha is forced opaque because
+// mpv leaves it undefined for opaque video. Holds render_mutex_ so the render thread
+// cannot cycle the ring back onto this buffer mid-read.
+bool mpv_handle_t::read_surface_pixels(
+    std::vector<uint32_t> &out_pixels, int &out_width, int &out_height) {
+    std::lock_guard<std::mutex> guard(render_mutex_);
+    if (!buffers_allocated_ || latest_index_ < 0) return false;
+    auto surface = (IOSurfaceRef) buffers_[latest_index_].io_surface;
+    if (!surface) return false;
+
+    if (IOSurfaceLock(surface, kIOSurfaceLockReadOnly, nullptr) != kIOReturnSuccess) {
+        LOGE("read_surface_pixels: IOSurfaceLock failed");
+        return false;
+    }
+    const auto *base = (const uint8_t *) IOSurfaceGetBaseAddress(surface);
+    size_t bpr = IOSurfaceGetBytesPerRow(surface);
+    size_t width = IOSurfaceGetWidth(surface);
+    size_t height = IOSurfaceGetHeight(surface);
+    out_pixels.resize(width * height);
+    for (size_t y = 0; y < height; ++y) {
+        const auto *src = (const uint32_t *) (base + y * bpr);
+        uint32_t *dst = out_pixels.data() + y * width;
+        for (size_t x = 0; x < width; ++x) dst[x] = src[x] | 0xFF000000u;
+    }
+    IOSurfaceUnlock(surface, kIOSurfaceLockReadOnly, nullptr);
+    out_width = (int) width;
+    out_height = (int) height;
+    return true;
+}
+
 // Writes the latest rendered frame (BGRA IOSurface) as PNG. Independent of mpv's
 // screenshot pipeline, which cannot convert hwdec (videotoolbox) frames without a GPU
 // download. Holds render_mutex_ for the whole save so the render thread cannot cycle

--- a/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
@@ -50,6 +50,14 @@ external fun nHasMetalSurface(ptr: Long): Boolean
 @InternalMediampApi
 external fun nSaveSurfacePng(ptr: Long, path: String): Boolean
 
+/**
+ * Reads the latest rendered frame as ARGB_8888 pixels (`0xAARRGGBB`, row-major,
+ * top-down, alpha forced opaque), writing `[width, height]` into [dims] (size >= 2).
+ * Returns `null` when no frame is available.
+ */
+@InternalMediampApi
+external fun nReadSurfacePixelsMacos(ptr: Long, dims: IntArray): IntArray?
+
 // Windows render path (render_d3d11.cpp): a native render thread drives mpv through
 // the libmpv D3D11 render API into a ring of shared textures, each also opened on
 // Skia's D3D12 device as an ID3D12Resource.
@@ -91,6 +99,14 @@ external fun nHasD3D11Surface(ptr: Long): Boolean
 /** Saves the latest rendered frame (shared texture contents) as PNG. */
 @InternalMediampApi
 external fun nSaveSurfacePngD3D11(ptr: Long, path: String): Boolean
+
+/**
+ * Reads the latest rendered frame as ARGB_8888 pixels (`0xAARRGGBB`, row-major,
+ * top-down, alpha forced opaque), writing `[width, height]` into [dims] (size >= 2).
+ * Returns `null` when no frame is available.
+ */
+@InternalMediampApi
+external fun nReadSurfacePixelsD3D11(ptr: Long, dims: IntArray): IntArray?
 
 @OptIn(InternalMediampApi::class)
 internal actual fun attachSurface(ptr: Long, surface: Any): Boolean {

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
@@ -9,11 +9,14 @@
 package org.openani.mediamp.mpv
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -26,15 +29,12 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.PreviewFrame
-import org.openani.mediamp.io.SeekableInput
+import org.openani.mediamp.mpv.internal.MpvPreviewDecoder
+import org.openani.mediamp.mpv.internal.MpvSurfaceRingBackend
+import org.openani.mediamp.mpv.internal.currentSurfaceRingBackend
 import org.openani.mediamp.source.MediaData
-import org.openani.mediamp.source.MediaExtraFiles
-import org.openani.mediamp.source.SeekableInputMediaData
-import org.openani.mediamp.source.UriMediaData
-import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -44,27 +44,26 @@ internal actual fun createMpvFramePreview(
     context: Any,
     parentCoroutineContext: CoroutineContext,
 ): FramePreview? {
-    // The preview decoder is itself an MpvMediampPlayer, which would recursively get its own
-    // (never-used) FramePreview. Cut the recursion at depth 1.
-    if (context is MpvFramePreviewContextMarker) return null
-    return MpvFramePreview(player, context, parentCoroutineContext)
+    // Without a surface-ring backend (Linux, TODO) frames cannot be read back, so the
+    // feature is absent rather than present-but-always-null.
+    val ringBackend = currentSurfaceRingBackend() ?: return null
+    return MpvFramePreview(player, context, ringBackend, parentCoroutineContext)
 }
 
-/** Marks the `context` of a preview decoder instance so it does not create nested previews. */
-internal class MpvFramePreviewContextMarker(val delegate: Any)
-
 /**
- * [FramePreview] implementation backed by a second, headless mpv instance.
+ * [FramePreview] implementation backed by a second, minimal mpv instance
+ * ([MpvPreviewDecoder] — no event listeners, no player features, tiny demuxer cache).
  *
- * The preview instance loads the same media (a second [SeekableInput] for stream_cb media),
- * stays paused, and renders into a small native surface ring sized to fit the requested
- * dimensions; each request is a keyframe seek followed by a surface readback.
+ * The decoder loads the same media (a second input for stream_cb media), stays paused,
+ * and renders into a small native surface ring sized per request; each request is a
+ * keyframe seek followed by a direct pixel readback.
  */
 @OptIn(ExperimentalMediampApi::class)
 internal class MpvFramePreview(
     private val mainPlayer: JvmMpvMediampPlayer,
     private val context: Any,
-    private val parentCoroutineContext: CoroutineContext,
+    private val ringBackend: MpvSurfaceRingBackend,
+    parentCoroutineContext: CoroutineContext,
 ) : FramePreview, AutoCloseable {
     private val scope = CoroutineScope(
         parentCoroutineContext + SupervisorJob(parentCoroutineContext[Job.Key]),
@@ -79,7 +78,7 @@ internal class MpvFramePreview(
             // so it never outlives the media data it reads from.
             mainPlayer.mediaData.collect { data ->
                 mutex.withLock {
-                    if (session != null && session?.originalData !== data) {
+                    if (session != null && session?.mediaData !== data) {
                         discardSessionLocked()
                     }
                 }
@@ -93,9 +92,9 @@ internal class MpvFramePreview(
         return withContext(Dispatchers.IO) {
             mutex.withLock {
                 if (closed) return@withLock null
-                val session = obtainSessionLocked(data, maxWidth, maxHeight) ?: return@withLock null
+                val session = obtainSessionLocked(data) ?: return@withLock null
                 try {
-                    session.grabFrame(positionMillis)
+                    session.grabFrame(positionMillis, maxWidth, maxHeight)
                 } catch (e: CancellationException) {
                     // The caller moved on to a newer position (collectLatest). The session is
                     // still healthy — destroying it here would tear down and rebuild the whole
@@ -110,24 +109,30 @@ internal class MpvFramePreview(
         }
     }
 
-    private suspend fun obtainSessionLocked(data: MediaData, maxWidth: Int, maxHeight: Int): PreviewSession? {
+    private suspend fun obtainSessionLocked(data: MediaData): PreviewSession? {
         session?.let { existing ->
-            if (existing.originalData === data) return existing
+            if (existing.mediaData === data) return existing
             discardSessionLocked()
         }
         return try {
-            // NonCancellable: session creation is expensive shared state; a cancelled first
+            // NonCancellable: decoder creation is expensive shared state; a cancelled first
             // request must not abort it half-way (the next request reuses the session).
             withContext(NonCancellable) {
-                PreviewSession.create(context, parentCoroutineContext, data, maxWidth, maxHeight)
+                val decoder = MpvPreviewDecoder(context, ringBackend)
+                try {
+                    PreviewSession(data, decoder, scope)
+                } catch (e: Throwable) {
+                    decoder.close()
+                    throw e
+                }
             }.also { session = it }
         } catch (e: Exception) {
             null
         }
     }
 
-    private fun discardSessionLocked() {
-        session?.close()
+    private suspend fun discardSessionLocked() {
+        session?.closeSuspending()
         session = null
     }
 
@@ -144,22 +149,57 @@ internal class MpvFramePreview(
         }
     }
 
-    private class PreviewSession private constructor(
+    private class PreviewSession(
         /** The main player's media data; identity-compared to detect media changes. */
-        val originalData: MediaData,
-        private val previewData: MediaData,
-        private val player: MpvMediampPlayer,
-        private val renderCounter: MutableStateFlow<Long>,
-        private val maxWidth: Int,
-        private val maxHeight: Int,
+        val mediaData: MediaData,
+        private val decoder: MpvPreviewDecoder,
+        private val scope: CoroutineScope,
     ) : AutoCloseable {
-        private var started = false
+        private val renderCounter = MutableStateFlow(0L)
 
-        suspend fun grabFrame(positionMillis: Long): PreviewFrame? {
-            // NonCancellable: starting (paused load + surface setup) is shared progress that
-            // must survive the cancellation of the request that happened to trigger it.
-            if (!withContext(NonCancellable) { ensureStarted() }) return null
-            val handle = player.handle
+        private enum class StartOutcome {
+            READY,
+
+            /**
+             * The media has no video track, or the load terminated without producing one
+             * (e.g. a corrupt file). Permanent for this session.
+             */
+            UNPLAYABLE,
+
+            /** Transient (e.g. the data is not downloaded yet); retried by the next request. */
+            FAILED,
+        }
+
+        /**
+         * The shared load-and-probe attempt. Runs on the session [scope] so a caller
+         * cancelled mid-wait (scrubbing) does not abort it; the await in [ensureStarted]
+         * stays cancellable, unlike the previous NonCancellable block which pinned a
+         * cancelled caller (and the mutex) for the full 10s wait on unavailable data.
+         *
+         * All fields are confined to the preview mutex except [cachedOutcome], which the
+         * attempt writes from its own coroutine.
+         */
+        private var startAttempt: Deferred<StartOutcome>? = null
+
+        @Volatile
+        private var cachedOutcome: StartOutcome? = null
+
+        /** Display dimensions of the video (rotation/anamorphic-corrected), set by a READY attempt. */
+        private var videoWidth = 0
+        private var videoHeight = 0
+
+        private var surfaceWidth = 0
+        private var surfaceHeight = 0
+        private var surfaceHasFrame = false
+
+        init {
+            decoder.setRenderUpdateListener { renderCounter.update { it + 1 } }
+        }
+
+        suspend fun grabFrame(positionMillis: Long, maxWidth: Int, maxHeight: Int): PreviewFrame? {
+            if (!ensureStarted()) return null
+            if (!ensureSurface(maxWidth, maxHeight)) return null
+            val handle = decoder.handle
 
             val durationMillis = (handle.getPropertyDouble("duration") * 1000).toLong()
             val target = if (durationMillis > 0) {
@@ -169,145 +209,152 @@ internal class MpvFramePreview(
             }
 
             val counterBefore = renderCounter.value
+            val timePosBeforeMillis = (handle.getPropertyDouble("time-pos") * 1000).toLong()
             if (!handle.command("seek", formatSecondsForMpv(target / 1000.0), "absolute+keyframes")) {
                 return null
             }
 
-            // Wait until the seek lands: while paused, mpv decodes the target frame, updates
-            // time-pos and pushes a render update.
+            // Wait for the seek to finish. time-pos is deliberately NOT required to land near
+            // the target: `keyframes` snaps to the previous keyframe, which on long-GOP content
+            // (keyint of 5-10s is common) can be arbitrarily far from the target — a distance
+            // check would permanently blank previews for such positions. Completion is instead
+            // a full seeking true->false cycle, an observed position change, or a fresh render.
+            // A no-op seek (the target maps to the already-displayed keyframe) may show none of
+            // these, so a short quiet window also counts as done.
+            var moved = false
             val landed = withTimeoutOrNull(5_000) {
+                var sawSeeking = false
+                var quietPolls = 0
                 while (true) {
+                    if (renderCounter.value > counterBefore) break
                     val seeking = handle.getPropertyBoolean("seeking")
                     val timePosMillis = (handle.getPropertyDouble("time-pos") * 1000).toLong()
-                    if (!seeking && abs(timePosMillis - target) < 3_000) break
+                    if (timePosMillis != timePosBeforeMillis) moved = true
+                    if (seeking) sawSeeking = true
+                    if (!seeking && (sawSeeking || moved)) break
+                    if (!seeking && ++quietPolls >= 15) break
                     delay(20)
                 }
                 true
             } ?: false
             if (!landed) return null
 
-            // Prefer a frame rendered after the seek. The surface ring only publishes complete
-            // frames, so the first post-seek render is safe to read immediately. When the seek
-            // lands on the keyframe that is already displayed, mpv may not push a new render —
-            // the surface content is still correct, so a timeout here is not an error.
-            withTimeoutOrNull(500) { renderCounter.first { it > counterBefore } }
+            if (renderCounter.value == counterBefore && moved) {
+                // The decoder landed on a different frame, so a fresh render is coming; without
+                // it the surface still holds the pre-seek picture. If it does not arrive in
+                // time we read anyway — a slightly stale thumbnail beats none. When !moved the
+                // displayed keyframe already is the target and no render will come at all;
+                // waiting here used to cost every same-keyframe request a flat 500ms.
+                withTimeoutOrNull(1_000) { renderCounter.first { it > counterBefore } }
+            }
 
             val dims = IntArray(2)
-            val pixels = player.readSurfacePixels(dims) ?: return null
+            val pixels = decoder.readSurfacePixels(dims) ?: return null
             return PreviewFrame(target, dims[0], dims[1], pixels)
         }
 
-        /** Loads the media paused, sizes the surface ring to the video, waits for the first frame. */
         private suspend fun ensureStarted(): Boolean {
-            if (started) return true
-            val handle = player.handle
-            if (!player.commandLoadFilePaused()) return false
+            // Fast path: a completed attempt already decided this session's fate.
+            when (cachedOutcome) {
+                StartOutcome.READY -> return true
+                StartOutcome.UNPLAYABLE -> return false
+                StartOutcome.FAILED, null -> {}
+            }
+            val attempt = startAttempt?.takeIf { it.isActive }
+                ?: scope.async(Dispatchers.IO) { doStart().also { cachedOutcome = it } }
+                    .also { startAttempt = it }
+            return attempt.await() == StartOutcome.READY
+        }
 
-            // Video dimensions become available once the first frame is decoded.
+        /** Loads the media paused and waits for the video dimensions of the first frame. */
+        private suspend fun doStart(): StartOutcome {
+            if (!decoder.loadPaused(mediaData)) return StartOutcome.FAILED
+
+            var unplayable = false
+            var codedFallbackPolls = 0
+            var sawLoading = false
+            var idlePolls = 0
             val dims = withTimeoutOrNull(10_000) {
                 while (true) {
-                    val w = handle.getPropertyInt("width")
-                    val h = handle.getPropertyInt("height")
-                    if (w > 0 && h > 0) return@withTimeoutOrNull w to h
+                    // Display dimensions include rotation and anamorphic aspect; the coded
+                    // width/height would distort such content. They normally appear together,
+                    // but fall back to the coded size if only that becomes available.
+                    val dw = decoder.handle.getPropertyInt("dwidth")
+                    val dh = decoder.handle.getPropertyInt("dheight")
+                    if (dw > 0 && dh > 0) return@withTimeoutOrNull dw to dh
+                    val w = decoder.handle.getPropertyInt("width")
+                    val h = decoder.handle.getPropertyInt("height")
+                    if (w > 0 && h > 0 && ++codedFallbackPolls >= 20) return@withTimeoutOrNull w to h
+
+                    // A load that TERMINATES without video dimensions (audio-only file with
+                    // aid=no selects no track at all; corrupt file) drops mpv back to idle.
+                    // Waiting out the full timeout — and re-waiting on every request — would
+                    // burn 10s per hover, so detect the idle transition. This cannot misfire
+                    // for merely-slow media: a demuxer blocked on unavailable data (torrent
+                    // inputs block rather than error) keeps idle-active false the whole time.
+                    val idleActive = decoder.handle.getPropertyBoolean("idle-active")
+                    if (!idleActive) {
+                        sawLoading = true
+                        idlePolls = 0
+                    } else if (sawLoading || ++idlePolls >= 40) {
+                        // Load ended (or, after 2s of continuous idle, never started).
+                        unplayable = true
+                        return@withTimeoutOrNull null
+                    }
                     delay(50)
                 }
                 @Suppress("UNREACHABLE_CODE")
                 null
-            } ?: return false
+            }
+            if (unplayable) return StartOutcome.UNPLAYABLE
+            if (dims == null) return StartOutcome.FAILED
+            videoWidth = dims.first
+            videoHeight = dims.second
+            return StartOutcome.READY
+        }
 
-            val (videoWidth, videoHeight) = dims
+        /**
+         * Sizes the surface ring to fit the video within [maxWidth] x [maxHeight] and makes
+         * sure a frame has landed in it. Re-checked on every request: the max size may
+         * legitimately change between requests, and returning frames larger than the
+         * requested bounds would break the [FramePreview.getPreviewFrame] contract.
+         */
+        private suspend fun ensureSurface(maxWidth: Int, maxHeight: Int): Boolean {
             val scale = min(
                 maxWidth.toFloat() / videoWidth,
                 maxHeight.toFloat() / videoHeight,
             ).coerceAtMost(1f)
-            val surfaceWidth = max(2, (videoWidth * scale).roundToInt())
-            val surfaceHeight = max(2, (videoHeight * scale).roundToInt())
-            if (!player.requestSurface(surfaceWidth, surfaceHeight, 0L)) return false
+            val desiredWidth = max(2, (videoWidth * scale).roundToInt())
+            val desiredHeight = max(2, (videoHeight * scale).roundToInt())
+            if (desiredWidth != surfaceWidth || desiredHeight != surfaceHeight) {
+                if (!decoder.requestSurface(desiredWidth, desiredHeight)) return false
+                surfaceWidth = desiredWidth
+                surfaceHeight = desiredHeight
+                surfaceHasFrame = false
+            }
+            if (!surfaceHasFrame) {
+                // After a reconfig the new ring is empty until the render thread redraws the
+                // current frame into it (this happens even while paused). The probe read
+                // covers a frame that landed while no request was waiting (e.g. the request
+                // that reconfigured was cancelled mid-wait).
+                val counterNow = renderCounter.value
+                surfaceHasFrame = decoder.readSurfacePixels(IntArray(2)) != null ||
+                    withTimeoutOrNull(5_000) { renderCounter.first { it > counterNow } } != null
+            }
+            return surfaceHasFrame
+        }
 
-            if (withTimeoutOrNull(5_000) { renderCounter.first { it > 0 } } == null) return false
-            started = true
-            return true
+        /**
+         * Cancels the in-flight start attempt (waiting for it to actually finish, so no
+         * coroutine still touches the handle) and then tears down the native decoder.
+         */
+        suspend fun closeSuspending() {
+            startAttempt?.cancelAndJoin()
+            close()
         }
 
         override fun close() {
-            try {
-                player.setRenderUpdateListener(null)
-                player.releaseSurface()
-                player.releaseRenderContext()
-            } catch (_: Exception) {
-            }
-            try {
-                player.close()
-            } catch (_: Exception) {
-            }
-            (previewData as? NonClosingSeekableInputMediaData)?.closeOpenInputs()
-        }
-
-        companion object {
-            suspend fun create(
-                context: Any,
-                parentCoroutineContext: CoroutineContext,
-                data: MediaData,
-                maxWidth: Int,
-                maxHeight: Int,
-            ): PreviewSession {
-                val previewData: MediaData = when (data) {
-                    is SeekableInputMediaData -> NonClosingSeekableInputMediaData(data)
-                    // UriMediaData is sealed; a fresh copy is safe because its close() is a no-op.
-                    is UriMediaData -> UriMediaData(data.uri, data.headers, data.extraFiles, data.options)
-                }
-                val renderCounter = MutableStateFlow(0L)
-                val player = MpvMediampPlayer(MpvFramePreviewContextMarker(context), parentCoroutineContext)
-                try {
-                    val handle = player.handle
-                    // Keep the preview decoder lightweight: no audio, no subtitles.
-                    handle.setPropertyString("aid", "no")
-                    handle.setPropertyString("sid", "no")
-                    handle.setPropertyBoolean("pause", true)
-                    player.setRenderUpdateListener { renderCounter.update { it + 1 } }
-                    player.setMediaData(previewData)
-                    return PreviewSession(data, previewData, player, renderCounter, maxWidth, maxHeight)
-                } catch (e: Throwable) {
-                    try {
-                        player.close()
-                    } catch (_: Exception) {
-                    }
-                    (previewData as? NonClosingSeekableInputMediaData)?.closeOpenInputs()
-                    throw e
-                }
-            }
-        }
-    }
-
-    /**
-     * Delegates to the main player's media but never closes it (the main player owns it),
-     * and tracks inputs opened for the preview decoder so the session can close them.
-     */
-    private class NonClosingSeekableInputMediaData(
-        private val delegate: SeekableInputMediaData,
-    ) : SeekableInputMediaData {
-        private val openInputs = CopyOnWriteArrayList<SeekableInput>()
-
-        override val uri: String get() = delegate.uri
-        override val extraFiles: MediaExtraFiles get() = delegate.extraFiles
-        override val options: List<String> get() = delegate.options
-        override fun fileLength(): Long? = delegate.fileLength()
-
-        override suspend fun createInput(coroutineContext: CoroutineContext): SeekableInput =
-            delegate.createInput(coroutineContext).also { openInputs.add(it) }
-
-        override fun close() {
-            // no-op: the shared media data is owned by the main player.
-        }
-
-        fun closeOpenInputs() {
-            openInputs.forEach {
-                try {
-                    it.close()
-                } catch (_: Exception) {
-                }
-            }
-            openInputs.clear()
+            decoder.close()
         }
     }
 }

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
@@ -192,6 +192,14 @@ internal class MpvFramePreview(
         private var surfaceHeight = 0
         private var surfaceHasFrame = false
 
+        /**
+         * True while a seek or ring reconfig may still produce a render that no request
+         * has accounted for — set before issuing either, cleared once the effect (or its
+         * absence) is confirmed. A caller cancelled mid-wait (fast scrubbing) leaves this
+         * true, and the next request settles the leftovers first.
+         */
+        private var unsettled = false
+
         init {
             decoder.setRenderUpdateListener { renderCounter.update { it + 1 } }
         }
@@ -200,6 +208,23 @@ internal class MpvFramePreview(
             if (!ensureStarted()) return null
             if (!ensureSurface(maxWidth, maxHeight)) return null
             val handle = decoder.handle
+
+            // Settle leftovers from a previous request that was cancelled or timed out
+            // mid-seek: cancelling the caller does NOT cancel mpv's seek, so its seek and
+            // render are still in flight and would otherwise satisfy the completion
+            // signals below — this request would then return the PREVIOUS position's
+            // frame labeled with the new target, which is exactly what fast scrubbing
+            // used to produce. Wait out the in-flight seek, then absorb its pending
+            // render so the baselines captured below belong to this request alone.
+            withTimeoutOrNull(5_000) {
+                while (handle.getPropertyBoolean("seeking")) delay(20)
+                true
+            } ?: return null
+            if (unsettled) {
+                val counterAtSettle = renderCounter.value
+                withTimeoutOrNull(100) { renderCounter.first { it > counterAtSettle } }
+                unsettled = false
+            }
 
             val durationMillis = (handle.getPropertyDouble("duration") * 1000).toLong()
             val target = if (durationMillis > 0) {
@@ -210,6 +235,7 @@ internal class MpvFramePreview(
 
             val counterBefore = renderCounter.value
             val timePosBeforeMillis = (handle.getPropertyDouble("time-pos") * 1000).toLong()
+            unsettled = true
             if (!handle.command("seek", formatSecondsForMpv(target / 1000.0), "absolute+keyframes")) {
                 return null
             }
@@ -242,10 +268,17 @@ internal class MpvFramePreview(
             if (renderCounter.value == counterBefore && moved) {
                 // The decoder landed on a different frame, so a fresh render is coming; without
                 // it the surface still holds the pre-seek picture. If it does not arrive in
-                // time we read anyway — a slightly stale thumbnail beats none. When !moved the
+                // time we read anyway — a slightly stale thumbnail beats none (and unsettled
+                // stays true, so the next request absorbs the late render). When !moved the
                 // displayed keyframe already is the target and no render will come at all;
                 // waiting here used to cost every same-keyframe request a flat 500ms.
-                withTimeoutOrNull(1_000) { renderCounter.first { it > counterBefore } }
+                if (withTimeoutOrNull(1_000) { renderCounter.first { it > counterBefore } } != null) {
+                    unsettled = false
+                }
+            } else {
+                // Either our render already arrived (post-settle bumps are ours), or the
+                // seek was a no-op and no render is pending.
+                unsettled = false
             }
 
             val dims = IntArray(2)
@@ -327,6 +360,7 @@ internal class MpvFramePreview(
             val desiredWidth = max(2, (videoWidth * scale).roundToInt())
             val desiredHeight = max(2, (videoHeight * scale).roundToInt())
             if (desiredWidth != surfaceWidth || desiredHeight != surfaceHeight) {
+                unsettled = true // the reconfig redraw is a render nobody has accounted for yet
                 if (!decoder.requestSurface(desiredWidth, desiredHeight)) return false
                 surfaceWidth = desiredWidth
                 surfaceHeight = desiredHeight
@@ -336,7 +370,10 @@ internal class MpvFramePreview(
                 // After a reconfig the new ring is empty until the render thread redraws the
                 // current frame into it (this happens even while paused). The probe read
                 // covers a frame that landed while no request was waiting (e.g. the request
-                // that reconfigured was cancelled mid-wait).
+                // that reconfigured was cancelled mid-wait). unsettled deliberately stays
+                // true on all paths: a leftover seek's render and the reconfig redraw can
+                // both be pending, so the bump observed here is not proof of quiescence —
+                // grabFrame's settle phase absorbs whatever is still in flight.
                 val counterNow = renderCounter.value
                 surfaceHasFrame = decoder.readSurfacePixels(IntArray(2)) != null ||
                     withTimeoutOrNull(5_000) { renderCounter.first { it > counterNow } } != null

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
@@ -31,9 +31,7 @@ import org.openani.mediamp.source.MediaData
 import org.openani.mediamp.source.MediaExtraFiles
 import org.openani.mediamp.source.SeekableInputMediaData
 import org.openani.mediamp.source.UriMediaData
-import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
-import javax.imageio.ImageIO
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.abs
@@ -194,16 +192,9 @@ internal class MpvFramePreview(
             // the surface content is still correct, so a timeout here is not an error.
             withTimeoutOrNull(500) { renderCounter.first { it > counterBefore } }
 
-            val tmp = File.createTempFile("mediamp-mpv-preview", ".png")
-            try {
-                if (!player.dumpSurfaceForDebug(tmp.absolutePath)) return null
-                val image = ImageIO.read(tmp) ?: return null
-                val pixels = IntArray(image.width * image.height)
-                image.getRGB(0, 0, image.width, image.height, pixels, 0, image.width)
-                return PreviewFrame(target, image.width, image.height, pixels)
-            } finally {
-                tmp.delete()
-            }
+            val dims = IntArray(2)
+            val pixels = player.readSurfacePixels(dims) ?: return null
+            return PreviewFrame(target, dims[0], dims[1], pixels)
         }
 
         /** Loads the media paused, sizes the surface ring to the video, waits for the first frame. */

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
@@ -72,8 +72,9 @@ actual class MpvMediampPlayer(
         surfaceRing?.release()
     }
 
-    internal fun dumpSurfaceForDebug(path: String): Boolean =
-        ringBackend?.saveSurfacePng(handle.ptr, path) ?: false
+    /** See [MpvSurfaceRingBackend.readSurfacePixels]. */
+    internal fun readSurfacePixels(dims: IntArray): IntArray? =
+        ringBackend?.readSurfacePixels(handle.ptr, dims)
 
     /**
      * Reads the frame back from our own surface ring (mpv's screenshot pipeline cannot

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
@@ -12,13 +12,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.Image
-import org.jetbrains.skiko.OS
-import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.InternalMediampApi
-import org.openani.mediamp.mpv.internal.D3D11SurfaceRingBackend
-import org.openani.mediamp.mpv.internal.MacosSurfaceRingBackend
 import org.openani.mediamp.mpv.internal.MpvSurfaceRing
 import org.openani.mediamp.mpv.internal.MpvSurfaceRingBackend
+import org.openani.mediamp.mpv.internal.currentSurfaceRingBackend
 import kotlin.coroutines.CoroutineContext
 
 @OptIn(InternalMediampApi::class)
@@ -27,14 +24,8 @@ actual class MpvMediampPlayer(
     parentCoroutineContext: CoroutineContext,
 ) : JvmMpvMediampPlayer(context, parentCoroutineContext) {
 
-    // Native surface-ring render path: macOS renders through Metal/IOSurface
-    // (render_macos.mm), Windows through D3D11/D3D12 shared textures
-    // (render_d3d11.cpp). The consumer state machine is shared (MpvSurfaceRing).
-    private val ringBackend: MpvSurfaceRingBackend? = when (hostOs) {
-        OS.MacOS -> MacosSurfaceRingBackend
-        OS.Windows -> D3D11SurfaceRingBackend
-        else -> null // TODO: Linux render path
-    }
+    // Native surface-ring render path; the consumer state machine is shared (MpvSurfaceRing).
+    private val ringBackend: MpvSurfaceRingBackend? = currentSurfaceRingBackend()
     private val surfaceRing: MpvSurfaceRing? = ringBackend?.let { MpvSurfaceRing(handle.ptr, it) }
 
     init {

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.internal
+
+import kotlinx.coroutines.currentCoroutineContext
+import org.openani.mediamp.ExperimentalMediampApi
+import org.openani.mediamp.io.SeekableInput
+import org.openani.mediamp.mpv.MPVHandle
+import org.openani.mediamp.mpv.RenderUpdateListener
+import org.openani.mediamp.source.MediaData
+import org.openani.mediamp.source.SeekableInputMediaData
+import org.openani.mediamp.source.UriMediaData
+
+private const val FRAME_PREVIEW_LOAD_TARGET_PREFIX = "mediamp://frame_preview/"
+
+/**
+ * A minimal, headless mpv instance dedicated to frame-preview extraction.
+ *
+ * Unlike the full `MpvMediampPlayer`, this registers no event listener, observes no
+ * properties and creates no player features: the frame-preview session drives the handle
+ * directly and polls the few properties it needs, so property-change events would only
+ * add JNI upcall traffic on every seek. The demuxer cache is also kept tiny — this
+ * instance only ever decodes single keyframes while paused, and the player's default
+ * cache would read ahead tens of MB after every scrub seek, which is hostile to
+ * torrent-backed [SeekableInputMediaData] sources.
+ */
+@OptIn(ExperimentalMediampApi::class)
+internal class MpvPreviewDecoder(
+    context: Any,
+    private val ringBackend: MpvSurfaceRingBackend,
+) : AutoCloseable {
+    val handle = MPVHandle(context)
+
+    /** Input opened for stream_cb media; owned and closed by this decoder. */
+    private var openInput: SeekableInput? = null
+    private var loadTarget: String? = null
+
+    init {
+        try {
+            configure()
+            check(ringBackend.createRenderContext(handle.ptr)) {
+                "Failed to create the mpv render context for frame preview"
+            }
+        } catch (e: Throwable) {
+            handle.close()
+            throw e
+        }
+    }
+
+    private fun configure() {
+        // Mirrored from JvmMpvMediampPlayer.configureNativeHandle — keep the two in sync.
+        // Only options that affect decoding or frame correctness are kept; playback-only
+        // options (ao, volume-max, input bindings) are intentionally absent.
+        handle.option("config", "no")
+        handle.option("profile", "fast")
+        handle.option("vo", "libmpv")
+        // HDR -> SDR tone-mapping, same as the main player (see there for the full
+        // rationale) — without it HDR sources produce near-black thumbnails.
+        handle.option("gpu-dumb-mode", "no")
+        handle.option("target-prim", "bt.709")
+        handle.option("target-trc", "srgb")
+        handle.option("hwdec", "auto")
+        handle.option("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
+        // workaround for <https://github.com/mpv-player/mpv/issues/14651>
+        handle.option("vd-lavc-film-grain", "cpu")
+
+        // Preview-specific: no audio/subtitles, start paused, and bound how much data a
+        // single keyframe seek may pull in (the player default of 64 MB would be read
+        // ahead after every scrub position).
+        handle.option("aid", "no")
+        handle.option("sid", "no")
+        handle.option("pause", "yes")
+        handle.option("demuxer-max-bytes", "${8 * 1024 * 1024}")
+        handle.option("demuxer-max-back-bytes", "${4 * 1024 * 1024}")
+
+        handle.initialize()
+
+        handle.option("save-position-on-quit", "no")
+        handle.option("force-window", "no")
+        handle.option("idle", "yes")
+        handle.option("keep-open", "always")
+    }
+
+    /**
+     * Loads [data] into mpv with playback paused (mirrors the media-loading part of
+     * `JvmMpvMediampPlayer.setMediaDataImpl`). Never closes [data] — it is owned by the
+     * main player; only the input opened here for stream_cb media is owned by this
+     * decoder. Idempotent: a retry after a failed first-frame wait re-issues loadfile.
+     */
+    suspend fun loadPaused(data: MediaData): Boolean {
+        val target = loadTarget ?: when (data) {
+            is UriMediaData -> {
+                val headers = data.headers.toMutableMap()
+                headers.remove("User-Agent")?.let { handle.option("user-agent", it) }
+                headers.remove("Referer")?.let { handle.option("referrer", it) }
+                val headerFields = headers.entries.joinToString(",") { (key, value) -> "$key: $value" }
+                handle.option("http-header-fields", headerFields)
+                data.uri
+            }
+
+            is SeekableInputMediaData -> {
+                val input = data.createInput(currentCoroutineContext())
+                val registered = try {
+                    handle.registerSeekableInput(input, FRAME_PREVIEW_LOAD_TARGET_PREFIX + data.uri)
+                } catch (t: Throwable) {
+                    input.close()
+                    throw t
+                }
+                openInput = input
+                registered
+            }
+        }.also { loadTarget = it }
+
+        handle.setPropertyBoolean("pause", true)
+        return handle.command("loadfile", target, "replace")
+    }
+
+    fun setRenderUpdateListener(listener: RenderUpdateListener?): Boolean =
+        handle.setRenderUpdateListener(listener)
+
+    /** See [MpvSurfaceRingBackend.setSurfaceConfig]; the preview ring is always headless. */
+    fun requestSurface(width: Int, height: Int): Boolean =
+        ringBackend.setSurfaceConfig(handle.ptr, width, height, 0L)
+
+    /** See [MpvSurfaceRingBackend.readSurfacePixels]. */
+    fun readSurfacePixels(dims: IntArray): IntArray? =
+        ringBackend.readSurfacePixels(handle.ptr, dims)
+
+    override fun close() {
+        try {
+            handle.setRenderUpdateListener(null)
+            ringBackend.setSurfaceConfig(handle.ptr, 0, 0, 0L)
+            ringBackend.destroyRenderContext(handle.ptr)
+        } catch (_: Exception) {
+        }
+        try {
+            handle.destroy()
+        } catch (_: Exception) {
+        }
+        handle.close()
+        try {
+            openInput?.close()
+        } catch (_: Exception) {
+        }
+        openInput = null
+    }
+}

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
@@ -17,6 +17,8 @@ import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.MPVLog
 import org.openani.mediamp.mpv.nAckRetiredBuffersD3D11
@@ -39,6 +41,17 @@ import org.openani.mediamp.mpv.nSetSurfaceConfigD3D11
 import org.openani.mediamp.mpv.nSetSurfaceConfigMacos
 
 internal const val SURFACE_RING_BUFFER_COUNT = 3
+
+/**
+ * The native surface-ring backend for the current host: macOS renders through
+ * Metal/IOSurface (render_macos.mm), Windows through D3D11/D3D12 shared textures
+ * (render_d3d11.cpp). Returns `null` where no render path exists (Linux, TODO).
+ */
+internal fun currentSurfaceRingBackend(): MpvSurfaceRingBackend? = when (hostOs) {
+    OS.MacOS -> MacosSurfaceRingBackend
+    OS.Windows -> D3D11SurfaceRingBackend
+    else -> null
+}
 
 /**
  * Platform half of the native surface-ring render path: the JNI entry points plus how

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
@@ -31,6 +31,8 @@ import org.openani.mediamp.mpv.nGetFrameStateD3D11
 import org.openani.mediamp.mpv.nGetFrameStateMacos
 import org.openani.mediamp.mpv.nHasD3D11Surface
 import org.openani.mediamp.mpv.nHasMetalSurface
+import org.openani.mediamp.mpv.nReadSurfacePixelsD3D11
+import org.openani.mediamp.mpv.nReadSurfacePixelsMacos
 import org.openani.mediamp.mpv.nSaveSurfacePng
 import org.openani.mediamp.mpv.nSaveSurfacePngD3D11
 import org.openani.mediamp.mpv.nSetSurfaceConfigD3D11
@@ -60,6 +62,13 @@ internal interface MpvSurfaceRingBackend {
     fun hasSurface(ptr: Long): Boolean
     fun saveSurfacePng(ptr: Long, path: String): Boolean
 
+    /**
+     * Reads the latest rendered frame as ARGB_8888 pixels (`0xAARRGGBB`, row-major,
+     * top-down), writing `[width, height]` into [dims]. Returns `null` when no frame
+     * is available.
+     */
+    fun readSurfacePixels(ptr: Long, dims: IntArray): IntArray?
+
     fun makeRenderTarget(width: Int, height: Int, texturePtr: Long): BackendRenderTarget
     val wrapColorFormat: SurfaceColorFormat
 }
@@ -76,6 +85,7 @@ internal object MacosSurfaceRingBackend : MpvSurfaceRingBackend {
     override fun ackRetiredBuffers(ptr: Long) = nAckRetiredBuffersMacos(ptr)
     override fun hasSurface(ptr: Long) = nHasMetalSurface(ptr)
     override fun saveSurfacePng(ptr: Long, path: String) = nSaveSurfacePng(ptr, path)
+    override fun readSurfacePixels(ptr: Long, dims: IntArray) = nReadSurfacePixelsMacos(ptr, dims)
 
     override fun makeRenderTarget(width: Int, height: Int, texturePtr: Long): BackendRenderTarget =
         BackendRenderTarget.makeMetal(width, height, texturePtr)
@@ -97,6 +107,7 @@ internal object D3D11SurfaceRingBackend : MpvSurfaceRingBackend {
     override fun ackRetiredBuffers(ptr: Long) = nAckRetiredBuffersD3D11(ptr)
     override fun hasSurface(ptr: Long) = nHasD3D11Surface(ptr)
     override fun saveSurfacePng(ptr: Long, path: String) = nSaveSurfacePngD3D11(ptr, path)
+    override fun readSurfacePixels(ptr: Long, dims: IntArray) = nReadSurfacePixelsD3D11(ptr, dims)
 
     override fun makeRenderTarget(width: Int, height: Int, texturePtr: Long): BackendRenderTarget =
         BackendRenderTarget.makeDirect3D(

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -117,6 +118,96 @@ class MpvFramePreviewTest {
                     assertDominantColor(blue, "blue") { r, _, b -> b > 180 && r < 80 }
                 }
                 assertTrue(elapsed < 5_000, "grab after cancellation storm took ${elapsed}ms")
+            } finally {
+                player.close()
+            }
+        }
+    }
+
+    /**
+     * Regression: seek-landing detection must not require time-pos to end up near the target.
+     * With `absolute+keyframes` the decoder snaps to the previous keyframe; this video has its
+     * only keyframe at t=0, so a request at 4s lands ~4s away from the target. The old check
+     * (|time-pos - target| < 3s) permanently failed for such positions.
+     */
+    @Test
+    fun `long-GOP media - positions far from a keyframe still produce frames`() {
+        if (!prepareOrSkip()) return
+        val video = generateLongGopVideo() ?: run {
+            skip("ffmpeg unavailable or long-GOP video generation failed")
+            return
+        }
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            try {
+                player.setMediaData(UriMediaData(video.absolutePath, emptyMap(), MediaExtraFiles.EMPTY))
+                val preview = assertNotNull(player.features[FramePreview.Key])
+                val frame = assertNotNull(
+                    preview.getPreviewFrame(4_000, 160, 160),
+                    "no frame at 4s on long-GOP media",
+                )
+                assertDominantColor(frame, "red") { r, _, b -> r > 180 && b < 80 }
+            } finally {
+                player.close()
+            }
+        }
+    }
+
+    /**
+     * Contract: frames must fit within the maxWidth/maxHeight of EACH request. The session used
+     * to size its surface from the first request only, so a later smaller request received
+     * oversized frames.
+     */
+    @Test
+    fun `smaller max size in a later request shrinks the frame`() {
+        if (!prepareOrSkip()) return
+        val video = generateColorVideo()!!
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            try {
+                player.setMediaData(UriMediaData(video.absolutePath, emptyMap(), MediaExtraFiles.EMPTY))
+                val preview = assertNotNull(player.features[FramePreview.Key])
+
+                val big = assertNotNull(preview.getPreviewFrame(1_000, 160, 160), "no frame at 160x160")
+                assertTrue(big.width <= 160 && big.height <= 160, "unexpected size ${big.width}x${big.height}")
+
+                val small = assertNotNull(preview.getPreviewFrame(1_000, 64, 64), "no frame at 64x64")
+                assertTrue(
+                    small.width <= 64 && small.height <= 64,
+                    "frame ${small.width}x${small.height} exceeds the requested 64x64 bounds",
+                )
+                assertDominantColor(small, "red") { r, _, b -> r > 180 && b < 80 }
+            } finally {
+                player.close()
+            }
+        }
+    }
+
+    /** Audio-only media must fail fast (no-video detection) and cache the verdict. */
+    @Test
+    fun `audio-only media returns null quickly and caches the result`() {
+        if (!prepareOrSkip()) return
+        val audio = generateAudioOnlyMedia() ?: run {
+            skip("ffmpeg unavailable or audio-only media generation failed")
+            return
+        }
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            try {
+                player.setMediaData(UriMediaData(audio.absolutePath, emptyMap(), MediaExtraFiles.EMPTY))
+                val preview = assertNotNull(player.features[FramePreview.Key])
+
+                val first = kotlin.system.measureTimeMillis {
+                    assertNull(preview.getPreviewFrame(1_000, 160, 160), "audio-only media produced a frame")
+                }
+                // The no-video-track detection kicks in once the demuxer opens the file; it must
+                // not sit out the full 10s first-frame timeout.
+                assertTrue(first < 8_000, "no-video detection took ${first}ms")
+
+                val second = kotlin.system.measureTimeMillis {
+                    assertNull(preview.getPreviewFrame(2_000, 160, 160))
+                }
+                assertTrue(second < 1_000, "no-video verdict should be cached, took ${second}ms")
             } finally {
                 player.close()
             }
@@ -230,13 +321,43 @@ class MpvFramePreviewTest {
         return target
     }
 
-    private fun findFfmpeg(): String? {
-        // The assembled Windows runtime ships ffmpeg.exe next to the natives.
-        System.getProperty("mediamp.mpv.dev.native.dir")
-            ?.let { File(it, "ffmpeg.exe") }
-            ?.takeIf { it.canExecute() }
-            ?.let { return it.absolutePath }
-        return listOf("/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg")
-            .firstOrNull { File(it).canExecute() }
+    /** 5s of solid red with keyframes only at t=0 (keyint 300, scenecut off). */
+    private fun generateLongGopVideo(): File? {
+        val target = File(System.getProperty("java.io.tmpdir"), "mediamp-mpv-frame-preview-longgop.mp4")
+        if (target.isFile && target.length() > 0) return target
+        val ffmpeg = findFfmpeg() ?: return null
+        val process = ProcessBuilder(
+            ffmpeg, "-y",
+            "-f", "lavfi", "-i", "color=c=red:size=640x360:rate=30:duration=5",
+            "-pix_fmt", "yuv420p", "-c:v", "libx264", "-preset", "ultrafast",
+            "-x264-params", "keyint=300:min-keyint=300:scenecut=0",
+            target.absolutePath,
+        ).redirectErrorStream(true).start()
+        process.inputStream.readAllBytes()
+        if (!process.waitFor(60, TimeUnit.SECONDS) || process.exitValue() != 0) return null
+        return target
     }
+
+    /** 3s sine tone, no video track. */
+    private fun generateAudioOnlyMedia(): File? {
+        val target = File(System.getProperty("java.io.tmpdir"), "mediamp-mpv-frame-preview-audio.m4a")
+        if (target.isFile && target.length() > 0) return target
+        val ffmpeg = findFfmpeg() ?: return null
+        val process = ProcessBuilder(
+            ffmpeg, "-y",
+            "-f", "lavfi", "-i", "sine=frequency=440:duration=3",
+            "-c:a", "aac",
+            target.absolutePath,
+        ).redirectErrorStream(true).start()
+        process.inputStream.readAllBytes()
+        if (!process.waitFor(60, TimeUnit.SECONDS) || process.exitValue() != 0) return null
+        return target
+    }
+
+    // Same discovery as MpvMediampPlayerSmokeTest. Deliberately NOT the ffmpeg shipped in
+    // the assembled runtime: that one is an LGPL build without libx264, so it can decode
+    // but not generate the H.264 test videos.
+    private fun findFfmpeg(): String? =
+        listOf("/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg", "ffmpeg", "ffmpeg.exe")
+            .firstOrNull { runCatching { ProcessBuilder(it, "-version").start().waitFor() }.getOrNull() == 0 }
 }

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
@@ -230,7 +230,13 @@ class MpvFramePreviewTest {
         return target
     }
 
-    private fun findFfmpeg(): String? =
-        listOf("/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg")
+    private fun findFfmpeg(): String? {
+        // The assembled Windows runtime ships ffmpeg.exe next to the natives.
+        System.getProperty("mediamp.mpv.dev.native.dir")
+            ?.let { File(it, "ffmpeg.exe") }
+            ?.takeIf { it.canExecute() }
+            ?.let { return it.absolutePath }
+        return listOf("/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg")
             .firstOrNull { File(it).canExecute() }
+    }
 }

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvFramePreviewTest.kt
@@ -280,7 +280,11 @@ class MpvFramePreviewTest {
     }
 
     @OptIn(ExperimentalMediampApi::class)
-    private class FileSeekableInputMediaData(private val file: File) : SeekableInputMediaData {
+    private class FileSeekableInputMediaData(
+        private val file: File,
+        /** Artificial latency per read, to widen decode/seek timing windows in race tests. */
+        private val readDelayMillis: Long = 0,
+    ) : SeekableInputMediaData {
         override val uri: String get() = "test://${file.name}"
         override val extraFiles: MediaExtraFiles get() = MediaExtraFiles.EMPTY
         override val options: List<String> get() = emptyList()
@@ -295,8 +299,10 @@ class MpvFramePreviewTest {
                 override val bytesRemaining: Long get() = fileSize - raf.filePointer
                 override val size: Long get() = fileSize
                 override fun seekTo(position: Long) = raf.seek(position)
-                override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
-                    raf.read(buffer, offset, length)
+                override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+                    if (readDelayMillis > 0) Thread.sleep(readDelayMillis)
+                    return raf.read(buffer, offset, length)
+                }
 
                 override fun close() = raf.close()
             }
@@ -319,6 +325,53 @@ class MpvFramePreviewTest {
         process.inputStream.readAllBytes()
         if (!process.waitFor(60, TimeUnit.SECONDS) || process.exitValue() != 0) return null
         return target
+    }
+
+    /**
+     * Regression (fast-scrub wrong thumbnail): a request following a CANCELLED in-flight
+     * request must return its OWN position's frame. Cancelling the caller does not cancel
+     * mpv's seek, so the previous request's seek/render can still be in flight when the
+     * next request starts; if completion detection attributes that activity to the new
+     * request, it returns the previous position's frame labeled with the new target.
+     *
+     * Note: the misattribution window depends on mpv-internal timing and does not reliably
+     * reproduce in-process even with slowed reads (the demuxer cache absorbs most of the
+     * latency), so this test is a functional guard for the cancel-then-grab sequence rather
+     * than a deterministic reproducer of the race.
+     */
+    @Test
+    fun `frame after a cancelled request matches the new position`() {
+        if (!prepareOrSkip()) return
+        val video = generateColorVideo()!!
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            try {
+                // Slow reads stretch each seek to >100ms so a cancelled request's seek is
+                // reliably still in flight when the next request starts; with instant local
+                // reads the race window is only microseconds wide and the test cannot see it.
+                player.setMediaData(FileSeekableInputMediaData(video, readDelayMillis = 10))
+                val preview = assertNotNull(player.features[FramePreview.Key])
+                // Warm the session so iteration timing is dominated by the seeks themselves.
+                assertNotNull(preview.getPreviewFrame(1_000, 160, 160))
+
+                repeat(8) { i ->
+                    // Seek towards the blue zone and cancel while the seek is in flight;
+                    // vary the cancellation point across iterations.
+                    val job = launch { preview.getPreviewFrame(4_000, 160, 160) }
+                    delay(40L + (i % 4) * 20L)
+                    job.cancel()
+                    job.join()
+
+                    val frame = assertNotNull(
+                        preview.getPreviewFrame(1_000, 160, 160),
+                        "no frame in iteration $i",
+                    )
+                    assertDominantColor(frame, "red (iteration $i)") { r, _, b -> r > 180 && b < 80 }
+                }
+            } finally {
+                player.close()
+            }
+        }
     }
 
     /** 5s of solid red with keyframes only at t=0 (keyint 300, scenecut off). */

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -413,18 +413,6 @@ abstract class JvmMpvMediampPlayer(
      * Used by the frame-preview decoder to mirror the main player's media.
      */
     internal fun currentMediaDataOrNull(): MediaData? = openResource.value?.mediaData
-
-    /**
-     * Loads the media previously set via [setMediaData] into mpv with playback paused,
-     * WITHOUT transitioning the public [playbackState]. mpv decodes and displays the first
-     * frame, then stays paused. Used by the frame-preview decoder instance, which drives
-     * the handle directly and never "plays".
-     */
-    internal fun commandLoadFilePaused(): Boolean {
-        val media = openResource.value ?: return false
-        handle.setPropertyBoolean("pause", true)
-        return handle.command("loadfile", media.loadTarget, "replace")
-    }
 }
 
 /**


### PR DESCRIPTION
## What changed

Two commits, one theme: make the mpv `FramePreview` path lean and correct.

### Commit 1 — direct pixel readback

`MpvFramePreview` extracted each frame by dumping the surface ring to a **temporary PNG** and decoding it back with `ImageIO`. New native `read_surface_pixels()` (exposed as `nReadSurfacePixelsD3D11` / `nReadSurfacePixelsMacos`) copies the latest ring buffer straight into an ARGB_8888 `IntArray` in one atomic JNI call. On Windows the staging-texture readback is shared with `save_surface_png` via `read_frame_argb_locked`, and the PNG encode moved **outside** `render_mutex_`; on macOS the IOSurface BGRA words are read directly (little-endian BGRA == `0xAARRGGBB`).

### Commit 2 — minimal preview decoder + fixes

The preview session was a **full second `MpvMediampPlayer`**: 15 observed properties firing JNI upcalls on every seek, 7 unused feature objects, the full state machine, a 64 MB demuxer cache, plus a recursion-guard hack (`MpvFramePreviewContextMarker`) and a `NonClosingSeekableInputMediaData` wrapper to protect the shared media data. It is now a purpose-built **`MpvPreviewDecoder`**: bare `MPVHandle` + render context + surface ring, no event listener, no observed properties, no features, **8 MB demuxer cache** (a scrub seek no longer reads ahead tens of MB — this was hostile to torrent-backed inputs). Both hacks are deleted; on Linux (no render path) the feature is now absent instead of present-but-always-null.

Grab-path fixes bundled in:

- **Long-GOP media produced no previews at all**: seek completion required `|time-pos − target| < 3s`, but `absolute+keyframes` snaps to the previous keyframe — with `keyint` of 5–10s (common in anime encodes) whole stretches of the timeline permanently returned `null`. Completion is now a `seeking` true→false cycle / position change / fresh render, with a quiet-window fallback.
- **Same-keyframe requests burned a flat 500 ms** waiting for a render that never comes; now skipped when the landed position is unchanged.
- **Contract violation**: the surface was sized by the *first* request's `maxWidth/maxHeight` forever; it is now resized per request, so a later smaller request gets a frame within its bounds.
- **Aspect correctness**: surface size derives from `dwidth/dheight` (rotation/anamorphic corrected), not the coded `width/height`.
- **Startup responsiveness**: the load-and-probe phase was a `NonCancellable` block holding the session mutex for up to 10 s against a cancelled scrub; it is now a shared attempt on the session scope — callers await cancellably, transient failures retry, and **unplayable media (audio-only/corrupt) is detected via the `idle-active` transition and cached** instead of re-burning the 10 s timeout on every hover.

## Verification

⚠️ **Correction to this PR's earlier claim**: `MpvFramePreviewTest` had been *silently self-skipping* on Windows — its ffmpeg discovery only probed Unix paths, and the runtime-bundled ffmpeg found by commit 1's fix turned out to be an LGPL build with **no H.264 encoder**, so test-video generation failed and every test passed vacuously (JUnit reports them as passed, the skip only shows in stderr). The suite's discovery now probes `PATH` like the smoke test, and I verified via per-test timings + absence of skip markers in the JUnit XML that everything genuinely executes.

Current state on Windows (all genuinely executed, 0 skipped, realistic timings):

- `MpvFramePreviewTest` — **6/6**: uri + stream_cb position-color assertions, cancellation storm, **new:** long-GOP (keyint 300, request 4 s from the only keyframe), **new:** per-request shrink to 64×64, **new:** audio-only fast-fail (0.17 s, cached verdict).
- `MpvMediampPlayerSmokeTest` — **4/4**, including the screenshot pixel verification covering the refactored Windows `save_surface_png`.

The smoke tests were genuinely passing all along (they use `PATH` ffmpeg), so commit 1's Windows PNG-path refactor was covered; the frame-preview pixel path is now *actually* covered too.

## Notes for reviewers

- macOS native code compiles on CI only (authored on Windows); it mirrors the existing `save_surface_png` patterns.
- `MpvPreviewDecoder.configure()` mirrors `JvmMpvMediampPlayer.configureNativeHandle` minus playback-only options (ao, volume-max, input bindings) — flagged inline to keep the two in sync.
- The unplayable-detection assumes torrent-like `SeekableInput`s **block** on unavailable data rather than erroring (mediamp's documented contract); an input that errors during demuxer open would be cached as unplayable until the media changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)