### PR TITLE
feat(mpv): add Windows ARM64 zero-copy runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,12 +125,21 @@ jobs:
         msystem: 'CLANGARM64'
         update: 'true'
         install: |-
+          git
           mingw-w64-clang-aarch64-clang
           mingw-w64-clang-aarch64-lld
+          mingw-w64-clang-aarch64-libass
+          mingw-w64-clang-aarch64-libplacebo
+          mingw-w64-clang-aarch64-meson
+          mingw-w64-clang-aarch64-ninja
           mingw-w64-clang-aarch64-pkgconf
           mingw-w64-clang-aarch64-nasm
           mingw-w64-clang-aarch64-openssl
           mingw-w64-clang-aarch64-ca-certificates
+          mingw-w64-clang-aarch64-python-certifi
+          mingw-w64-clang-aarch64-python
+          mingw-w64-clang-aarch64-shaderc
+          mingw-w64-clang-aarch64-spirv-cross
     - id: 'step-5'
       name: 'Configure MSYS2 root'
       run: |-
@@ -147,14 +156,21 @@ jobs:
       with:
         timeout_minutes: '60'
         max_attempts: '3'
-        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
     - id: 'step-8'
-      name: 'Build FFmpeg artifacts'
-      run: './gradlew :mediamp-ffmpeg:ffmpegBuildAll "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+      name: 'Check'
+      uses: 'nick-fields/retry@v2'
+      with:
+        timeout_minutes: '60'
+        max_attempts: '2'
+        command: './gradlew :mediamp-mpv:desktopTest "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
     - id: 'step-9'
-      name: 'Build FFmpeg runtime jar'
-      run: './gradlew :mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+      name: 'Build FFmpeg artifacts'
+      run: './gradlew :mediamp-ffmpeg:ffmpegBuildAll "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
     - id: 'step-10'
+      name: 'Build FFmpeg runtime jar'
+      run: './gradlew :mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
+    - id: 'step-11'
       name: 'Upload FFmpeg runtime jar'
       uses: 'actions/upload-artifact@v4'
       with:
@@ -162,6 +178,16 @@ jobs:
         path: 'mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-arm64.jar'
         if-no-files-found: 'error'
         overwrite: 'true'
+    - id: 'step-12'
+      name: 'Build mpv runtime jar'
+      run: './gradlew :mediamp-mpv:mpvRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
+    - id: 'step-13'
+      name: 'Verify mpv zero-config loading'
+      run: './gradlew :mediamp-mpv:zeroConfigTest "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
+    - id: 'step-14'
+      name: 'Verify mpv Maven publication'
+      # windows-11-arm does not provide an Android SDK; validate only the ARM64 runtime publication.
+      run: './gradlew "-Dmaven.repo.local=mediamp-mpv/build/maven-local" :mediamp-mpv:publishMpvRuntimeWindowsArm64PublicationToMavenLocal "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
   build_github-ubuntu-2404:
     name: 'Build (Ubuntu 24.04 x86_64)'
     runs-on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,12 +203,21 @@ jobs:
         msystem: 'CLANGARM64'
         update: 'true'
         install: |-
+          git
           mingw-w64-clang-aarch64-clang
           mingw-w64-clang-aarch64-lld
+          mingw-w64-clang-aarch64-libass
+          mingw-w64-clang-aarch64-libplacebo
+          mingw-w64-clang-aarch64-meson
+          mingw-w64-clang-aarch64-ninja
           mingw-w64-clang-aarch64-pkgconf
           mingw-w64-clang-aarch64-nasm
           mingw-w64-clang-aarch64-openssl
           mingw-w64-clang-aarch64-ca-certificates
+          mingw-w64-clang-aarch64-python-certifi
+          mingw-w64-clang-aarch64-python
+          mingw-w64-clang-aarch64-shaderc
+          mingw-w64-clang-aarch64-spirv-cross
     - id: 'step-7'
       name: 'Configure MSYS2 root'
       run: |-
@@ -225,7 +234,7 @@ jobs:
       with:
         timeout_minutes: '60'
         max_attempts: '3'
-        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+        command: './gradlew "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
     - id: 'step-10'
       name: 'Update Release Version Name'
       env:
@@ -233,16 +242,27 @@ jobs:
         GITHUB_REPOSITORY: '${{ secrets.GITHUB_REPOSITORY }}'
         CI_RELEASE_ID: '${{ needs.create-release.outputs.id }}'
         CI_TAG: '${{ steps.step-1.outputs.tag }}'
-      run: './gradlew updateReleaseVersionNameFromGit "-DCI_TAG=${{ steps.step-1.outputs.tag }}" "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+      run: './gradlew updateReleaseVersionNameFromGit "-DCI_TAG=${{ steps.step-1.outputs.tag }}" "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
     - id: 'step-11'
       name: 'Build FFmpeg runtime jar'
-      run: './gradlew :mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.ffmpeg.buildvariant=windows"'
+      run: './gradlew :mediamp-ffmpeg:ffmpegRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
     - id: 'step-12'
       name: 'Upload FFmpeg runtime jar'
       uses: 'actions/upload-artifact@v4'
       with:
         name: 'mediamp-ffmpeg-runtime-windows-arm64'
         path: 'mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-arm64.jar'
+        if-no-files-found: 'error'
+        overwrite: 'true'
+    - id: 'step-13'
+      name: 'Build mpv runtime jar'
+      run: './gradlew :mediamp-mpv:mpvRuntimeJarWindowsArm64 "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=windows" "-Pmediamp.mpv.buildvariant=windows"'
+    - id: 'step-14'
+      name: 'Upload mpv runtime jar'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'mediamp-mpv-runtime-windows-arm64'
+        path: 'mediamp-mpv/build/libs/mediamp-mpv-runtime-*-windows-arm64.jar'
         if-no-files-found: 'error'
         overwrite: 'true'
   release_github-ubuntu-2404:
@@ -549,16 +569,21 @@ jobs:
     - id: 'step-19'
       uses: 'actions/download-artifact@v4'
       with:
+        name: 'mediamp-mpv-runtime-windows-arm64'
+        path: 'mediamp-mpv/build/prebuilt-runtime-jars/windows-arm64'
+    - id: 'step-20'
+      uses: 'actions/download-artifact@v4'
+      with:
         name: 'mediamp-mpv-runtime-linux-x64'
         path: 'mediamp-mpv/build/prebuilt-runtime-jars/linux-x64'
-    - id: 'step-20'
+    - id: 'step-21'
       uses: 'actions/download-artifact@v4'
       with:
         name: 'mediamp-mpv-runtime-macos-x64'
         path: 'mediamp-mpv/build/prebuilt-runtime-jars/macos-x64'
-    - id: 'step-21'
-      run: 'ls -R mediamp-mpv/build/prebuilt-runtime-jars || true'
     - id: 'step-22'
+      run: 'ls -R mediamp-mpv/build/prebuilt-runtime-jars || true'
+    - id: 'step-23'
       name: 'Publish'
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: '${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}'
@@ -567,7 +592,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingInMemoryKeyId: '${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyId }}'
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: '${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}'
       run: './gradlew publish "--scan" "--no-configuration-cache" "-Porg.gradle.daemon.idletimeout=60000" "-Pkotlin.native.ignoreDisabledTargets=true" "-Dfile.encoding=UTF-8" "-Dorg.gradle.jvmargs=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "-Pani.android.abis=arm64-v8a" "-Pmediamp.mpv.test.required=true" "-Pmediamp.ffmpeg.buildvariant=ios,macos,android" "-Pmediamp.mpv.buildvariant=macos"'
-    - id: 'step-23'
+    - id: 'step-24'
       name: 'Cleanup temp files'
       continue-on-error: true
       run: 'chmod +x ./ci-helper/cleanup-temp-files-macos.sh && ./ci-helper/cleanup-temp-files-macos.sh'

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -162,7 +162,7 @@ class MatrixInstance(
     val ffmpegBuildVariant: String? = null,
     /**
      * mpv 原生构建家族 (`mediamp.mpv.buildvariant`). null = 不设置属性 (Gradle 侧默认全家族注册).
-     * 注意 mpv 没有 windows-arm64 与 ios 目标; Android 交叉编译管线未就绪, 发布时勿包含 android.
+     * 注意 mpv 没有 ios 目标; Android 交叉编译管线未就绪, 发布时勿包含 android.
      */
     val mpvBuildVariant: String? = null,
 
@@ -373,12 +373,12 @@ val buildMatrixInstances = listOf(
         gradleHeap = "4g",
         uploadDesktopInstallers = true,
         ffmpegBuildVariant = "windows",
+        mpvBuildVariant = "windows",
         extraGradleArgs = listOf(
             "-P$ANI_ANDROID_ABIS=arm64-v8a",
+            "-Pmediamp.mpv.test.required=true",
         ),
         buildAllAndroidAbis = false,
-        // The Windows ARM64 job only builds and uploads the FFmpeg runtime artifact.
-        runTests = false,
     ),
     MatrixInstance(
         runner = Runner.GithubUbuntu2404,
@@ -624,6 +624,7 @@ workflow(
                 artifactName = ArtifactNames.ffmpegRuntimeJar("windows-arm64"),
                 path = "mediamp-ffmpeg/build/libs/mediamp-ffmpeg-runtime-*-windows-arm64.jar",
             )
+            uploadMpvRuntimeJar()
         }
     }
     val linux = addJob(buildMatrixInstances[Runner.GithubUbuntu2404]) {
@@ -659,9 +660,8 @@ workflow(
                 )
             }
             run(command = "ls -R mediamp-ffmpeg/build/prebuilt-runtime-jars || true")
-            // mpv runtime prebuilt jars (macos-arm64 在本机由 publish 触发 mpvAssembleMacosArm64 构建;
-            // mpv 没有 windows-arm64 目标)
-            listOf("windows-x64", "linux-x64", "macos-x64").forEach { platformId ->
+            // mpv runtime prebuilt jars (macos-arm64 在本机由 publish 触发 mpvAssembleMacosArm64 构建)
+            listOf("windows-x64", "windows-arm64", "linux-x64", "macos-x64").forEach { platformId ->
                 uses(
                     action = DownloadArtifact(
                         name = ArtifactNames.mpvRuntimeJar(platformId),
@@ -934,12 +934,21 @@ class WithMatrix(
                         "msystem" to "CLANGARM64",
                         "update" to "true",
                         "install" to """
+                            git
                             mingw-w64-clang-aarch64-clang
                             mingw-w64-clang-aarch64-lld
+                            mingw-w64-clang-aarch64-libass
+                            mingw-w64-clang-aarch64-libplacebo
+                            mingw-w64-clang-aarch64-meson
+                            mingw-w64-clang-aarch64-ninja
                             mingw-w64-clang-aarch64-pkgconf
                             mingw-w64-clang-aarch64-nasm
                             mingw-w64-clang-aarch64-openssl
                             mingw-w64-clang-aarch64-ca-certificates
+                            mingw-w64-clang-aarch64-python-certifi
+                            mingw-w64-clang-aarch64-python
+                            mingw-w64-clang-aarch64-shaderc
+                            mingw-w64-clang-aarch64-spirv-cross
                         """.trimIndent(),
                     ),
                 ),
@@ -1021,12 +1030,20 @@ class WithMatrix(
 
     fun JobBuilder<*>.gradleCheck() {
         if (matrix.runTests) {
+            val tasks = if (matrix.isWindowsAArch64) {
+                // Kotlin/Native does not publish a Windows AArch64 host distribution, so the root
+                // check task cannot configure its Native targets on this runner. The mpv desktop
+                // suite is architecture-neutral and exercises the freshly built ARM64 runtime.
+                ":mediamp-mpv:desktopTest"
+            } else {
+                "check"
+            }
             uses(
                 name = "Check",
                 action = Retry_Untyped(
                     maxAttempts_Untyped = "2",
                     timeoutMinutes_Untyped = "60",
-                    command_Untyped = "./gradlew check " + matrix.gradleArgs,
+                    command_Untyped = "./gradlew $tasks " + matrix.gradleArgs,
                 ),
             )
         }
@@ -1116,10 +1133,11 @@ class WithMatrix(
     }
 
     /**
-     * mpv 在当前 host 上的 runtime jar 任务. mpv 没有 windows-arm64 目标.
+     * mpv 在当前 host 上的 runtime jar 任务.
      */
     fun mpvHostRuntimeJarInfo(): Pair<String, String>? = when {
         matrix.isWindows && matrix.isX64 -> ":mediamp-mpv:mpvRuntimeJarWindowsX64" to "windows-x64"
+        matrix.isWindows && matrix.isAArch64 -> ":mediamp-mpv:mpvRuntimeJarWindowsArm64" to "windows-arm64"
         matrix.isUbuntu && matrix.isX64 -> ":mediamp-mpv:mpvRuntimeJarLinuxX64" to "linux-x64"
         matrix.isMacOS && matrix.isX64 -> ":mediamp-mpv:mpvRuntimeJarMacosX64" to "macos-x64"
         matrix.isMacOSAArch64 -> ":mediamp-mpv:mpvRuntimeJarMacosArm64" to "macos-arm64"

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
@@ -266,7 +266,7 @@ private fun FfmpegBuildContext.windowsArm64Target(): FfmpegBuildTarget {
             "--target-os=mingw32",
             "--cc=${msys2Dir.resolve("clangarm64/bin/clang.exe").absolutePath.toMsysPath()}",
             "--cxx=${msys2Dir.resolve("clangarm64/bin/clang++.exe").absolutePath.toMsysPath()}",
-        ) + opensslHttpTlsFlags,
+        ) + opensslHttpTlsFlags + windowsD3d11vaFlags,
         env = mapOf("MSYSTEM" to "CLANGARM64"),
         shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
         libExtension = "dll",

--- a/buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt
@@ -125,6 +125,7 @@ private fun registerMpvTasks(
         wrapDependencies.set(target.wrapDependencies)
         wrapFiles.set(target.wrapFiles)
         msys2Packages.set(target.msys2Packages)
+        target.msysSubsystem?.let { msysSubsystem.set(it) }
         buildDirPath.set(buildDir)
         stagedSourceDir.set(buildDir.map { it.dir("source") })
         this.configStamp.set(configStamp)
@@ -200,6 +201,7 @@ private fun registerMpvTasks(
         jniLibrary.set(jniOutputFile)
         runtimeDirName.set(target.runtime.runtimeDirName)
         postProcessing.set(target.runtime.postProcessing.name)
+        target.msysSubsystem?.let { msysSubsystem.set(it) }
         this.outputDir.set(outputDirProvider)
         if (msys2Dir != null) {
             this.msys2Dir.set(msys2Dir)

--- a/buildSrc/src/main/kotlin/mpv/MpvRuntimePublishing.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvRuntimePublishing.kt
@@ -194,7 +194,7 @@ private fun runtimeManifestEntries(
             val msys2Root = msys2Dir ?: error("MSYS2 directory must be available when packaging Windows mpv runtimes.")
             orderWindowsDllsByDependencies(
                 execOperations = execOperations,
-                objdumpExecutable = resolveWindowsObjdump(msys2Root),
+                objdumpExecutable = resolveWindowsObjdump(msys2Root, windowsMsysBinDir(target)),
                 dllFiles = dependencyLibraries,
             )
         }
@@ -220,6 +220,9 @@ private fun runtimeManifestEntries(
     return (orderedShared + wrapperFiles.sortedBy { it.name.lowercase() })
         .map { manifestRelativePath(runtimeRoot, it) }
 }
+
+private fun windowsMsysBinDir(target: DesktopRuntimeTarget): String =
+    if (target.targetName == "WindowsArm64") "clangarm64/bin" else "ucrt64/bin"
 
 private fun wrapperLibraryName(os: String): String =
     when (os) {

--- a/buildSrc/src/main/kotlin/mpv/MpvSupport.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvSupport.kt
@@ -70,7 +70,11 @@ internal class MpvBuildContext(
         enabledBuildVariantFamilies.includesBuildVariant(family)
 
     fun hostDesktopTargetName(): String? = when (hostOs) {
-        Os.Windows -> "WindowsX64"
+        Os.Windows -> when (hostArch) {
+            Arch.AARCH64 -> "WindowsArm64"
+            Arch.X86_64 -> "WindowsX64"
+            Arch.UNKNOWN -> null
+        }
         Os.Linux -> "LinuxX64"
         Os.MacOS -> when (hostArch) {
             Arch.AARCH64 -> "MacosArm64"

--- a/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
@@ -9,6 +9,7 @@
 package mpv
 
 import Os
+import Arch
 import getPropertyOrNull
 import nativebuild.AndroidAbi
 import nativebuild.androidTargetName
@@ -81,6 +82,8 @@ internal data class MpvBuildTarget(
     val wrapDependencies: List<String> = emptyList(),
     val wrapFiles: Map<String, String> = emptyMap(),
     val msys2Packages: List<String> = emptyList(),
+    /** MSYS2 subsystem prefix used by Windows targets (`ucrt64` or `clangarm64`). */
+    val msysSubsystem: String? = null,
     /**
      * Version probe command lines identifying the meson toolchain and the system
      * libraries mpv links against (see [nativebuild.ToolchainFingerprintValueSource]).
@@ -159,28 +162,61 @@ private fun jniCompilerFallback(context: MpvBuildContext, default: String): Stri
 // Windows
 // ---------------------------------------------------------------------------------------
 
-internal fun MpvBuildContext.windowsTarget(): MpvBuildTarget {
+internal fun MpvBuildContext.windowsTarget(): MpvBuildTarget = when (hostArch) {
+    Arch.AARCH64 -> windowsTarget(
+        name = "WindowsArm64",
+        ffmpegTargetName = "WindowsArm64",
+        msystem = "CLANGARM64",
+        msysSubsystem = "clangarm64",
+        packagePrefix = "mingw-w64-clang-aarch64",
+        compilerExecutable = "clang++.exe",
+        compilerPackage = "clang",
+    )
+
+    Arch.X86_64 -> windowsTarget(
+        name = "WindowsX64",
+        ffmpegTargetName = "WindowsX64",
+        msystem = "UCRT64",
+        msysSubsystem = "ucrt64",
+        packagePrefix = "mingw-w64-ucrt-x86_64",
+        compilerExecutable = "g++.exe",
+        compilerPackage = "gcc",
+    )
+
+    Arch.UNKNOWN -> error("Failed to configure mpv tasks, unknown Windows host architecture.")
+}
+
+private fun MpvBuildContext.windowsTarget(
+    name: String,
+    ffmpegTargetName: String,
+    msystem: String,
+    msysSubsystem: String,
+    packagePrefix: String,
+    compilerExecutable: String,
+    compilerPackage: String,
+): MpvBuildTarget {
     val msys2Root = project.resolveMsys2Dir()
     val msys2Packages = listOf(
         "git",
-        "mingw-w64-ucrt-x86_64-ca-certificates",
-        "mingw-w64-ucrt-x86_64-gcc",
-        "mingw-w64-ucrt-x86_64-libass",
-        "mingw-w64-ucrt-x86_64-libplacebo",
-        "mingw-w64-ucrt-x86_64-meson",
-        "mingw-w64-ucrt-x86_64-ninja",
-        "mingw-w64-ucrt-x86_64-pkgconf",
-        "mingw-w64-ucrt-x86_64-python-certifi",
-        "mingw-w64-ucrt-x86_64-python",
-        "mingw-w64-ucrt-x86_64-shaderc",
-        "mingw-w64-ucrt-x86_64-spirv-cross",
+        "$packagePrefix-ca-certificates",
+        "$packagePrefix-$compilerPackage",
+        "$packagePrefix-libass",
+        "$packagePrefix-libplacebo",
+        "$packagePrefix-meson",
+        "$packagePrefix-ninja",
+        "$packagePrefix-pkgconf",
+        "$packagePrefix-python-certifi",
+        "$packagePrefix-python",
+        "$packagePrefix-shaderc",
+        "$packagePrefix-spirv-cross",
     )
     return MpvBuildTarget(
-        name = "WindowsX64",
+        name = name,
         family = "windows",
-        ffmpegTargetName = "WindowsX64",
+        ffmpegTargetName = ffmpegTargetName,
         shell = msys2Root.resolve("usr/bin/bash.exe").absolutePath,
-        env = mapOf("MSYSTEM" to "UCRT64"),
+        env = mapOf("MSYSTEM" to msystem),
+        msysSubsystem = msysSubsystem,
         msys2Packages = msys2Packages,
         toolchainProbes = listOf(
             listOf(msys2Root.resolve("usr/bin/pacman.exe").absolutePath, "-Q") + msys2Packages,
@@ -204,7 +240,7 @@ internal fun MpvBuildContext.windowsTarget(): MpvBuildTarget {
             "-Daaudio=disabled",
         ),
         jni = MpvJniToolchain(
-            compilerCommand = pathForShell(msys2Root.resolve("ucrt64/bin/g++.exe"), true),
+            compilerCommand = pathForShell(msys2Root.resolve("$msysSubsystem/bin/$compilerExecutable"), true),
             compilerArgs = listOf(CPP_STANDARD_FLAG, "-fPIC", "-shared", "-D_WIN32_WINNT=0x0A00"),
             // D3D11 render path (render_d3d11.cpp); windowscodecs/ole32 are for the WIC PNG readback.
             linkerArgs = listOf("-ld3d11", "-ld3d12", "-ldxgi", "-ldxguid", "-lwindowscodecs", "-lole32"),
@@ -433,6 +469,7 @@ internal fun MpvBuildContext.androidTarget(abi: AndroidAbi): MpvBuildTarget {
         androidAbi = abi,
         shell = if (hostOs == Os.Windows) project.resolveMsys2Dir().resolve("usr/bin/bash.exe").absolutePath else "bash",
         env = if (hostOs == Os.Windows) mapOf("MSYSTEM" to "UCRT64") else emptyMap(),
+        msysSubsystem = if (hostOs == Os.Windows) "ucrt64" else null,
         toolchainProbes = toolchainProbes,
         wrapDependencies = listOf(
             "expat",

--- a/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
@@ -75,6 +75,10 @@ abstract class MpvConfigureTask : DefaultTask() {
 
     @get:Input
     @get:Optional
+    abstract val msysSubsystem: Property<String>
+
+    @get:Input
+    @get:Optional
     abstract val crossFileContent: Property<String>
 
     /**
@@ -107,6 +111,7 @@ abstract class MpvConfigureTask : DefaultTask() {
         val mesonBuildDir = buildRoot.resolve("meson")
         val installDir = buildRoot.resolve("install")
         val windowsMsys = hostOsName.get() == "Windows"
+        val windowsMsysPrefix = msysSubsystem.orNull ?: "ucrt64"
         val ffmpegInstall = ffmpegInstallDir.get().asFile
 
         require(ffmpegInstall.isDirectory) {
@@ -147,8 +152,8 @@ abstract class MpvConfigureTask : DefaultTask() {
         if (windowsMsys) {
             val msys2Root = msys2Dir.orNull?.asFile
                 ?: error("MSYS2 directory must be configured for Windows mpv builds.")
-            val certFile = msys2Root.resolve("ucrt64/etc/ssl/cert.pem")
-            val certDir = msys2Root.resolve("ucrt64/etc/ssl/certs")
+            val certFile = msys2Root.resolve("$windowsMsysPrefix/etc/ssl/cert.pem")
+            val certDir = msys2Root.resolve("$windowsMsysPrefix/etc/ssl/certs")
             if (certFile.isFile) {
                 baseEnv["SSL_CERT_FILE"] = pathForShell(certFile, windowsMsys)
             }
@@ -166,7 +171,7 @@ abstract class MpvConfigureTask : DefaultTask() {
         } else {
             val prefix = pathForShell(pkgConfigDir, windowsMsys)
             val defaultPkgConfigPaths = if (windowsMsys) {
-                listOf("/ucrt64/lib/pkgconfig", "/ucrt64/share/pkgconfig")
+                listOf("/$windowsMsysPrefix/lib/pkgconfig", "/$windowsMsysPrefix/share/pkgconfig")
             } else {
                 emptyList()
             }
@@ -540,6 +545,10 @@ abstract class MpvAssembleTask : DefaultTask() {
     @get:Internal
     abstract val msys2Dir: DirectoryProperty
 
+    @get:Input
+    @get:Optional
+    abstract val msysSubsystem: Property<String>
+
     @get:Inject
     abstract val execOperations: ExecOperations
 
@@ -564,7 +573,13 @@ abstract class MpvAssembleTask : DefaultTask() {
             MpvRuntimePostProcessing.WINDOWS_COLLECT_DLLS -> {
                 val msys2Root = msys2Dir.orNull?.asFile
                     ?: error("MSYS2 directory must be configured for Windows mpv assembly.")
-                collectWindowsRuntimeDlls(execOperations, logger, msys2Root, runtimeDir)
+                collectWindowsRuntimeDlls(
+                    execOperations,
+                    logger,
+                    msys2Root,
+                    msysSubsystem.orNull ?: "ucrt64",
+                    runtimeDir,
+                )
             }
 
             MpvRuntimePostProcessing.MACOS_BUNDLE_DYLIBS -> {
@@ -731,10 +746,11 @@ private fun collectWindowsRuntimeDlls(
     execOperations: ExecOperations,
     logger: Logger,
     msys2Dir: File,
+    msysSubsystem: String,
     outputBin: File,
 ) {
-    val ucrt64Bin = msys2Dir.resolve("ucrt64/bin")
-    val objdumpExecutable = resolveWindowsObjdump(msys2Dir)
+    val msysBin = msys2Dir.resolve("$msysSubsystem/bin")
+    val objdumpExecutable = resolveWindowsObjdump(msys2Dir, "$msysSubsystem/bin")
     val copied = mutableSetOf<String>()
 
     fun shouldIgnore(dllName: String): Boolean = isWindowsSystemLibrary(dllName)
@@ -753,7 +769,7 @@ private fun collectWindowsRuntimeDlls(
                     return@forEach
                 }
 
-                val fromMsys = ucrt64Bin.resolve(dllName)
+                val fromMsys = msysBin.resolve(dllName)
                 if (fromMsys.exists()) {
                     fromMsys.copyTo(existing, overwrite = true)
                     if (copied.add(existing.name.lowercase())) {

--- a/mediamp-mpv-demo/build.gradle.kts
+++ b/mediamp-mpv-demo/build.gradle.kts
@@ -63,12 +63,13 @@ tasks.register<JavaExec>("runD3D11") {
     mainClass = "org.openani.mediamp.mpvdemo.MpvD3D11MainKt"
     classpath = sourceSets["main"].runtimeClasspath
     val runtimeTarget = when {
-        System.getProperty("os.name").contains("Windows") -> "WindowsX64"
+        System.getProperty("os.name").contains("Windows") ->
+            if (System.getProperty("os.arch") == "aarch64") "WindowsArm64" else "WindowsX64"
         System.getProperty("os.name").contains("Linux") -> "LinuxX64"
         System.getProperty("os.arch") == "aarch64" -> "MacosArm64"
         else -> "MacosX64"
     }
-    val runtimeSubdir = if (runtimeTarget == "WindowsX64") "bin" else "lib"
+    val runtimeSubdir = if (runtimeTarget.startsWith("Windows")) "bin" else "lib"
     systemProperty(
         "mediamp.mpv.runtime.dir",
         project(":mediamp-mpv").layout.buildDirectory

--- a/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/MpvD3D11Main.kt
+++ b/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/MpvD3D11Main.kt
@@ -46,7 +46,8 @@ fun main(args: Array<String>) {
         ?: "av://lavfi:testsrc2=size=1280x720:rate=60"
 
     val hostRuntimeTask = when {
-        System.getProperty("os.name").contains("Windows") -> "mpvAssembleWindowsX64"
+        System.getProperty("os.name").contains("Windows") ->
+            if (System.getProperty("os.arch") == "aarch64") "mpvAssembleWindowsArm64" else "mpvAssembleWindowsX64"
         System.getProperty("os.name").contains("Linux") -> "mpvAssembleLinuxX64"
         System.getProperty("os.arch") == "aarch64" -> "mpvAssembleMacosArm64"
         else -> "mpvAssembleMacosX64"

--- a/mediamp-mpv/build.gradle.kts
+++ b/mediamp-mpv/build.gradle.kts
@@ -87,10 +87,18 @@ val compileJniDevMacos = tasks.register<Exec>("compileJniDevMacos") {
     )
 }
 
+val hostMpvTargetName = when (getOs()) {
+    Os.Windows -> if (getArch() == Arch.AARCH64) "WindowsArm64" else "WindowsX64"
+    Os.Linux -> "LinuxX64"
+    Os.MacOS -> if (getArch() == Arch.AARCH64) "MacosArm64" else "MacosX64"
+    else -> null
+}
+val hostMpvAssembleTaskName = hostMpvTargetName?.let { "mpvAssemble$it" }
+
 tasks.withType<Test>().configureEach {
     // Where MpvMediampPlayerSmokeTest loads the native runtime from:
     // - Windows: the assembled meson runtime (no system libmpv exists, and the D3D11
-    //     render API needs our patched build anyway) — mpv-output/WindowsX64/bin.
+    //     render API needs our patched build anyway) — mpv-output/<target>/bin.
     // - macOS on a required runner (self-hosted, full environment): the assembled meson
     //     runtime — mpv-output/<target>/lib, which includes libmediampv.dylib. That
     //     runner has no Homebrew libmpv, so the dev fast-path below would skip and, under
@@ -102,9 +110,9 @@ tasks.withType<Test>().configureEach {
     val testNativeDir = when {
         getOs() == Os.Windows -> {
             if (mpvTestRequired) {
-                dependsOn("mpvAssembleWindowsX64")
+                hostMpvAssembleTaskName?.let { dependsOn(it) }
             }
-            layout.buildDirectory.dir("mpv-output/WindowsX64/bin").get().asFile
+            layout.buildDirectory.dir("mpv-output/$hostMpvTargetName/bin").get().asFile
         }
 
         getOs() == Os.MacOS && mpvTestRequired -> {
@@ -123,14 +131,7 @@ tasks.withType<Test>().configureEach {
     systemProperty("mediamp.mpv.test.required", getPropertyOrNull("mediamp.mpv.test.required") ?: "false")
 }
 
-val hostMpvTargetName = when (getOs()) {
-    Os.Windows -> "WindowsX64"
-    Os.Linux -> "LinuxX64"
-    Os.MacOS -> if (getArch() == Arch.AARCH64) "MacosArm64" else "MacosX64"
-    else -> null
-}
 val hostMpvOutputDir = hostMpvTargetName?.let { layout.buildDirectory.dir("mpv-output/$it") }
-val hostMpvAssembleTaskName = hostMpvTargetName?.let { "mpvAssemble$it" }
 val legacyNativeBuildDir = projectDir.resolve("build-ci")
 
 val nativeJarForCurrentPlatform = tasks.register("nativeJarForCurrentPlatform", Jar::class.java) {


### PR DESCRIPTION
## Summary

Add a Windows ARM64 runtime for `mediamp-mpv`.

- Build FFmpeg and mpv with the MSYS2 `CLANGARM64` toolchain.
- Select the ARM64 runtime, compiler, MSYS2 subsystem, and dependency DLL directory on Windows ARM64 hosts.
- Package and publish the `windows-arm64` mpv runtime alongside the existing desktop artifacts.
- Run `:mediamp-mpv:desktopTest` on Windows ARM64 as the equivalent of the x64 native validation.

## Validation

- `:mediamp-mpv:desktopTest -Pmediamp.mpv.test.required=true -Pmediamp.ffmpeg.buildvariant=windows -Pmediamp.mpv.buildvariant=windows`
  - Passed on Windows ARM64: 42 tests, 0 failures.
- Interactive D3D11 demo using a locally generated H.264 High Profile 1920x1080@60 sample.
  - Task Manager reported Video Decode at 24% and GPU 3D at 21%.

![Windows ARM64 H.264 hardware decode and D3D11 rendering](https://github.com/user-attachments/assets/0fdc5091-698f-43da-9f87-2dc6e537f39e)
