### PR TITLE
build: layered Gradle build cache for the ffmpeg/mpv native builds

### DIFF
--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegAppleTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegAppleTaskTypes.kt
@@ -16,15 +16,20 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import java.io.File
 import javax.inject.Inject
 
+@CacheableTask
 abstract class FfmpegAppleFrameworkTask : DefaultTask() {
     @get:Input
     abstract val targetName: Property<String>
@@ -35,16 +40,35 @@ abstract class FfmpegAppleFrameworkTask : DefaultTask() {
     @get:Input
     abstract val ffmpegLibNames: ListProperty<String>
 
-    @get:InputDirectory
+    /**
+     * Configure-produced working directory (config.mak and the compile cwd). Always
+     * present locally because configure runs in every build that needs this task; its
+     * cache-relevant content is captured by [toolchainConfigSummary].
+     */
+    @get:Internal
     abstract val buildDirPath: DirectoryProperty
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val installDir: DirectoryProperty
 
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val fftoolsObjectsDir: DirectoryProperty
+
+    /** See [sanitizedFfmpegToolchainSummary]. */
+    @get:Input
+    abstract val toolchainConfigSummary: Property<String>
+
+    @get:Input
+    abstract val toolchainFingerprint: Property<String>
+
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val wrapperSource: RegularFileProperty
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val publicHeaderSource: RegularFileProperty
 
     @get:OutputDirectory
@@ -83,6 +107,7 @@ abstract class FfmpegAppleFrameworkTask : DefaultTask() {
             frameworkName = frameworkNameValue,
             wrapperSource = wrapperSource.get().asFile,
             buildDir = buildDir,
+            fftoolsDir = fftoolsObjectsDir.get().asFile,
             installDir = installDirFile,
             frameworkBinary = frameworkDir.resolve(frameworkNameValue),
             ffmpegLibNames = ffmpegLibNames.get(),
@@ -95,9 +120,11 @@ abstract class FfmpegAppleXcframeworkTask : DefaultTask() {
     abstract val frameworkName: Property<String>
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val iosDeviceFramework: DirectoryProperty
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val iosSimulatorFramework: DirectoryProperty
 
     @get:OutputDirectory
@@ -136,6 +163,7 @@ private fun buildAppleFrameworkBinary(
     frameworkName: String,
     wrapperSource: File,
     buildDir: File,
+    fftoolsDir: File,
     installDir: File,
     frameworkBinary: File,
     ffmpegLibNames: List<String>,
@@ -145,10 +173,10 @@ private fun buildAppleFrameworkBinary(
     }
 
     val config = readFfmpegConfig(buildDir.resolve("ffbuild/config.mak"))
-    val fftoolsDir = buildDir.resolve("fftools")
     val fftoolsObjects = fftoolsDir.walkTopDown()
         .filter { it.isFile && it.extension == "o" }
         .map(File::getAbsolutePath)
+        .sorted()
         .toList()
     require(fftoolsObjects.isNotEmpty()) {
         "No fftools object files found in $fftoolsDir while building $frameworkName."

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegBuildTasks.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegBuildTasks.kt
@@ -13,6 +13,8 @@ import nativebuild.PatchedSourceTemplateSpec
 import nativebuild.registerPatchedSourceTemplate
 import nativebuild.resolveMsys2Dir
 import nativebuild.resolveNdkDir
+import nativebuild.toolchainFingerprint
+import org.gradle.api.JavaVersion
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
@@ -105,9 +107,12 @@ private fun registerFfmpegTasks(
     val project = context.project
     val buildDir = project.layout.buildDirectory.dir("ffmpeg/${target.name}")
     val installDir = project.layout.buildDirectory.dir("ffmpeg/${target.name}/install")
+    val fftoolsDir = buildDir.map { it.dir("fftools") }
     val configStamp = project.layout.buildDirectory.file("ffmpeg/${target.name}/.config_stamp")
     val buildStamp = project.layout.buildDirectory.file("ffmpeg/${target.name}/.build_stamp")
     val msys2Dir = if (context.hostOs == Os.Windows) context.project.resolveMsys2Dir() else null
+    val toolchainFingerprint = project.toolchainFingerprint(target.toolchainProbes)
+    val toolchainConfigSummary = buildDir.map { sanitizedFfmpegToolchainSummary(it.asFile) }
 
     val configureTask = project.tasks.register<FfmpegConfigureTask>("ffmpegConfigure${target.name}") {
         group = "ffmpeg"
@@ -119,6 +124,7 @@ private fun registerFfmpegTasks(
         envVars.set(target.env)
         hostOsName.set(context.hostOs.name)
         buildDirPath.set(buildDir)
+        stagedSourceDir.set(buildDir.map { it.dir("source") })
         installPrefix.set(installDir.map { it.asFile.absolutePath })
         this.configStamp.set(configStamp)
         if (msys2Dir != null) {
@@ -131,13 +137,16 @@ private fun registerFfmpegTasks(
         group = "ffmpeg"
         description = "Build FFmpeg for ${target.name}"
         dependsOn(configureTask)
+        stagedSourceDir.set(configureTask.flatMap { it.stagedSourceDir })
         this.configStamp.set(configStamp)
         shell.set(target.shell)
         envVars.set(target.env)
         makeJobs.set(context.makeJobs)
         hostOsName.set(context.hostOs.name)
+        this.toolchainFingerprint.set(toolchainFingerprint)
         buildDirPath.set(buildDir)
-        installDirPath.set(installDir.map { it.asFile.absolutePath })
+        this.installDir.set(installDir)
+        fftoolsObjectsDir.set(fftoolsDir)
         this.buildStamp.set(buildStamp)
     }
 
@@ -153,7 +162,11 @@ private fun registerFfmpegTasks(
         libPrefix.set(target.libPrefix)
         ffmpegLibNames.set(context.ffmpegLibNames)
         buildDirPath.set(buildDir)
-        this.installDir.set(installDir)
+        this.installDir.set(buildTask.flatMap { it.installDir })
+        fftoolsObjectsDir.set(buildTask.flatMap { it.fftoolsObjectsDir })
+        this.toolchainConfigSummary.set(toolchainConfigSummary)
+        this.toolchainFingerprint.set(toolchainFingerprint)
+        jdkMajorVersion.set(JavaVersion.current().majorVersion)
         this.outputDir.set(project.layout.buildDirectory.dir("ffmpeg-output/${target.name}"))
         if (target.jniWrapperName != null) {
             jniWrapperName.set(target.jniWrapperName)
@@ -184,7 +197,10 @@ private fun registerFfmpegTasks(
             frameworkName.set(context.appleFrameworkName)
             ffmpegLibNames.set(context.ffmpegLibNames)
             buildDirPath.set(buildDir)
-            this.installDir.set(installDir)
+            this.installDir.set(buildTask.flatMap { it.installDir })
+            fftoolsObjectsDir.set(buildTask.flatMap { it.fftoolsObjectsDir })
+            this.toolchainConfigSummary.set(toolchainConfigSummary)
+            this.toolchainFingerprint.set(toolchainFingerprint)
             wrapperSource.set(context.commandWrapperSource)
             publicHeaderSource.set(context.applePublicHeaderSource)
             outputDir.set(project.layout.buildDirectory.dir("apple-framework/${target.name}/${context.appleFrameworkName}.framework"))

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
@@ -34,6 +34,13 @@ internal data class FfmpegBuildTarget(
     val libPrefix: String = "lib",
     val msys2Packages: List<String> = emptyList(),
 
+    /**
+     * Version probe command lines whose combined output identifies the toolchain for the
+     * build cache (see [nativebuild.ToolchainFingerprintValueSource]). Probes must be
+     * runnable directly by the JVM (native paths, no MSYS path forms).
+     */
+    val toolchainProbes: List<List<String>> = emptyList(),
+
     // ---- assemble-stage behavior ----
 
     /** JVM JNI wrapper library file name, or null when the target has no JVM runtime (iOS). */
@@ -196,19 +203,8 @@ internal fun FfmpegBuildContext.hostWindowsTarget(): FfmpegBuildTarget = when (h
     else -> windowsX64Target()
 }
 
-private fun FfmpegBuildContext.windowsX64Target(): FfmpegBuildTarget = FfmpegBuildTarget(
-    name = "WindowsX64",
-    configureFlags = listOf(
-        "--arch=x86_64",
-        "--target-os=mingw32",
-        "--cc=${msys2Dir.resolve("ucrt64/bin/gcc.exe").absolutePath.toMsysPath()}",
-        "--cxx=${msys2Dir.resolve("ucrt64/bin/g++.exe").absolutePath.toMsysPath()}",
-    ) + opensslHttpTlsFlags + windowsD3d11vaFlags,
-    env = mapOf("MSYSTEM" to "UCRT64"),
-    shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
-    libExtension = "dll",
-    libPrefix = "",
-    msys2Packages = listOf(
+private fun FfmpegBuildContext.windowsX64Target(): FfmpegBuildTarget {
+    val msys2Packages = listOf(
         "make",
         "diffutils",
         "pkg-config",
@@ -216,26 +212,32 @@ private fun FfmpegBuildContext.windowsX64Target(): FfmpegBuildTarget = FfmpegBui
         "mingw-w64-ucrt-x86_64-gcc",
         "mingw-w64-ucrt-x86_64-nasm",
         "mingw-w64-ucrt-x86_64-openssl",
-    ),
-    jniWrapperName = "ffmpegkitjni.dll",
-    jniWrapperExtraLibs = listOf("-lstdc++"),
-    msysSubsystem = "ucrt64",
-    collectWindowsRuntime = true,
-)
+    )
+    return FfmpegBuildTarget(
+        name = "WindowsX64",
+        configureFlags = listOf(
+            "--arch=x86_64",
+            "--target-os=mingw32",
+            "--cc=${msys2Dir.resolve("ucrt64/bin/gcc.exe").absolutePath.toMsysPath()}",
+            "--cxx=${msys2Dir.resolve("ucrt64/bin/g++.exe").absolutePath.toMsysPath()}",
+        ) + opensslHttpTlsFlags + windowsD3d11vaFlags,
+        env = mapOf("MSYSTEM" to "UCRT64"),
+        shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
+        libExtension = "dll",
+        libPrefix = "",
+        msys2Packages = msys2Packages,
+        toolchainProbes = listOf(
+            listOf(msys2Dir.resolve("usr/bin/pacman.exe").absolutePath, "-Q") + msys2Packages,
+        ),
+        jniWrapperName = "ffmpegkitjni.dll",
+        jniWrapperExtraLibs = listOf("-lstdc++"),
+        msysSubsystem = "ucrt64",
+        collectWindowsRuntime = true,
+    )
+}
 
-private fun FfmpegBuildContext.windowsArm64Target(): FfmpegBuildTarget = FfmpegBuildTarget(
-    name = "WindowsArm64",
-    configureFlags = listOf(
-        "--arch=aarch64",
-        "--target-os=mingw32",
-        "--cc=${msys2Dir.resolve("clangarm64/bin/clang.exe").absolutePath.toMsysPath()}",
-        "--cxx=${msys2Dir.resolve("clangarm64/bin/clang++.exe").absolutePath.toMsysPath()}",
-    ) + opensslHttpTlsFlags,
-    env = mapOf("MSYSTEM" to "CLANGARM64"),
-    shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
-    libExtension = "dll",
-    libPrefix = "",
-    msys2Packages = listOf(
+private fun FfmpegBuildContext.windowsArm64Target(): FfmpegBuildTarget {
+    val msys2Packages = listOf(
         "make",
         "diffutils",
         "pkg-config",
@@ -244,12 +246,29 @@ private fun FfmpegBuildContext.windowsArm64Target(): FfmpegBuildTarget = FfmpegB
         "mingw-w64-clang-aarch64-nasm",
         "mingw-w64-clang-aarch64-openssl",
         "mingw-w64-clang-aarch64-pkgconf",
-    ),
-    jniWrapperName = "ffmpegkitjni.dll",
-    jniWrapperExtraLibs = listOf("-lstdc++"),
-    msysSubsystem = "clangarm64",
-    collectWindowsRuntime = true,
-)
+    )
+    return FfmpegBuildTarget(
+        name = "WindowsArm64",
+        configureFlags = listOf(
+            "--arch=aarch64",
+            "--target-os=mingw32",
+            "--cc=${msys2Dir.resolve("clangarm64/bin/clang.exe").absolutePath.toMsysPath()}",
+            "--cxx=${msys2Dir.resolve("clangarm64/bin/clang++.exe").absolutePath.toMsysPath()}",
+        ) + opensslHttpTlsFlags,
+        env = mapOf("MSYSTEM" to "CLANGARM64"),
+        shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
+        libExtension = "dll",
+        libPrefix = "",
+        msys2Packages = msys2Packages,
+        toolchainProbes = listOf(
+            listOf(msys2Dir.resolve("usr/bin/pacman.exe").absolutePath, "-Q") + msys2Packages,
+        ),
+        jniWrapperName = "ffmpegkitjni.dll",
+        jniWrapperExtraLibs = listOf("-lstdc++"),
+        msysSubsystem = "clangarm64",
+        collectWindowsRuntime = true,
+    )
+}
 
 // ---------------------------------------------------------------------------------------
 // Linux
@@ -262,6 +281,11 @@ internal fun FfmpegBuildContext.linuxX64Target(): FfmpegBuildTarget = FfmpegBuil
         "--target-os=linux",
     ) + opensslHttpTlsFlags + linuxRuntimeSearchPathFlags,
     libExtension = "so",
+    toolchainProbes = listOf(
+        listOf("cc", "--version"),
+        listOf("nasm", "--version"),
+        listOf("pkg-config", "--modversion", "openssl"),
+    ),
     jniWrapperName = "libffmpegkitjni.so",
 )
 
@@ -286,6 +310,9 @@ private fun macosTarget(name: String, arch: String): FfmpegBuildTarget = FfmpegB
         "--extra-ldflags=-arch $arch -mmacosx-version-min=12.0",
     ) + secureTransportHttpTlsFlags + macosVideotoolboxFlags,
     libExtension = "dylib",
+    toolchainProbes = listOf(
+        listOf("clang", "--version"),
+    ),
     jniWrapperName = "libffmpegkitjni.dylib",
     jniWrapperLinkFlags = listOf("-dynamiclib", "-Wl,-install_name,@loader_path/libffmpegkitjni.dylib"),
     rewriteAppleInstallNames = true,
@@ -320,6 +347,10 @@ private fun FfmpegBuildContext.iosTarget(
     ) + appleHostToolFlags + secureTransportHttpTlsFlags,
     shell = "bash",
     libExtension = "a",
+    toolchainProbes = listOf(
+        listOf("xcrun", "--sdk", sdk, "clang", "--version"),
+        listOf("xcrun", "--sdk", sdk, "--show-sdk-version"),
+    ),
     jniWrapperName = null,
     rewriteAppleInstallNames = true,
     bundleFfmpegExecutable = false,
@@ -371,11 +402,15 @@ internal fun FfmpegBuildContext.androidTarget(abi: AndroidAbi): FfmpegBuildTarge
         else -> emptyList()
     }
 
+    // .cmd wrappers need a shell on Windows; probe failures degrade to a stable marker.
+    val clangProbe = if (hostOs == Os.Windows) listOf("cmd", "/c", cc, "--version") else listOf(cc, "--version")
+
     return FfmpegBuildTarget(
         name = androidTargetName(abi),
         libExtension = "so",
         shell = if (hostOs == Os.Windows) msys2Dir.resolve("usr/bin/bash.exe").absolutePath else "bash",
         env = if (hostOs == Os.Windows) mapOf("MSYSTEM" to "UCRT64") else emptyMap(),
+        toolchainProbes = listOf(clangProbe),
         configureFlags = listOf(
             // Android keeps network disabled until a cross-compiled TLS backend
             // is wired in for this target family.

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTaskTypes.kt
@@ -3,11 +3,14 @@ package ffmpeg
 import nativebuild.copyTreeRecursively
 import nativebuild.isWindowsSystemLibrary
 import nativebuild.jniIncludeFlags
+import nativebuild.makePkgConfigRelocatable
 import nativebuild.pathForShell
 import nativebuild.parseWindowsImportedDllNames
 import nativebuild.recreateDirectory
 import nativebuild.resolveWindowsObjdump
 import nativebuild.restoreExecutablePermissions
+import nativebuild.rewriteMachOToLoaderPath
+import nativebuild.sanitizeAbsolutePaths
 import nativebuild.shellQuote
 import nativebuild.toMsysPath
 import org.gradle.api.DefaultTask
@@ -17,9 +20,11 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
@@ -30,6 +35,12 @@ import org.gradle.process.ExecOperations
 import java.io.File
 import javax.inject.Inject
 
+/**
+ * Stages the patched source template into the target build directory and runs
+ * `./configure`. Deliberately NOT cacheable: its interesting product is the whole staged
+ * build tree (hundreds of MB) which is cheap to recreate locally but expensive to store;
+ * the cache boundary is [FfmpegBuildTask], whose outputs are the compiled artifacts.
+ */
 abstract class FfmpegConfigureTask : DefaultTask() {
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -47,17 +58,31 @@ abstract class FfmpegConfigureTask : DefaultTask() {
     @get:Input
     abstract val hostOsName: Property<String>
 
-    @get:OutputDirectory
+    /**
+     * Whole target build directory. Internal on purpose: configure only owns
+     * [stagedSourceDir] and the generated config files; `make` (the build task) writes
+     * its objects and the install tree in here too, and declaring the whole directory as
+     * an output would make the two tasks' outputs overlap, which disables build caching.
+     */
+    @get:Internal
     abstract val buildDirPath: DirectoryProperty
 
+    /** The staged FFmpeg source tree, `<buildDir>/source`. */
+    @get:OutputDirectory
+    abstract val stagedSourceDir: DirectoryProperty
+
+    /**
+     * Absolute install prefix. Declared as an input so that moving/copying a worktree
+     * reruns configure: the generated config.mak embeds absolute paths.
+     */
     @get:Input
     abstract val installPrefix: Property<String>
 
     @get:OutputFile
     abstract val configStamp: RegularFileProperty
 
-    @get:InputDirectory
-    @get:Optional
+    /** Tool location, not content input: versions are captured by the toolchain fingerprint. */
+    @get:Internal
     abstract val msys2Dir: DirectoryProperty
 
     @get:Input
@@ -117,18 +142,17 @@ abstract class FfmpegConfigureTask : DefaultTask() {
         val buildDirShellPath = if (hostOs == "Windows") buildDir.absolutePath.toMsysPath() else buildDir.absolutePath
         val flagsStr = allFlags.joinToString(" ") { flag -> if (' ' in flag) "'$flag'" else flag }
 
-        val configureCommand = if (hostOs == "Windows") {
-            "cd '$buildDirShellPath' && bash '$configurePath' $flagsStr"
-        } else {
-            "cd '$buildDirShellPath' && bash '$configurePath' $flagsStr"
-        }
+        val configureCommand = "cd '$buildDirShellPath' && bash '$configurePath' $flagsStr"
 
         execOperations.exec {
             commandLine(shell.get(), "-l", "-c", configureCommand)
             environment(envVars.get())
         }
 
-        configStamp.get().asFile.writeText(allFlags.joinToString("\n"))
+        // The stamp feeds the build task's cache key, so it must not contain the
+        // worktree-specific --prefix flag; the remaining flags may reference machine-level
+        // tool locations (MSYS2, NDK), which is acceptable.
+        configStamp.get().asFile.writeText(configureFlags.get().joinToString("\n"))
     }
 
     private fun copySourceTree(src: File, dst: File) {
@@ -141,8 +165,23 @@ abstract class FfmpegConfigureTask : DefaultTask() {
     }
 }
 
+/**
+ * Runs `make && make install` — the expensive step and therefore the primary build-cache
+ * boundary (layer 1). The cache key is the patched source content, the configure flags,
+ * the target environment and the toolchain fingerprint; the cached outputs are the
+ * install prefix plus the fftools object files that the assemble task links the JNI
+ * wrapper against.
+ */
+@CacheableTask
 abstract class FfmpegBuildTask : DefaultTask() {
+    /** Patched source content — the real "what are we building" cache key input. */
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val stagedSourceDir: DirectoryProperty
+
+    /** Configure flags as written by [FfmpegConfigureTask] (without the absolute prefix). */
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val configStamp: RegularFileProperty
 
     @get:Input
@@ -151,17 +190,31 @@ abstract class FfmpegBuildTask : DefaultTask() {
     @get:Input
     abstract val envVars: MapProperty<String, String>
 
-    @get:Input
+    /** Parallelism is machine-specific and must not affect the cache key. */
+    @get:Internal
     abstract val makeJobs: Property<Int>
 
     @get:Input
     abstract val hostOsName: Property<String>
 
-    @get:InputDirectory
+    /** See [nativebuild.ToolchainFingerprintValueSource]. */
+    @get:Input
+    abstract val toolchainFingerprint: Property<String>
+
+    /** Working directory prepared by configure; scratch state, not an input or output. */
+    @get:Internal
     abstract val buildDirPath: DirectoryProperty
 
-    @get:Input
-    abstract val installDirPath: Property<String>
+    @get:OutputDirectory
+    abstract val installDir: DirectoryProperty
+
+    /**
+     * `<buildDir>/fftools` object files. Declared as an output so a cache hit still
+     * provides everything [FfmpegAssembleTask] needs to link the JNI wrapper without
+     * rerunning make.
+     */
+    @get:OutputDirectory
+    abstract val fftoolsObjectsDir: DirectoryProperty
 
     @get:OutputFile
     abstract val buildStamp: RegularFileProperty
@@ -172,51 +225,42 @@ abstract class FfmpegBuildTask : DefaultTask() {
     @TaskAction
     fun run() {
         val buildDir = buildDirPath.get().asFile
-        val installDirFile = File(installDirPath.get())
+        val installDirFile = installDir.get().asFile
+        require(buildDir.resolve("ffbuild/config.mak").isFile) {
+            "FFmpeg build directory at ${buildDir.absolutePath} is not configured. " +
+                "Run the matching ffmpegConfigure task first."
+        }
         val buildDirShellPath = buildDir.absolutePath
         execOperations.exec {
             commandLine(shell.get(), "-l", "-c", "cd '$buildDirShellPath' && make -j${makeJobs.get()} && make install")
             environment(envVars.get())
         }
-        rewritePkgConfigPaths(installDirFile, hostOsName.get(), logger)
+        makePkgConfigRelocatable(installDirFile, logger)
         buildStamp.get().asFile.writeText(System.currentTimeMillis().toString())
     }
 }
 
-private fun rewritePkgConfigPaths(
-    installDir: File,
-    hostOs: String,
-    logger: Logger,
-) {
-    if (hostOs != "Windows") return
-
-    val pkgConfigDir = installDir.resolve("lib/pkgconfig")
-    if (!pkgConfigDir.isDirectory) return
-
-    val msysPrefix = installDir.absolutePath.toMsysPath()
-    val nativePrefix = installDir.absolutePath.replace("\\", "/")
-    var rewrittenFiles = 0
-
-    pkgConfigDir.listFiles()
-        ?.filter { it.isFile && it.extension == "pc" }
-        .orEmpty()
-        .forEach { pcFile ->
-            val original = pcFile.readText()
-            val rewritten = original.replace(msysPrefix, nativePrefix)
-            if (rewritten != original) {
-                pcFile.writeText(rewritten)
-                rewrittenFiles += 1
-            }
-        }
-
-    if (rewrittenFiles > 0) {
-        logger.lifecycle(
-            "Rewrote $rewrittenFiles FFmpeg pkg-config file(s) under ${pkgConfigDir.absolutePath} " +
-                "to use native Windows paths.",
-        )
-    }
+/**
+ * Computes a relocatable summary of the toolchain configuration recorded in
+ * `ffbuild/config.mak`. Used as a cache key input by the assemble/framework tasks in
+ * place of the raw file, which embeds worktree-absolute paths and would defeat
+ * cross-worktree cache hits.
+ */
+internal fun sanitizedFfmpegToolchainSummary(buildDir: File): String {
+    val configFile = buildDir.resolve("ffbuild/config.mak")
+    if (!configFile.isFile) return "config.mak missing"
+    val config = readFfmpegConfig(configFile)
+    val summary = listOf("CC", "CPPFLAGS", "CFLAGS", "LDFLAGS", "EXTRALIBS")
+        .joinToString("\n") { key -> "$key=${expandMakeVariables(config[key].orEmpty(), config)}" }
+    return sanitizeAbsolutePaths(summary, listOf(buildDir))
 }
 
+/**
+ * Assembles the runtime layout and links the `ffmpegkitjni` wrapper — build-cache
+ * layer 2: keyed on the JNI wrapper sources plus the layer-1 outputs, so editing the JNI
+ * code only relinks and never invalidates the FFmpeg compile.
+ */
+@CacheableTask
 abstract class FfmpegAssembleTask : DefaultTask() {
     @get:Input
     abstract val targetName: Property<String>
@@ -230,11 +274,33 @@ abstract class FfmpegAssembleTask : DefaultTask() {
     @get:Input
     abstract val ffmpegLibNames: ListProperty<String>
 
-    @get:InputDirectory
+    /**
+     * Configure-produced working directory (config.mak, staged source for includes, and
+     * the cwd of the wrapper compile). Always present locally because configure runs in
+     * every build that needs this task; its cache-relevant content is captured by
+     * [toolchainConfigSummary] instead.
+     */
+    @get:Internal
     abstract val buildDirPath: DirectoryProperty
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val installDir: DirectoryProperty
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val fftoolsObjectsDir: DirectoryProperty
+
+    /** See [sanitizedFfmpegToolchainSummary]. */
+    @get:Input
+    abstract val toolchainConfigSummary: Property<String>
+
+    @get:Input
+    abstract val toolchainFingerprint: Property<String>
+
+    /** The JNI wrapper compiles against the Gradle JVM's JNI headers. */
+    @get:Input
+    abstract val jdkMajorVersion: Property<String>
 
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
@@ -268,15 +334,20 @@ abstract class FfmpegAssembleTask : DefaultTask() {
     abstract val bundleFfmpegExecutable: Property<Boolean>
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:Optional
     abstract val commandWrapperSource: RegularFileProperty
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:Optional
     abstract val jniWrapperSource: RegularFileProperty
 
-    @get:InputDirectory
-    @get:Optional
+    /**
+     * Tool location for the DLL collection step. Not a content input: the relevant
+     * package versions are captured by [toolchainFingerprint].
+     */
+    @get:Internal
     abstract val msys2Dir: DirectoryProperty
 
     @get:Inject
@@ -320,6 +391,7 @@ abstract class FfmpegAssembleTask : DefaultTask() {
                 commandWrapperSource = commandWrapperSource.get().asFile,
                 jniWrapperSource = jniWrapperSource.get().asFile,
                 buildDir = buildDirFile,
+                fftoolsDir = fftoolsObjectsDir.get().asFile,
                 installDir = installDirFile,
                 outputDir = outputDirFile,
                 msys2Dir = msys2Dir.orNull?.asFile,
@@ -346,10 +418,18 @@ abstract class FfmpegAssembleTask : DefaultTask() {
         }
 
         if (rewriteAppleInstallNames.get()) {
-            rewriteAppleInstallNames(
+            val bundledDylibs = outputDirFile.listFiles()
+                ?.filter { it.isFile && it.name.endsWith(".dylib") }
+                .orEmpty()
+            val machOFiles = buildList {
+                addAll(bundledDylibs)
+                val ffmpegBinary = outputDirFile.resolve("ffmpeg")
+                if (ffmpegBinary.exists()) add(ffmpegBinary)
+            }
+            rewriteMachOToLoaderPath(
                 execOperations = execOperations,
-                installDir = installDirFile,
-                outputDir = outputDirFile,
+                machOFiles = machOFiles,
+                bundledLibraryNames = bundledDylibs.map(File::getName).toSet(),
             )
         }
 
@@ -388,6 +468,7 @@ private fun buildJvmJniWrapper(
     commandWrapperSource: File,
     jniWrapperSource: File,
     buildDir: File,
+    fftoolsDir: File,
     installDir: File,
     outputDir: File,
     msys2Dir: File?,
@@ -401,10 +482,10 @@ private fun buildJvmJniWrapper(
 
     val config = readFfmpegConfig(buildDir.resolve("ffbuild/config.mak"))
     val wrapperOut = buildDir.resolve(wrapperName)
-    val fftoolsDir = buildDir.resolve("fftools")
     val fftoolsObjects = fftoolsDir.walkTopDown()
         .filter { it.isFile && it.extension == "o" }
         .map(File::getAbsolutePath)
+        .sorted()
         .toList()
     require(fftoolsObjects.isNotEmpty()) {
         "No fftools object files found in $fftoolsDir while building $wrapperName."
@@ -434,14 +515,11 @@ private fun buildJvmJniWrapper(
         .onEach { require(it.isDirectory) { "FFmpeg include directory not found at ${it.absolutePath}" } }
         .joinToString(" ") { "-I${shellQuote(pathForShell(it, windowsMsys))}" }
     val linkerMode = linkFlags.joinToString(" ")
+    // Link against the install prefix rather than the make build tree: the install dir is
+    // a declared (cacheable) output of the build task, so this also works when the FFmpeg
+    // compile was restored from the build cache and the make tree never existed locally.
     val linkLibraries = buildString {
-        append("-L${shellQuote(pathForShell(buildDir.resolve("libavdevice"), windowsMsys))} ")
-        append("-L${shellQuote(pathForShell(buildDir.resolve("libavfilter"), windowsMsys))} ")
-        append("-L${shellQuote(pathForShell(buildDir.resolve("libavformat"), windowsMsys))} ")
-        append("-L${shellQuote(pathForShell(buildDir.resolve("libavcodec"), windowsMsys))} ")
-        append("-L${shellQuote(pathForShell(buildDir.resolve("libswresample"), windowsMsys))} ")
-        append("-L${shellQuote(pathForShell(buildDir.resolve("libswscale"), windowsMsys))} ")
-        append("-L${shellQuote(pathForShell(buildDir.resolve("libavutil"), windowsMsys))} ")
+        append("-L${shellQuote(pathForShell(installDir.resolve("lib"), windowsMsys))} ")
         append("-lavdevice -lavfilter -lavformat -lavcodec -lswresample -lswscale -lavutil -lm -pthread")
         extraLibs.forEach { append(" $it") }
     }
@@ -480,38 +558,6 @@ private fun buildJvmJniWrapper(
 
     wrapperOut.copyTo(outputDir.resolve(wrapperName), overwrite = true)
     logger.info("Built JVM FFmpeg JNI wrapper: $wrapperOut")
-}
-
-private fun rewriteAppleInstallNames(
-    execOperations: ExecOperations,
-    installDir: File,
-    outputDir: File,
-) {
-    val copiedDylibs = outputDir.listFiles()?.filter { it.isFile && it.name.endsWith(".dylib") }.orEmpty()
-    val machOFiles = buildList {
-        addAll(copiedDylibs)
-        val ffmpegBinary = outputDir.resolve("ffmpeg")
-        if (ffmpegBinary.exists()) add(ffmpegBinary)
-    }
-    val installNameMap = copiedDylibs.associateBy(
-        keySelector = { installDir.resolve("lib/${it.name}").absolutePath },
-        valueTransform = { "@loader_path/${it.name}" },
-    )
-
-    copiedDylibs.forEach { dylib ->
-        execOperations.exec {
-            commandLine("xcrun", "install_name_tool", "-id", "@loader_path/${dylib.name}", dylib.absolutePath)
-        }
-    }
-
-    machOFiles.forEach { machO ->
-        installNameMap.forEach { (oldPath, newPath) ->
-            execOperations.exec {
-                commandLine("xcrun", "install_name_tool", "-change", oldPath, newPath, machO.absolutePath)
-                isIgnoreExitValue = true
-            }
-        }
-    }
 }
 
 internal fun readFfmpegConfig(configFile: File): Map<String, String> {

--- a/buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt
@@ -7,6 +7,9 @@ import nativebuild.PrepareSourceTreeTask
 import nativebuild.registerPatchedSourceTemplate
 import nativebuild.resolveMsys2Dir
 import nativebuild.resolveNdkDir
+import nativebuild.sanitizeAbsolutePaths
+import nativebuild.toolchainFingerprint
+import org.gradle.api.JavaVersion
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
@@ -104,6 +107,8 @@ private fun registerMpvTasks(
         return previousTargetTask
     }
     val msys2Dir = if (context.hostOs == Os.Windows) context.project.resolveMsys2Dir() else null
+    val toolchainFingerprint = project.toolchainFingerprint(target.toolchainProbes)
+    val jniToolchainFingerprint = project.toolchainFingerprint(target.jni.versionProbes)
 
     val configureTask = project.tasks.register<MpvConfigureTask>("mpvConfigure${target.name}") {
         group = "mpv"
@@ -121,6 +126,7 @@ private fun registerMpvTasks(
         wrapFiles.set(target.wrapFiles)
         msys2Packages.set(target.msys2Packages)
         buildDirPath.set(buildDir)
+        stagedSourceDir.set(buildDir.map { it.dir("source") })
         this.configStamp.set(configStamp)
         target.androidAbi?.let { crossFileContent.set(context.androidCrossFileContent(it)) }
         if (msys2Dir != null) {
@@ -132,11 +138,23 @@ private fun registerMpvTasks(
         group = "mpv"
         description = "Build mpv for ${target.name}"
         dependsOn(configureTask)
+        stagedSourceDir.set(configureTask.flatMap { it.stagedSourceDir })
+        this.ffmpegInstallDir.set(ffmpegInstallDir)
         this.configStamp.set(configStamp)
         shell.set(target.shell)
         envVars.set(target.env)
         hostOsName.set(context.hostOs.name)
+        this.toolchainFingerprint.set(toolchainFingerprint)
+        target.androidAbi?.let { abi ->
+            crossFileFingerprint.set(
+                sanitizeAbsolutePaths(
+                    context.androidCrossFileContent(abi),
+                    listOf(project.rootProject.projectDir),
+                ),
+            )
+        }
         buildDirPath.set(buildDir)
+        installDir.set(buildDir.map { it.dir("install") })
         this.buildStamp.set(buildStamp)
         if (target.androidAbi != null) {
             // Cross builds configure prefix=/ and install via --destdir (see MpvConfigureTask).
@@ -150,11 +168,13 @@ private fun registerMpvTasks(
         dependsOn(buildTask)
         targetName.set(target.name)
         sourceDir.set(project.layout.projectDirectory.dir("src/cpp"))
-        mpvInstallDir.set(buildDir.map { it.dir("install") })
+        mpvInstallDir.set(buildTask.flatMap { it.installDir })
         this.ffmpegInstallDir.set(ffmpegInstallDir)
         shell.set(target.shell)
         envVars.set(target.env)
         hostOsName.set(context.hostOs.name)
+        this.toolchainFingerprint.set(jniToolchainFingerprint)
+        jdkMajorVersion.set(JavaVersion.current().majorVersion)
         compilerCommand.set(target.jni.compilerCommand)
         compilerArgs.set(target.jni.compilerArgs)
         linkerArgs.set(target.jni.linkerArgs)
@@ -175,7 +195,7 @@ private fun registerMpvTasks(
             mustRunAfter(previousTargetTask)
         }
         targetName.set(target.name)
-        installDir.set(buildDir.map { it.dir("install") })
+        installDir.set(buildTask.flatMap { it.installDir })
         this.ffmpegInstallDir.set(ffmpegInstallDir)
         jniLibrary.set(jniOutputFile)
         runtimeDirName.set(target.runtime.runtimeDirName)

--- a/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
@@ -35,6 +35,12 @@ internal data class MpvJniToolchain(
      * `{name}` is substituted; a trailing `*` matches any suffix (versioned `.so`).
      */
     val linkLibraryPatterns: List<String>,
+    /**
+     * Version probe command lines identifying the JNI compiler for the build cache
+     * (see [nativebuild.ToolchainFingerprintValueSource]). Must be runnable directly by
+     * the JVM (native paths, no MSYS path forms).
+     */
+    val versionProbes: List<List<String>> = emptyList(),
 )
 
 /** Post-assembly fixup making the runtime directory self-contained on each platform. */
@@ -75,6 +81,11 @@ internal data class MpvBuildTarget(
     val wrapDependencies: List<String> = emptyList(),
     val wrapFiles: Map<String, String> = emptyMap(),
     val msys2Packages: List<String> = emptyList(),
+    /**
+     * Version probe command lines identifying the meson toolchain and the system
+     * libraries mpv links against (see [nativebuild.ToolchainFingerprintValueSource]).
+     */
+    val toolchainProbes: List<List<String>> = emptyList(),
     val jni: MpvJniToolchain,
     val runtime: MpvRuntimeLayout,
 )
@@ -150,25 +161,29 @@ private fun jniCompilerFallback(context: MpvBuildContext, default: String): Stri
 
 internal fun MpvBuildContext.windowsTarget(): MpvBuildTarget {
     val msys2Root = project.resolveMsys2Dir()
+    val msys2Packages = listOf(
+        "git",
+        "mingw-w64-ucrt-x86_64-ca-certificates",
+        "mingw-w64-ucrt-x86_64-gcc",
+        "mingw-w64-ucrt-x86_64-libass",
+        "mingw-w64-ucrt-x86_64-libplacebo",
+        "mingw-w64-ucrt-x86_64-meson",
+        "mingw-w64-ucrt-x86_64-ninja",
+        "mingw-w64-ucrt-x86_64-pkgconf",
+        "mingw-w64-ucrt-x86_64-python-certifi",
+        "mingw-w64-ucrt-x86_64-python",
+        "mingw-w64-ucrt-x86_64-shaderc",
+        "mingw-w64-ucrt-x86_64-spirv-cross",
+    )
     return MpvBuildTarget(
         name = "WindowsX64",
         family = "windows",
         ffmpegTargetName = "WindowsX64",
         shell = msys2Root.resolve("usr/bin/bash.exe").absolutePath,
         env = mapOf("MSYSTEM" to "UCRT64"),
-        msys2Packages = listOf(
-            "git",
-            "mingw-w64-ucrt-x86_64-ca-certificates",
-            "mingw-w64-ucrt-x86_64-gcc",
-            "mingw-w64-ucrt-x86_64-libass",
-            "mingw-w64-ucrt-x86_64-libplacebo",
-            "mingw-w64-ucrt-x86_64-meson",
-            "mingw-w64-ucrt-x86_64-ninja",
-            "mingw-w64-ucrt-x86_64-pkgconf",
-            "mingw-w64-ucrt-x86_64-python-certifi",
-            "mingw-w64-ucrt-x86_64-python",
-            "mingw-w64-ucrt-x86_64-shaderc",
-            "mingw-w64-ucrt-x86_64-spirv-cross",
+        msys2Packages = msys2Packages,
+        toolchainProbes = listOf(
+            listOf(msys2Root.resolve("usr/bin/pacman.exe").absolutePath, "-Q") + msys2Packages,
         ),
         mesonOptions = commonMesonOptions + listOf(
             "-Dgl=enabled",
@@ -197,6 +212,9 @@ internal fun MpvBuildContext.windowsTarget(): MpvBuildTarget {
             sourceExtensions = setOf("cpp"),
             useJdkIncludes = true,
             linkLibraryPatterns = listOf("lib{name}.dll.a", "{name}.lib"),
+            versionProbes = listOf(
+                listOf(msys2Root.resolve("ucrt64/bin/g++.exe").absolutePath, "--version"),
+            ),
         ),
         runtime = MpvRuntimeLayout(
             runtimeDirName = "bin",
@@ -213,6 +231,12 @@ internal fun MpvBuildContext.linuxX64Target(): MpvBuildTarget = MpvBuildTarget(
     name = "LinuxX64",
     family = "linux",
     ffmpegTargetName = "LinuxX64",
+    toolchainProbes = listOf(
+        listOf("cc", "--version"),
+        listOf("meson", "--version"),
+        listOf("ninja", "--version"),
+        listOf("pkg-config", "--modversion", "libass", "libplacebo"),
+    ),
     mesonOptions = commonMesonOptions + listOf(
         "-Dgl=enabled",
         "-Dgl-x11=enabled",
@@ -234,6 +258,9 @@ internal fun MpvBuildContext.linuxX64Target(): MpvBuildTarget = MpvBuildTarget(
         sourceExtensions = setOf("cpp"),
         useJdkIncludes = true,
         linkLibraryPatterns = listOf("lib{name}.so", "lib{name}.so.*"),
+        versionProbes = listOf(
+            listOf(jniCompilerFallback(this, default = "g++"), "--version"),
+        ),
     ),
     runtime = MpvRuntimeLayout(
         runtimeDirName = "lib",
@@ -269,6 +296,12 @@ private fun MpvBuildContext.macosTarget(
         name = name,
         family = "macos",
         ffmpegTargetName = name,
+        toolchainProbes = listOf(
+            listOf("clang", "--version"),
+            listOf("meson", "--version"),
+            listOf("ninja", "--version"),
+            listOf("pkg-config", "--modversion", "libass", "libplacebo"),
+        ),
         env = mapOf(
             "CC" to "clang",
             "CXX" to "clang++",
@@ -306,6 +339,9 @@ private fun MpvBuildContext.macosTarget(
         ),
         jni = MpvJniToolchain(
             compilerCommand = jniCompilerFallback(this, default = "clang++"),
+            versionProbes = listOf(
+                listOf(jniCompilerFallback(this, default = "clang++"), "--version"),
+            ),
             // -fobjc-arc is required by render_macos.mm; it has no effect on plain C++ sources.
             compilerArgs = archArgs + listOf("-fobjc-arc", CPP_STANDARD_FLAG, "-fPIC", "-dynamiclib"),
             // Metal/IOSurface render path (render_macos.mm)
@@ -353,6 +389,30 @@ internal fun MpvBuildContext.androidTarget(abi: AndroidAbi): MpvBuildTarget {
         """.trimIndent(),
     )
 
+    val msys2Packages = if (hostOs == Os.Windows) {
+        listOf(
+            "git",
+            "mingw-w64-ucrt-x86_64-ca-certificates",
+            "mingw-w64-ucrt-x86_64-gcc",
+            "mingw-w64-ucrt-x86_64-meson",
+            "mingw-w64-ucrt-x86_64-ninja",
+            "mingw-w64-ucrt-x86_64-pkgconf",
+            "mingw-w64-ucrt-x86_64-python-certifi",
+            "mingw-w64-ucrt-x86_64-python",
+        )
+    } else {
+        emptyList()
+    }
+    val toolchainProbes = buildList {
+        add(listOf(toolchain.cc.absolutePath, "--version"))
+        if (hostOs == Os.Windows) {
+            add(listOf(project.resolveMsys2Dir().resolve("usr/bin/pacman.exe").absolutePath, "-Q") + msys2Packages)
+        } else {
+            add(listOf("meson", "--version"))
+            add(listOf("ninja", "--version"))
+        }
+    }
+
     return MpvBuildTarget(
         name = androidTargetName(abi),
         family = "android",
@@ -360,6 +420,7 @@ internal fun MpvBuildContext.androidTarget(abi: AndroidAbi): MpvBuildTarget {
         androidAbi = abi,
         shell = if (hostOs == Os.Windows) project.resolveMsys2Dir().resolve("usr/bin/bash.exe").absolutePath else "bash",
         env = if (hostOs == Os.Windows) mapOf("MSYSTEM" to "UCRT64") else emptyMap(),
+        toolchainProbes = toolchainProbes,
         wrapDependencies = listOf(
             "expat",
             "freetype2",
@@ -369,20 +430,7 @@ internal fun MpvBuildContext.androidTarget(abi: AndroidAbi): MpvBuildTarget {
             "zlib",
         ),
         wrapFiles = wrapFiles,
-        msys2Packages = if (hostOs == Os.Windows) {
-            listOf(
-                "git",
-                "mingw-w64-ucrt-x86_64-ca-certificates",
-                "mingw-w64-ucrt-x86_64-gcc",
-                "mingw-w64-ucrt-x86_64-meson",
-                "mingw-w64-ucrt-x86_64-ninja",
-                "mingw-w64-ucrt-x86_64-pkgconf",
-                "mingw-w64-ucrt-x86_64-python-certifi",
-                "mingw-w64-ucrt-x86_64-python",
-            )
-        } else {
-            emptyList()
-        },
+        msys2Packages = msys2Packages,
         mesonOptions = commonMesonOptions + listOf(
             "--force-fallback-for=libass,libplacebo,expat,freetype2,fribidi,harfbuzz,libpng,zlib",
             "-Dgl=enabled",
@@ -404,6 +452,9 @@ internal fun MpvBuildContext.androidTarget(abi: AndroidAbi): MpvBuildTarget {
         ),
         jni = MpvJniToolchain(
             compilerCommand = pathForShell(toolchain.cxx, hostOs == Os.Windows),
+            versionProbes = listOf(
+                listOf(toolchain.cxx.absolutePath, "--version"),
+            ),
             compilerArgs = toolchain.cxxArgs +
                 "--sysroot=${pathForShell(toolchain.sysroot, hostOs == Os.Windows)}" +
                 listOf(CPP_STANDARD_FLAG, "-fPIC", "-shared"),

--- a/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
@@ -4,10 +4,12 @@ import nativebuild.copyTreePreservingLinks
 import nativebuild.deleteRecursivelyForce
 import nativebuild.isWindowsSystemLibrary
 import nativebuild.jniIncludeFlags
+import nativebuild.makePkgConfigRelocatable
 import nativebuild.pathForShell
 import nativebuild.parseWindowsImportedDllNames
 import nativebuild.recreateDirectory
 import nativebuild.resolveWindowsObjdump
+import nativebuild.rewriteMachOToLoaderPath
 import nativebuild.shellQuote
 import nativebuild.shellScriptWithExports
 import org.gradle.api.DefaultTask
@@ -18,9 +20,11 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
@@ -31,6 +35,11 @@ import org.gradle.process.ExecOperations
 import java.io.File
 import javax.inject.Inject
 
+/**
+ * Stages the patched mpv source and runs `meson setup`. Deliberately NOT cacheable: its
+ * interesting product is the configured build tree, which is cheap to recreate locally
+ * but expensive to store; the cache boundary is [MpvBuildTask].
+ */
 abstract class MpvConfigureTask : DefaultTask() {
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -68,14 +77,24 @@ abstract class MpvConfigureTask : DefaultTask() {
     @get:Optional
     abstract val crossFileContent: Property<String>
 
-    @get:OutputDirectory
+    /**
+     * Whole target build directory. Internal on purpose: configure only owns the staged
+     * source; `meson compile`/`meson install` (the build task) write in here too, and
+     * declaring the whole directory as an output would overlap with the build task's
+     * outputs, which disables build caching.
+     */
+    @get:Internal
     abstract val buildDirPath: DirectoryProperty
+
+    /** The staged mpv source tree, `<buildDir>/source`, including downloaded wraps. */
+    @get:OutputDirectory
+    abstract val stagedSourceDir: DirectoryProperty
 
     @get:OutputFile
     abstract val configStamp: RegularFileProperty
 
-    @get:InputDirectory
-    @get:Optional
+    /** Tool location, not content input: versions are captured by the toolchain fingerprint. */
+    @get:Internal
     abstract val msys2Dir: DirectoryProperty
 
     @get:Inject
@@ -202,10 +221,12 @@ abstract class MpvConfigureTask : DefaultTask() {
             environment(baseEnv)
         }
 
+        // The stamp feeds the build task's cache key, so it must not contain absolute
+        // worktree paths (the FFmpeg install participates in the key as a content input
+        // on the build task instead).
         configStamp.get().asFile.writeText(
             buildString {
                 appendLine("buildType=${mesonBuildType.get()}")
-                appendLine("ffmpegInstall=${ffmpegInstall.absolutePath}")
                 append(setupArgs.get().joinToString("\n"))
             },
         )
@@ -260,9 +281,33 @@ abstract class MpvConfigureTask : DefaultTask() {
     }
 }
 
+/**
+ * Runs `meson compile && meson install` — the expensive step and therefore the primary
+ * build-cache boundary (layer 1) for mpv. The cache key is the staged (patched, wraps
+ * included) source content, the meson configuration, the FFmpeg install it links
+ * against, and the toolchain fingerprint; the cached output is the install prefix.
+ */
+@CacheableTask
 abstract class MpvBuildTask : DefaultTask() {
+    /** Staged source content (including downloaded wrap subprojects). */
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val stagedSourceDir: DirectoryProperty
+
+    /** The FFmpeg install this mpv build compiles and links against. */
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val ffmpegInstallDir: DirectoryProperty
+
+    /** Meson build type and setup args as written by [MpvConfigureTask]. */
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val configStamp: RegularFileProperty
+
+    /** Cross-file content with worktree-specific paths masked (Android targets). */
+    @get:Input
+    @get:Optional
+    abstract val crossFileFingerprint: Property<String>
 
     @get:Input
     abstract val shell: Property<String>
@@ -273,13 +318,20 @@ abstract class MpvBuildTask : DefaultTask() {
     @get:Input
     abstract val hostOsName: Property<String>
 
-    /** Set on cross builds, which configure prefix=/ and install here via --destdir. */
+    /** See [nativebuild.ToolchainFingerprintValueSource]. */
     @get:Input
-    @get:Optional
+    abstract val toolchainFingerprint: Property<String>
+
+    /** Set on cross builds, which configure prefix=/ and install here via --destdir. */
+    @get:Internal
     abstract val installDestDir: Property<String>
 
-    @get:OutputDirectory
+    /** Working directory prepared by configure; scratch state, not an input or output. */
+    @get:Internal
     abstract val buildDirPath: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val installDir: DirectoryProperty
 
     @get:OutputFile
     abstract val buildStamp: RegularFileProperty
@@ -292,6 +344,10 @@ abstract class MpvBuildTask : DefaultTask() {
         val buildRoot = buildDirPath.get().asFile
         val mesonBuildDir = buildRoot.resolve("meson")
         val windowsMsys = hostOsName.get() == "Windows"
+        require(mesonBuildDir.isDirectory) {
+            "mpv build directory at ${mesonBuildDir.absolutePath} is not configured. " +
+                "Run the matching mpvConfigure task first."
+        }
 
         val destDirArg = installDestDir.orNull
             ?.let { " --destdir ${shellQuote(pathForShell(File(it), windowsMsys))}" }
@@ -310,10 +366,17 @@ abstract class MpvBuildTask : DefaultTask() {
             environment(envVars.get())
         }
 
+        makePkgConfigRelocatable(installDir.get().asFile, logger)
         buildStamp.get().asFile.writeText(System.currentTimeMillis().toString())
     }
 }
 
+/**
+ * Compiles the `mediampv` JNI wrapper — build-cache layer 2: keyed on the wrapper
+ * sources plus the layer-1 install outputs, so editing the JNI code only recompiles the
+ * wrapper and never invalidates the mpv/FFmpeg compiles.
+ */
+@CacheableTask
 abstract class MpvJniBuildTask : DefaultTask() {
     @get:Input
     abstract val targetName: Property<String>
@@ -323,9 +386,11 @@ abstract class MpvJniBuildTask : DefaultTask() {
     abstract val sourceDir: DirectoryProperty
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val mpvInstallDir: DirectoryProperty
 
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val ffmpegInstallDir: DirectoryProperty
 
     @get:Input
@@ -336,6 +401,14 @@ abstract class MpvJniBuildTask : DefaultTask() {
 
     @get:Input
     abstract val hostOsName: Property<String>
+
+    /** See [nativebuild.ToolchainFingerprintValueSource]. */
+    @get:Input
+    abstract val toolchainFingerprint: Property<String>
+
+    /** The wrapper may compile against the Gradle JVM's JNI headers. */
+    @get:Input
+    abstract val jdkMajorVersion: Property<String>
 
     // Toolchain description, provided by MpvJniToolchain (MpvTargets.kt).
 
@@ -360,8 +433,8 @@ abstract class MpvJniBuildTask : DefaultTask() {
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
-    @get:InputDirectory
-    @get:Optional
+    /** Tool location, not content input: versions are captured by [toolchainFingerprint]. */
+    @get:Internal
     abstract val msys2Dir: DirectoryProperty
 
     @get:Inject
@@ -463,8 +536,8 @@ abstract class MpvAssembleTask : DefaultTask() {
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
 
-    @get:InputDirectory
-    @get:Optional
+    /** Tool location, not content input. */
+    @get:Internal
     abstract val msys2Dir: DirectoryProperty
 
     @get:Inject
@@ -495,11 +568,20 @@ abstract class MpvAssembleTask : DefaultTask() {
             }
 
             MpvRuntimePostProcessing.MACOS_BUNDLE_DYLIBS -> {
-                rewriteAppleInstallNames(
+                // Name-based rewrite works for cache-restored install dirs too, whose
+                // recorded install names belong to another worktree/machine.
+                val bundledDylibs = runtimeDir.walkTopDown()
+                    .filter { it.isFile && it.name.endsWith(".dylib") }
+                    .map(File::getCanonicalFile)
+                    .distinctBy(File::getAbsolutePath)
+                    .toList()
+                rewriteMachOToLoaderPath(
                     execOperations = execOperations,
-                    mpvInstallDir = installPrefix,
-                    ffmpegInstallDir = ffmpegPrefix,
-                    outputDir = outputPrefix,
+                    machOFiles = bundledDylibs,
+                    bundledLibraryNames = runtimeDir.walkTopDown()
+                        .filter { it.isFile && it.name.endsWith(".dylib") }
+                        .map(File::getName)
+                        .toSet(),
                 )
                 bundleAppleExternalDependencies(
                     execOperations = execOperations,
@@ -689,51 +771,6 @@ private fun collectWindowsRuntimeDlls(
 
     if (copied.isNotEmpty()) {
         logger.lifecycle("Collected Windows runtime DLLs for mpv: ${copied.sorted().joinToString()}")
-    }
-}
-
-private fun rewriteAppleInstallNames(
-    execOperations: ExecOperations,
-    mpvInstallDir: File,
-    ffmpegInstallDir: File,
-    outputDir: File,
-) {
-    val outputLibDir = outputDir.resolve("lib")
-    val machOFiles = outputLibDir.walkTopDown()
-        .filter { it.isFile && it.name.endsWith(".dylib") }
-        .map(File::getCanonicalFile)
-        .distinctBy(File::getAbsolutePath)
-        .toList()
-
-    if (machOFiles.isEmpty()) return
-
-    val installNameMap = buildMap {
-        listOf(mpvInstallDir, ffmpegInstallDir)
-            .map { it.resolve("lib") }
-            .filter(File::isDirectory)
-            .forEach { libDir ->
-                libDir.walkTopDown()
-                    .filter { it.isFile && it.name.endsWith(".dylib") }
-                    .forEach { dylib ->
-                        put(dylib.canonicalFile.absolutePath, "@loader_path/${dylib.name}")
-                        put(dylib.absolutePath, "@loader_path/${dylib.name}")
-                    }
-            }
-    }
-
-    machOFiles.forEach { dylib ->
-        execOperations.exec {
-            commandLine("xcrun", "install_name_tool", "-id", "@loader_path/${dylib.name}", dylib.absolutePath)
-        }
-    }
-
-    machOFiles.forEach { machO ->
-        installNameMap.forEach { (oldPath, newPath) ->
-            execOperations.exec {
-                commandLine("xcrun", "install_name_tool", "-change", oldPath, newPath, machO.absolutePath)
-                isIgnoreExitValue = true
-            }
-        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/nativebuild/CacheKeySupport.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/CacheKeySupport.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package nativebuild
+
+import org.gradle.api.logging.Logger
+import java.io.File
+
+/**
+ * All textual spellings of [root] that may appear in generated files: the native form,
+ * the forward-slash form and (on Windows) the MSYS form (`/c/...`).
+ */
+internal fun absolutePathVariants(root: File): List<String> {
+    val native = root.absolutePath
+    val forward = native.replace('\\', '/')
+    val variants = mutableListOf(native, forward)
+    if (forward.length > 2 && forward[1] == ':') {
+        variants.add("/" + forward[0].lowercaseChar() + forward.substring(2))
+    }
+    return variants.distinct().sortedByDescending { it.length }
+}
+
+/**
+ * Replaces worktree-specific absolute paths in [text] with a stable token so that equal
+ * builds in different worktrees/machines produce equal build-cache keys.
+ */
+internal fun sanitizeAbsolutePaths(text: String, roots: List<File>): String {
+    var result = text
+    roots.flatMap { absolutePathVariants(it) }
+        .distinct()
+        .sortedByDescending { it.length }
+        .forEach { variant -> result = result.replace(variant, "<PATH>") }
+    return result
+}
+
+/**
+ * Rewrites pkg-config files under `[installDir]/lib/pkgconfig` to be relocatable:
+ * `prefix` becomes `${'$'}{pcfiledir}/../..` and every other absolute reference to the
+ * install prefix becomes `${'$'}{prefix}`.
+ *
+ * Required by the build cache: entries are shared across worktrees and machines, so the
+ * installed metadata must not point back at the absolute directory the entry was produced
+ * in. It also keeps downstream input fingerprints (mpv consumes the FFmpeg install via
+ * `PKG_CONFIG_LIBDIR`) identical across worktrees, which is what makes cross-worktree
+ * cache hits possible in the first place.
+ */
+internal fun makePkgConfigRelocatable(installDir: File, logger: Logger) {
+    val pkgConfigDir = installDir.resolve("lib/pkgconfig")
+    if (!pkgConfigDir.isDirectory) return
+
+    val variants = absolutePathVariants(installDir)
+    var rewrittenFiles = 0
+
+    pkgConfigDir.listFiles()
+        ?.filter { it.isFile && it.extension == "pc" }
+        .orEmpty()
+        .forEach { pcFile ->
+            val original = pcFile.readText()
+            val relocated = original.lineSequence().joinToString("\n") { line ->
+                if (line.startsWith("prefix=")) {
+                    "prefix=\${pcfiledir}/../.."
+                } else {
+                    var updated = line
+                    variants.forEach { variant -> updated = updated.replace(variant, "\${prefix}") }
+                    updated
+                }
+            }
+            if (relocated != original) {
+                pcFile.writeText(relocated)
+                rewrittenFiles += 1
+            }
+        }
+
+    if (rewrittenFiles > 0) {
+        logger.lifecycle(
+            "Rewrote $rewrittenFiles pkg-config file(s) under ${pkgConfigDir.absolutePath} to be relocatable.",
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/nativebuild/MachOSupport.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/MachOSupport.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package nativebuild
+
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+/** Lists the dependent-library install names of a Mach-O file via `otool -L`. */
+internal fun machODependencyPaths(execOperations: ExecOperations, machO: File): List<String> {
+    val output = ByteArrayOutputStream()
+    execOperations.exec {
+        commandLine("xcrun", "otool", "-L", machO.absolutePath)
+        standardOutput = output
+    }
+    return output.toString()
+        .lineSequence()
+        .drop(1) // first line is the file itself
+        .map { it.trim().substringBefore(" (") }
+        .filter { it.isNotEmpty() }
+        .toList()
+}
+
+/**
+ * Rewrites Mach-O load commands to `@loader_path` by dependency *file name* rather than
+ * by absolute path. Matching by name is what makes this correct for build-cache-restored
+ * libraries: their recorded install names contain the absolute paths of whatever worktree
+ * or machine originally built them, so an absolute-path map would silently miss them.
+ */
+internal fun rewriteMachOToLoaderPath(
+    execOperations: ExecOperations,
+    machOFiles: List<File>,
+    bundledLibraryNames: Set<String>,
+) {
+    machOFiles.forEach { machO ->
+        if (machO.name in bundledLibraryNames) {
+            execOperations.exec {
+                commandLine(
+                    "xcrun", "install_name_tool",
+                    "-id", "@loader_path/${machO.name}",
+                    machO.absolutePath,
+                )
+            }
+        }
+        machODependencyPaths(execOperations, machO)
+            .filter { dep -> !dep.startsWith("@") && File(dep).name in bundledLibraryNames }
+            .forEach { dep ->
+                execOperations.exec {
+                    commandLine(
+                        "xcrun", "install_name_tool",
+                        "-change", dep, "@loader_path/${File(dep).name}",
+                        machO.absolutePath,
+                    )
+                    isIgnoreExitValue = true
+                }
+            }
+    }
+}

--- a/buildSrc/src/main/kotlin/nativebuild/PatchedSourceTemplate.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/PatchedSourceTemplate.kt
@@ -4,16 +4,15 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Exec
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
 import java.io.File
 
 /**
- * The apply-patches -> snapshot -> revert-patches triplet both native modules use to turn
- * a git submodule plus an optional vendored patch into a stable source template for the
- * rest of the build. The patch is applied to the submodule working tree only for the
- * duration of the snapshot and reverted afterwards, so the submodule stays clean.
+ * Turns a git submodule plus an optional vendored patch into a stable source template for
+ * the rest of the build. The patch application happens inside [PrepareSourceTreeTask]
+ * itself (apply -> snapshot -> revert around the copy), keeping the submodule clean and
+ * the task's inputs deterministic.
  */
 internal class PatchedSourceTemplateSpec(
     /** Capitalized module tag used in task names, e.g. "Ffmpeg" -> `applyFfmpegPatches`. */
@@ -36,7 +35,9 @@ internal class PatchedSourceTemplateSpec(
 internal fun Project.registerPatchedSourceTemplate(
     spec: PatchedSourceTemplateSpec,
 ): TaskProvider<PrepareSourceTreeTask> {
-    val applyPatchesTask = tasks.register<Exec>("apply${spec.taskNameInfix}Patches") {
+    // Standalone developer conveniences for working on the patch itself; the template
+    // task no longer depends on them.
+    tasks.register<Exec>("apply${spec.taskNameInfix}Patches") {
         group = spec.taskGroup
         description = "Apply patches to the ${spec.sourceDisplayName} submodule source tree"
         enabled = spec.patchFile.exists()
@@ -45,7 +46,7 @@ internal fun Project.registerPatchedSourceTemplate(
         workingDir = spec.sourceDir
     }
 
-    val revertPatchesTask = tasks.register<Exec>("revert${spec.taskNameInfix}Patches") {
+    tasks.register<Exec>("revert${spec.taskNameInfix}Patches") {
         group = spec.taskGroup
         description = "Revert patches from the ${spec.sourceDisplayName} submodule source tree"
         enabled = spec.patchFile.exists()
@@ -57,11 +58,8 @@ internal fun Project.registerPatchedSourceTemplate(
     return tasks.register<PrepareSourceTreeTask>("prepare${spec.taskNameInfix}SourceTemplate") {
         group = spec.taskGroup
         description = "Create a stable ${spec.sourceDisplayName} source snapshot for this build"
-        dependsOn(applyPatchesTask)
-        finalizedBy(revertPatchesTask)
         if (spec.patchFile.exists()) {
-            inputs.file(spec.patchFile)
-                .withPathSensitivity(PathSensitivity.RELATIVE)
+            patchFile.set(spec.patchFile)
         }
         sourceDir.set(spec.sourceDir)
         outputDir.set(spec.outputDir)

--- a/buildSrc/src/main/kotlin/nativebuild/PrepareSourceTreeTask.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/PrepareSourceTreeTask.kt
@@ -2,19 +2,35 @@ package nativebuild
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
 abstract class PrepareSourceTreeTask : DefaultTask() {
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val sourceDir: DirectoryProperty
+
+    /**
+     * Optional patch applied to the snapshot. The submodule working tree is only mutated
+     * for the duration of this task's action (apply -> copy -> revert in a finally
+     * block), so [sourceDir]'s input fingerprint — taken before execution — always
+     * describes the clean checkout, and the patch participates in up-to-date checks as
+     * its own content-hashed input.
+     */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    @get:Optional
+    abstract val patchFile: RegularFileProperty
 
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
@@ -35,6 +51,9 @@ abstract class PrepareSourceTreeTask : DefaultTask() {
     @get:Input
     abstract val preserveExecutablePermissions: Property<Boolean>
 
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
     init {
         preserveSymbolicLinks.convention(false)
         preserveExecutablePermissions.convention(false)
@@ -51,20 +70,36 @@ abstract class PrepareSourceTreeTask : DefaultTask() {
         val src = sourceDir.get().asFile
         val dst = outputDir.get().asFile
         val marker = markerFileRelativePath.get()
+        val patch = patchFile.orNull?.asFile
 
         require(src.resolve(marker).isFile) {
             missingSourceMessage.orNull
                 ?: "${sourceDisplayName.get()} source tree is missing $marker at ${src.absolutePath}"
         }
 
-        recreateDirectory(dst)
-        if (preserveSymbolicLinks.get()) {
-            copyTreePreservingLinks(src, dst)
-        } else {
-            copyTreeRecursively(src, dst)
+        if (patch != null) {
+            execOperations.exec {
+                commandLine("git", "apply", patch.absolutePath)
+                workingDir = src
+            }
         }
-        if (preserveExecutablePermissions.get()) {
-            restoreExecutablePermissions(src, dst)
+        try {
+            recreateDirectory(dst)
+            if (preserveSymbolicLinks.get()) {
+                copyTreePreservingLinks(src, dst)
+            } else {
+                copyTreeRecursively(src, dst)
+            }
+            if (preserveExecutablePermissions.get()) {
+                restoreExecutablePermissions(src, dst)
+            }
+        } finally {
+            if (patch != null) {
+                execOperations.exec {
+                    commandLine("git", "apply", "--reverse", patch.absolutePath)
+                    workingDir = src
+                }
+            }
         }
 
         logger.lifecycle("Prepared ${sourceDisplayName.get()} source from ${src.absolutePath} to ${dst.absolutePath}")

--- a/buildSrc/src/main/kotlin/nativebuild/ToolchainFingerprint.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/ToolchainFingerprint.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package nativebuild
+
+import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+
+/**
+ * Captures the identity of the native toolchain (compiler/meson/system library versions)
+ * as a build-cache key input. The native compile tasks read their tools from machine
+ * state Gradle cannot fingerprint (MSYS2, Homebrew, apt, the NDK), so without this a
+ * toolchain upgrade would silently keep hitting stale cache entries.
+ *
+ * Probes are best-effort: a missing tool yields a stable "unavailable" marker instead of
+ * failing the build, so the fingerprint never breaks configurations that skip the
+ * corresponding target.
+ */
+abstract class ToolchainFingerprintValueSource :
+    ValueSource<String, ToolchainFingerprintValueSource.Parameters> {
+
+    interface Parameters : ValueSourceParameters {
+        /** Each entry is one probe command line with arguments separated by [ARG_SEPARATOR]. */
+        val probeCommandLines: ListProperty<String>
+    }
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String =
+        parameters.probeCommandLines.get().joinToString("\n") { encoded ->
+            val args = encoded.split(ARG_SEPARATOR)
+            val display = args.joinToString(" ")
+            runCatching {
+                val output = ByteArrayOutputStream()
+                execOperations.exec {
+                    commandLine(args)
+                    standardOutput = output
+                    errorOutput = output
+                    isIgnoreExitValue = true
+                }
+                "$display => ${output.toString(Charsets.UTF_8).trim()}"
+            }.getOrElse { failure ->
+                "$display => unavailable (${failure.message})"
+            }
+        }
+
+    companion object {
+        const val ARG_SEPARATOR: String = "\u0001"
+    }
+}
+
+internal fun Project.toolchainFingerprint(probes: List<List<String>>): Provider<String> {
+    val encoded = probes.map { it.joinToString(ToolchainFingerprintValueSource.ARG_SEPARATOR) }
+    return providers.of(ToolchainFingerprintValueSource::class.java) {
+        parameters.probeCommandLines.set(encoded)
+    }
+}

--- a/docs/native-build-cache.md
+++ b/docs/native-build-cache.md
@@ -1,0 +1,83 @@
+# Gradle build cache for the native modules
+
+`mediamp-ffmpeg` and `mediamp-mpv` participate in the Gradle build cache
+(`org.gradle.caching=true` in `gradle.properties`). The expensive native compiles are
+cached in three layers; a cache hit on layer 1 skips the 20–40 minute FFmpeg/mpv compile
+entirely, on any worktree or machine sharing the cache.
+
+## Layers and cache keys
+
+| Layer | Tasks | Key inputs | Cached outputs |
+|---|---|---|---|
+| 1 — native compile | `ffmpegBuild<Target>`, `mpvBuild<Target>` | patched source snapshot (content hash), configure flags / meson options, target env, toolchain fingerprint; mpv additionally keys on the FFmpeg install content | install prefix; FFmpeg additionally `fftools` object files (needed to link the JNI wrapper) |
+| 2 — JNI wrappers | `ffmpegAssemble<Target>` (links `ffmpegkitjni`), `mpvBuildJni<Target>` (`mediampv`), `ffmpegAppleFramework<Target>` | wrapper C/C++ sources, layer-1 install content, sanitized toolchain config, JDK major version | `ffmpeg-output/<Target>` / `mediampv` library / Apple framework |
+| 3 — Kotlin | standard KGP compile tasks | (Gradle defaults) | (Gradle defaults) |
+
+Editing JNI sources therefore only relinks layer 2; editing Kotlin only rebuilds layer 3.
+
+### What is deliberately NOT cached
+
+- `prepare*SourceTemplate` and `ffmpegConfigure*` / `mpvConfigure*`: their product is the
+  staged source/build tree — hundreds of MB that are cheap to recreate locally but
+  expensive to store. On a cold worktree with a warm cache you pay for the source copy and
+  `./configure` / `meson setup` (a few minutes), not the compile.
+- `ffmpegRuntimeJar*` / `mpvRuntimeJar*` / `mpvAssemble*`: cheap packaging; the mpv/ffmpeg
+  assemble DLL/dylib collection also reads machine state (MSYS2, Homebrew) that Gradle
+  cannot fingerprint.
+
+### Why the key is the source snapshot, not the submodule SHA + patch md5
+
+The `prepare*SourceTemplate` task copies the submodule and applies the vendored patch to
+the snapshot (the submodule is only mutated transiently, and its input fingerprint is
+always the clean tree plus the patch file as separate inputs). Downstream tasks key on the
+snapshot's *content*, which is exactly `f(sha, patch)` when the tree is clean — but also
+stays correct when the submodule has local modifications, which a SHA-based key would
+silently miss. Gradle's virtual file system caches the fingerprint, so the per-build cost
+is negligible.
+
+### Toolchain fingerprint
+
+The compilers/meson/system libraries come from machine state (MSYS2, Homebrew, apt, NDK).
+Each target declares version probes (`pacman -Q <packages>` on Windows, `cc --version`,
+`meson --version`, `pkg-config --modversion libass libplacebo`, …) whose combined output
+is an `@Input` — upgrading the toolchain invalidates the cache instead of silently
+reusing ABI-incompatible artifacts. Probes are best-effort: a missing tool contributes a
+stable "unavailable" marker rather than failing the build.
+
+### Relocatability
+
+Cache entries are shared across worktrees and machines, so nothing with an absolute path
+may leak into cached outputs or cache keys:
+
+- `.pc` files in the FFmpeg/mpv install prefixes are rewritten to
+  `prefix=${pcfiledir}/../..` after `make install`/`meson install`.
+- The config/build stamps exclude the absolute `--prefix`.
+- The assemble tasks key on a *sanitized* summary of `config.mak` (worktree paths masked)
+  instead of the raw file.
+- macOS install names are rewritten to `@loader_path` by dependency *file name* (via
+  `otool -L`), which also works for cache-restored dylibs whose recorded paths belong to
+  another worktree.
+
+## Known limitations
+
+- **macOS cross-worktree layer-2 hits**: the dylibs inside the install prefix embed the
+  absolute install names of the worktree that built them, so the layer-2 key differs per
+  worktree on macOS (CI paths are stable, so CI still hits). Layer 1 is unaffected.
+- **Symlinked libraries** (`libavcodec.so -> libavcodec.so.61` etc.) are materialized as
+  regular files when restored from the cache; runtimes stay functional but the restored
+  install dir is slightly larger.
+- **Android mpv wraps** (`libass`/`libplacebo` pinned to `master`): the *configure* step
+  still downloads floating revisions, but the build task keys on the staged source
+  *including* the downloaded wraps, so the cache never conflates two different wrap
+  revisions.
+- Windows DLL / macOS dylib closure collection in the assemble tasks reads the local
+  MSYS2/Homebrew installation; version drift is covered by the toolchain fingerprint, not
+  by content fingerprints.
+
+## CI
+
+CI currently runs `gradle/actions/setup-gradle` with `cache-disabled: true`, so runners
+start with an empty cache. To benefit there, either enable that cache (it persists
+`~/.gradle/caches/build-cache-1` via the GitHub Actions cache; mind the 10 GB repo quota —
+prefer `cache-write-only`/`cache-read-only` splits per job) or point
+`settings.gradle.kts` at a remote HTTP build cache node.


### PR DESCRIPTION
## Summary

Makes the `mediamp-ffmpeg` / `mediamp-mpv` native builds participate in the Gradle build cache, in three layers. A layer-1 cache hit skips the FFmpeg/mpv compile entirely on any worktree or machine sharing the cache; only the (non-cacheable, few-minute) source staging + `./configure` / `meson setup` steps run.

| Layer | Tasks | Key inputs | Cached outputs |
|---|---|---|---|
| 1 — native compile | `ffmpegBuild<T>`, `mpvBuild<T>` | patched source snapshot (content hash), configure flags / meson options, target env, toolchain fingerprint; mpv also keys on the FFmpeg install content | install prefix (+ `fftools` objects for FFmpeg) |
| 2 — JNI wrappers | `ffmpegAssemble<T>` (`ffmpegkitjni`), `mpvBuildJni<T>` (`mediampv`), `ffmpegAppleFramework<T>` | JNI sources, layer-1 install content, sanitized `config.mak` summary, JDK major version | runtime layout / wrapper library / framework |
| 3 — Kotlin | KGP defaults | — | — |

Design notes in [docs/native-build-cache.md](docs/native-build-cache.md), including why the key is the source snapshot content rather than submodule SHA + patch hash (identical when clean, still correct when the submodule is dirty), and what deliberately stays non-cacheable.

## Key mechanics

- **Toolchain fingerprint** (`ToolchainFingerprintValueSource`): per-target version probes (`pacman -Q <packages>` on Windows, `cc`/`meson --version`, `pkg-config --modversion libass libplacebo`, NDK clang) feed an `@Input`, so toolchain upgrades invalidate the cache instead of silently reusing ABI-incompatible artifacts. Probes degrade to a stable marker when a tool is missing.
- **Relocatability** (cache entries are shared across worktrees/machines): `.pc` files are rewritten to `prefix=${pcfiledir}/../..` after install; stamps drop the absolute `--prefix`; assemble keys on a path-sanitized `config.mak` summary; macOS install names are rewritten to `@loader_path` by dependency *file name* via `otool -L`, which also handles cache-restored dylibs whose recorded paths belong to another worktree.
- **No overlapping outputs**: configure tasks now declare only the staged source + stamp (the whole build dir would overlap with the build tasks' outputs and disable caching). The FFmpeg JNI link uses the install prefix (`-L install/lib`) instead of the make tree, so it works when the compile was restored from cache and the make tree never existed locally.
- **Patch handling**: the vendored patch is applied inside `PrepareSourceTreeTask` (apply → copy → revert in `finally`), so the submodule input fingerprint is always the clean tree and the patch is its own content-hashed input. `applyXPatches`/`revertXPatches` remain as standalone dev tasks.
- **Perf fix in passing**: `msys2Dir` is no longer an `@InputDirectory` — the whole MSYS2 installation (GBs) was being fingerprinted on every build.

## Verification (Windows, end-to-end)

- Full `ffmpegAssembleWindowsX64` build, then `rm -rf build/ffmpeg*` → rerun: `ffmpegBuildWindowsX64` and `ffmpegAssembleWindowsX64` **FROM-CACHE**; only configure re-executed.
- Editing `ffmpegkit_jni.c` re-runs only the assemble task (3s); the compile layer stays UP-TO-DATE.
- Same for mpv: after `rm -rf build/mpv*`, `mpvBuildWindowsX64` and `mpvBuildJniWindowsX64` **FROM-CACHE**.
- `:mediamp-mpv:zeroConfigTest --rerun` passes against the cache-restored natives (real `System.load` of libmpv + ffmpeg DLLs + `mediampv.dll` in a fresh JVM).
- The submodules stay clean throughout; the patch content is present in the source template.

macOS/Linux/Android/iOS paths are compile- and logic-reviewed but not machine-verified here; CI covers them. Known limitations (macOS cross-worktree layer-2 misses, symlink materialization on restore, floating Android wraps) are documented.

## Follow-up (not in this PR)

CI runs `setup-gradle` with `cache-disabled: true`, so runners currently start cold. Enabling that cache (mind the 10 GB repo quota; prefer read-only/write-only splits) or a remote build cache node is needed to get CI hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)