### PR TITLE
feat(exoplayer): add opt-in native WSOLA audio time-stretch

### DIFF
--- a/buildSrc/src/main/kotlin/wsola/WsolaAndroidBuild.kt
+++ b/buildSrc/src/main/kotlin/wsola/WsolaAndroidBuild.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package wsola
+
+import com.android.build.api.variant.KotlinMultiplatformAndroidComponentsExtension
+import Os
+import getOs
+import getPropertyOrNull
+import nativebuild.DEFAULT_ANDROID_ABIS
+import nativebuild.androidNdkHostTag
+import nativebuild.resolveAndroidAbis
+import nativebuild.resolveNdkDir
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.register
+
+
+/**
+ * Builds `libmediamp_wsola.so` (WSOLA time-stretch for the ExoPlayer backend) with the
+ * NDK LLVM clang++, one task per Android ABI, and injects the result into the module's
+ * jniLibs via `variant.sources.jniLibs` (same mechanism as the mpv packaging).
+ *
+ * Properties:
+ *  - `-Pmediamp.exoplayer.wsola.skip=true` disables everything (Kotlin falls back to Sonic).
+ *  - `-Pmediamp.exoplayer.wsola.androidabis=arm64-v8a,x86_64` restricts the ABI set.
+ */
+
+abstract class CompileWsolaLibraryTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val compiler: RegularFileProperty
+
+    @get:Input
+    abstract val compilerArgs: ListProperty<String>
+
+    @get:Input
+    abstract val windowsHost: Property<Boolean>
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceDir: DirectoryProperty
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val out = outputFile.get().asFile
+        out.parentFile.mkdirs()
+        val sources = sourceDir.get().asFile.listFiles()
+            ?.filter { it.extension == "cpp" }
+            ?.sortedBy { it.name }
+            .orEmpty()
+        require(sources.isNotEmpty()) { "No .cpp sources in ${sourceDir.get().asFile}" }
+        val launcher = if (windowsHost.get()) listOf("cmd.exe", "/d", "/c") else emptyList()
+        val command = launcher +
+            compiler.get().asFile.absolutePath +
+            compilerArgs.get() +
+            sources.map { it.absolutePath } +
+            listOf("-o", out.absolutePath)
+        val process = ProcessBuilder(command)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exitCode = process.waitFor()
+        if (exitCode != 0) {
+            throw GradleException(
+                "WSOLA compile failed (exit $exitCode): ${command.joinToString(" ")}\n$output",
+            )
+        }
+        logger.info(output)
+    }
+}
+
+abstract class PrepareWsolaAndroidJniLibsTask : DefaultTask() {
+    @get:InputFiles
+    abstract val inputFiles: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        project.sync {
+            inputFiles.files.sortedBy { it.parentFile.name }.forEach { library ->
+                from(library) {
+                    into(library.parentFile.name)
+                }
+            }
+            into(outputDir)
+        }
+    }
+}
+
+fun Project.configureWsolaAndroidBuild() {
+    if (getPropertyOrNull("mediamp.exoplayer.wsola.skip")?.toBoolean() == true) {
+        logger.lifecycle("Skipping WSOLA native build: mediamp.exoplayer.wsola.skip=true")
+        return
+    }
+    val ndkDir = runCatching { resolveNdkDir() }.getOrElse {
+        logger.warn("Android NDK not found – skipping WSOLA native build. Set ndk.dir or ANDROID_NDK_HOME to enable.")
+        return
+    }
+    val hostOs = getOs()
+    val hostTag = androidNdkHostTag(hostOs)
+    val windowsHost = hostOs == Os.Windows
+    val llvmBinDir = ndkDir.resolve("toolchains/llvm/prebuilt/$hostTag/bin")
+    require(llvmBinDir.isDirectory) { "NDK LLVM toolchain not found at '$llvmBinDir'." }
+    val sysroot = ndkDir.resolve("toolchains/llvm/prebuilt/$hostTag/sysroot")
+
+    val abis = resolveAndroidAbis(
+        propertyNames = listOf("mediamp.exoplayer.wsola.androidabis"),
+        availableAbis = DEFAULT_ANDROID_ABIS,
+    )
+
+    val compileTasks = mutableListOf<TaskProvider<CompileWsolaLibraryTask>>()
+    abis.forEach { abi ->
+        val taskName = "compileWsola${abi.abi.replace("-", "")}"
+        compileTasks += tasks.register<CompileWsolaLibraryTask>(taskName) {
+            group = "mediamp"
+            description = "Compile libmediamp_wsola.so for Android ${abi.abi}"
+            val compilerSuffix = if (windowsHost) ".cmd" else ""
+            compiler.set(
+                llvmBinDir.resolve("${abi.clangTriple}${abi.apiLevel}-clang++$compilerSuffix"),
+            )
+            this.windowsHost.set(windowsHost)
+            compilerArgs.set(
+                listOf(
+                    "--sysroot=${sysroot.absolutePath}",
+                    "-std=c++17",
+                    "-O2",
+                    "-DNDEBUG",
+                    "-Wall",
+                    "-Wextra",
+                    "-Werror",
+                    "-fPIC",
+                    "-shared",
+                    "-Wl,-z,max-page-size=16384",
+                    "-llog",
+                ),
+            )
+            sourceDir.set(layout.projectDirectory.dir("src/cpp"))
+            outputFile.set(
+                layout.buildDirectory.file("generated/wsola-jniLibs/${abi.abi}/libmediamp_wsola.so"),
+            )
+        }
+    }
+
+    val prepareTask = tasks.register<PrepareWsolaAndroidJniLibsTask>("prepareWsolaAndroidJniLibs") {
+        group = "mediamp"
+        description = "Prepare merged WSOLA jniLibs directory for Android variants"
+        dependsOn(compileTasks)
+        inputFiles.from(compileTasks.map { it.flatMap(CompileWsolaLibraryTask::outputFile) })
+        outputDir.set(layout.buildDirectory.dir("generated/wsola-jniLibs-merged"))
+    }
+
+    val androidComponents =
+        extensions.findByName("androidComponents") as? KotlinMultiplatformAndroidComponentsExtension
+    androidComponents?.onVariants(androidComponents.selector().all()) { variant ->
+        variant.sources.jniLibs?.addGeneratedSourceDirectory(
+            prepareTask,
+            PrepareWsolaAndroidJniLibsTask::outputDir,
+        )
+    }
+}

--- a/mediamp-exoplayer/build.gradle.kts
+++ b/mediamp-exoplayer/build.gradle.kts
@@ -9,6 +9,10 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.SourcesJar
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import wsola.configureWsolaAndroidBuild
 
 plugins {
     kotlin("multiplatform")
@@ -39,6 +43,38 @@ kotlin {
             implementation(libs.junit)
         }
     }
+}
+
+configureWsolaAndroidBuild()
+
+val wsolaLicensePath =
+    "META-INF/licenses/org.openani.mediamp/mediamp-exoplayer/scaletempo2.txt"
+val verifyWsolaLicensePackaging by tasks.registering {
+    group = "verification"
+    description = "Verifies that the Android AAR includes the scaletempo2 BSD license."
+    dependsOn("bundleAndroidMainAar")
+
+    val aar = layout.buildDirectory.file("outputs/aar/${project.name}.aar")
+    inputs.file(aar)
+
+    doLast {
+        ZipFile(aar.get().asFile).use { aarFile ->
+            val classesJar = aarFile.getEntry("classes.jar")
+                ?: error("classes.jar is missing from ${aar.get().asFile}")
+            val licensePackaged = aarFile.getInputStream(classesJar).use { input ->
+                ZipInputStream(ByteArrayInputStream(input.readBytes())).use { classes ->
+                    generateSequence { classes.nextEntry }.any { it.name == wsolaLicensePath }
+                }
+            }
+            check(licensePackaged) {
+                "$wsolaLicensePath is missing from classes.jar in ${aar.get().asFile}"
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(verifyWsolaLicensePackaging)
 }
 
 mavenPublishing {

--- a/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerAudioTimeStretch.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerAudioTimeStretch.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer
+
+/**
+ * Audio time-stretch backend used by [ExoPlayerMediampPlayer] for playback speed changes.
+ *
+ * This is a creation-time option; it cannot be changed after the player is created.
+ */
+public enum class ExoPlayerAudioTimeStretch {
+    /**
+     * Media3 default behavior: [androidx.media3.common.audio.SonicAudioProcessor] via the default
+     * audio processor chain. This is what ExoPlayer does out of the box.
+     */
+    Media3Default,
+
+    /**
+     * High-quality WSOLA time-stretch implemented in a native library (`libmediamp_wsola`).
+     *
+     * If the native library cannot be loaded at runtime, or the input audio format is not
+     * supported (WSOLA accepts mono/stereo 16-bit PCM and PCM float), the player transparently
+     * falls back to [androidx.media3.common.audio.SonicAudioProcessor].
+     */
+    HighQualityWsola,
+}

--- a/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
@@ -51,6 +51,7 @@ import org.openani.mediamp.PlaybackState
 import org.openani.mediamp.exoplayer.internal.ExoFramePreview
 import org.openani.mediamp.exoplayer.internal.ExoPlaybackStateMapper
 import org.openani.mediamp.exoplayer.internal.SeekableInputDataSource
+import org.openani.mediamp.exoplayer.internal.WsolaRenderersFactory
 import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.Buffering
@@ -82,7 +83,17 @@ import androidx.media3.common.Player as Media3Player
 class ExoPlayerMediampPlayer @UiThread constructor(
     context: Context,
     parentCoroutineContext: CoroutineContext,
+    private val audioTimeStretch: ExoPlayerAudioTimeStretch = ExoPlayerAudioTimeStretch.Media3Default,
 ) : AbstractMediampPlayer<ExoPlayerMediampPlayer.ExoPlayerData>(Dispatchers.Default) {
+
+    // Keep the previous two-argument JVM constructor for binary compatibility. A Kotlin default
+    // argument lets recompiled source omit audioTimeStretch, but does not preserve the old JVM
+    // constructor descriptor used by already-compiled callers.
+    @UiThread
+    constructor(
+        context: Context,
+        parentCoroutineContext: CoroutineContext,
+    ) : this(context, parentCoroutineContext, ExoPlayerAudioTimeStretch.Media3Default)
     
     public open class ExoPlayerData(
         mediaData: MediaData,
@@ -242,7 +253,13 @@ class ExoPlayerMediampPlayer @UiThread constructor(
     }
 
     private val exoPlayer: ExoPlayer = ExoPlayer.Builder(context)
-        .apply { setTrackSelector(trackSelector) }
+        .apply {
+            setTrackSelector(trackSelector)
+            if (audioTimeStretch == ExoPlayerAudioTimeStretch.HighQualityWsola) {
+                val renderersFactory = WsolaRenderersFactory(context)
+                setRenderersFactory(renderersFactory)
+            }
+        }
         .build()
         .apply {
             playWhenReady = true

--- a/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayerFactory.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayerFactory.kt
@@ -27,7 +27,8 @@ class ExoPlayerMediampPlayerFactory : MediampPlayerFactory<ExoPlayerMediampPlaye
     fun create(
         context: Context,
         parentCoroutineContext: CoroutineContext,
+        audioTimeStretch: ExoPlayerAudioTimeStretch = ExoPlayerAudioTimeStretch.Media3Default,
     ): ExoPlayerMediampPlayer {
-        return ExoPlayerMediampPlayer(context, parentCoroutineContext)
+        return ExoPlayerMediampPlayer(context, parentCoroutineContext, audioTimeStretch)
     }
 }

--- a/mediamp-exoplayer/src/androidMain/kotlin/internal/FallbackTimeStretchAudioProcessor.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/internal/FallbackTimeStretchAudioProcessor.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer.internal
+
+import android.util.Log
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.audio.AudioProcessor.UnhandledAudioFormatException
+import androidx.media3.common.audio.SonicAudioProcessor
+import androidx.media3.common.util.UnstableApi
+import java.nio.ByteBuffer
+
+/**
+ * Chooses one time-stretch backend when Media3 configures a stream. Mono/stereo PCM16 and PCM
+ * float prefer native WSOLA; unavailable or unsupported streams fall back to
+ * [SonicAudioProcessor]. Audio is sent only to the selected backend.
+ */
+@OptIn(UnstableApi::class)
+internal class FallbackTimeStretchAudioProcessor : AudioProcessor {
+    enum class Backend {
+        /** Media3 has not configured an input format yet. */
+        NOT_CONFIGURED,
+        WSOLA,
+        SONIC,
+    }
+
+    var backend: Backend = Backend.NOT_CONFIGURED
+        private set
+
+    private val wsola = WsolaAudioProcessor()
+    private val sonic = SonicAudioProcessor()
+    private var delegate: AudioProcessor = wsola
+
+    fun setSpeed(speed: Float) {
+        wsola.setSpeed(speed)
+        sonic.setSpeed(speed)
+    }
+
+    fun setPitch(pitch: Float) {
+        // TODO: Route non-default pitch requests to Sonic. Native WSOLA deliberately preserves
+        // the original pitch (1f) while changing playback speed.
+        sonic.setPitch(pitch)
+    }
+
+    override fun configure(inputAudioFormat: AudioFormat): AudioFormat {
+        val useWsola = WsolaProcessorNative.isAvailable && isWsolaSupported(inputAudioFormat)
+        return if (useWsola) {
+            try {
+                backend = Backend.WSOLA
+                delegate = wsola
+                wsola.configure(inputAudioFormat)
+            } catch (e: UnhandledAudioFormatException) {
+                configureWithSonic(
+                    inputAudioFormat,
+                    reason = "native WSOLA rejected the audio format",
+                    cause = e,
+                )
+            }
+        } else {
+            configureWithSonic(
+                inputAudioFormat,
+                reason = "nativeLoaded=${WsolaProcessorNative.isAvailable}, " +
+                    "supportedFormat=${isWsolaSupported(inputAudioFormat)}",
+            )
+        }
+    }
+
+    private fun isWsolaSupported(format: AudioFormat): Boolean {
+        return (format.encoding == C.ENCODING_PCM_16BIT || format.encoding == C.ENCODING_PCM_FLOAT) &&
+            format.channelCount in 1..2
+    }
+
+    private fun configureWithSonic(
+        inputAudioFormat: AudioFormat,
+        reason: String,
+        cause: Throwable? = null,
+    ): AudioFormat {
+        if (backend != Backend.SONIC) {
+            val message = "Falling back from native WSOLA to Sonic: reason=$reason, format=$inputAudioFormat"
+            if (cause == null) {
+                Log.w(TAG, message)
+            } else {
+                Log.w(TAG, message, cause)
+            }
+        }
+        backend = Backend.SONIC
+        delegate = sonic
+        return sonic.configure(inputAudioFormat)
+    }
+
+    override fun isActive(): Boolean = delegate.isActive
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        delegate.queueInput(inputBuffer)
+    }
+
+    override fun queueEndOfStream() {
+        delegate.queueEndOfStream()
+    }
+
+    override fun getOutput(): ByteBuffer = delegate.output
+
+    override fun isEnded(): Boolean = delegate.isEnded
+
+    override fun flush(streamMetadata: AudioProcessor.StreamMetadata) {
+        delegate.flush(streamMetadata)
+    }
+
+    override fun reset() {
+        wsola.reset()
+        sonic.reset()
+        delegate = wsola
+        backend = Backend.NOT_CONFIGURED
+    }
+
+    fun getMediaDuration(playoutDurationUs: Long): Long {
+        return when (delegate) {
+            wsola -> wsola.getMediaDuration(playoutDurationUs)
+            else -> if (sonic.isActive) sonic.getMediaDuration(playoutDurationUs) else playoutDurationUs
+        }
+    }
+
+    private companion object {
+        private const val TAG = "FallbackTimeStretch"
+    }
+}

--- a/mediamp-exoplayer/src/androidMain/kotlin/internal/WsolaAudioProcessor.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/internal/WsolaAudioProcessor.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer.internal
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.audio.AudioProcessor.UnhandledAudioFormatException
+import androidx.media3.common.util.UnstableApi
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Adapts Media3's streaming [AudioProcessor] contract to one native WSOLA instance. It accepts
+ * mono/stereo PCM16 and PCM float; backend selection and Sonic fallback live outside this class.
+ */
+@OptIn(UnstableApi::class)
+internal class WsolaAudioProcessor : AudioProcessor {
+    private var inputAudioFormat: AudioFormat = AudioFormat.NOT_SET
+    private var bytesPerFrame = 0
+
+    private var speed = 1f
+
+    private var handle = 0L
+
+    private var inputEnded = false
+    private var outputDrained = false
+
+    // Media3 consumes this buffer by advancing its position; do not overwrite unread output.
+    private var outputBuffer: ByteBuffer = AudioProcessor.EMPTY_BUFFER
+    private var outputPending = false
+
+    // JNI requires direct memory. Media3 normally provides it; retain a fallback buffer just in case.
+    private var inputScratch: ByteBuffer? = null
+
+    // Used to map playout time back to media time. Native pending frames are excluded at read time.
+    private var totalInputFrames = 0L
+    private var totalOutputFrames = 0L
+
+    fun setSpeed(speed: Float) {
+        require(speed > 0f && speed.isFinite()) { "speed must be finite and positive" }
+        this.speed = speed
+        if (handle != 0L) {
+            WsolaProcessorNative.setSpeed(handle, speed)
+        }
+    }
+
+    override fun configure(inputAudioFormat: AudioFormat): AudioFormat {
+        val sampleFormat = when (inputAudioFormat.encoding) {
+            C.ENCODING_PCM_16BIT -> WsolaProcessorNative.SAMPLE_FORMAT_S16
+            C.ENCODING_PCM_FLOAT -> WsolaProcessorNative.SAMPLE_FORMAT_FLOAT
+            else -> throw UnhandledAudioFormatException(inputAudioFormat)
+        }
+        if (inputAudioFormat.channelCount !in 1..2) {
+            throw UnhandledAudioFormatException(inputAudioFormat)
+        }
+        if (this.inputAudioFormat.sampleRate != inputAudioFormat.sampleRate ||
+            this.inputAudioFormat.channelCount != inputAudioFormat.channelCount ||
+            this.inputAudioFormat.encoding != inputAudioFormat.encoding
+        ) {
+            releaseHandle()
+            handle = WsolaProcessorNative.create(
+                inputAudioFormat.sampleRate,
+                inputAudioFormat.channelCount,
+                sampleFormat,
+            )
+            if (handle == 0L) {
+                throw UnhandledAudioFormatException("native create() failed", inputAudioFormat)
+            }
+            WsolaProcessorNative.setSpeed(handle, speed)
+        }
+        this.inputAudioFormat = inputAudioFormat
+        bytesPerFrame = inputAudioFormat.channelCount *
+            if (sampleFormat == WsolaProcessorNative.SAMPLE_FORMAT_FLOAT) 4 else 2
+        return inputAudioFormat
+    }
+
+    override fun isActive(): Boolean {
+        return handle != 0L && speed != 1f
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        val inputBytes = inputBuffer.remaining()
+        require(inputBytes % bytesPerFrame == 0) {
+            "PCM input must contain complete frames: bytes=$inputBytes, bytesPerFrame=$bytesPerFrame"
+        }
+        val frames = inputBytes / bytesPerFrame
+        if (frames == 0) {
+            return
+        }
+        val directBuffer =
+            if (inputBuffer.isDirect) {
+                inputBuffer
+            } else {
+                val scratch = inputScratch
+                    ?.takeIf { it.capacity() >= inputBuffer.remaining() }
+                    ?: ByteBuffer.allocateDirect(inputBuffer.remaining())
+                        .order(ByteOrder.nativeOrder())
+                        .also { inputScratch = it }
+                scratch.clear()
+                scratch.put(inputBuffer)
+                scratch.flip()
+                scratch
+            }
+        WsolaProcessorNative.queueInput(handle, directBuffer, directBuffer.position(), frames)
+        inputBuffer.position(inputBuffer.limit())
+        totalInputFrames += frames.toLong()
+    }
+
+    override fun queueEndOfStream() {
+        if (handle != 0L && !inputEnded) {
+            WsolaProcessorNative.finishInput(handle)
+        }
+        inputEnded = true
+    }
+
+    override fun getOutput(): ByteBuffer {
+        if (outputPending && outputBuffer.hasRemaining()) {
+            return outputBuffer
+        }
+        ensureOutputCapacity()
+        val maxFrames = outputBuffer.capacity() / bytesPerFrame
+        val frames = WsolaProcessorNative.drainOutput(handle, outputBuffer, maxFrames)
+        totalOutputFrames += frames.toLong()
+        outputBuffer.position(0)
+        outputBuffer.limit(frames * bytesPerFrame)
+        if (frames == 0 && inputEnded) {
+            outputDrained = true
+        }
+        outputPending = true
+        return outputBuffer
+    }
+
+    override fun isEnded(): Boolean = inputEnded && outputDrained
+
+    override fun flush(streamMetadata: AudioProcessor.StreamMetadata) {
+        if (handle != 0L) {
+            WsolaProcessorNative.flush(handle)
+        }
+        inputEnded = false
+        outputDrained = false
+        outputPending = false
+        outputBuffer = AudioProcessor.EMPTY_BUFFER
+        totalInputFrames = 0L
+        totalOutputFrames = 0L
+    }
+
+    override fun reset() {
+        flush(AudioProcessor.StreamMetadata.DEFAULT)
+        releaseHandle()
+        inputAudioFormat = AudioFormat.NOT_SET
+        bytesPerFrame = 0
+        speed = 1f
+        inputScratch = null
+    }
+
+    /**
+     * Maps playout time to media time using frames that have produced output, excluding input still
+     * buffered by JNI or WSOLA.
+     */
+    fun getMediaDuration(playoutDurationUs: Long): Long {
+        if (!isActive) {
+            return playoutDurationUs
+        }
+        return if (totalOutputFrames > 0) {
+            val pendingInputFrames = WsolaProcessorNative.getPendingInputFrames(handle)
+            val processedInputFrames = (totalInputFrames - pendingInputFrames).coerceAtLeast(0.0)
+            (playoutDurationUs * processedInputFrames / totalOutputFrames).toLong()
+        } else {
+            (playoutDurationUs * speed).toLong()
+        }
+    }
+
+    private fun ensureOutputCapacity() {
+        // Capacity is not latency: drainOutput exposes only the frames actually produced.
+        val wanted = maxOf(bytesPerFrame * inputAudioFormat.sampleRate / 2, 4096)
+        if (outputBuffer === AudioProcessor.EMPTY_BUFFER || outputBuffer.capacity() < wanted) {
+            outputBuffer = ByteBuffer.allocateDirect(wanted).order(ByteOrder.nativeOrder())
+        }
+    }
+
+    private fun releaseHandle() {
+        if (handle != 0L) {
+            WsolaProcessorNative.release(handle)
+            handle = 0L
+        }
+    }
+}

--- a/mediamp-exoplayer/src/androidMain/kotlin/internal/WsolaAudioProcessorChain.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/internal/WsolaAudioProcessorChain.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer.internal
+
+import android.content.Context
+import android.util.Log
+import androidx.annotation.OptIn
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessorChain
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
+
+/**
+ * Mirrors Media3's default `silence skipping -> Sonic` chain, replacing the Sonic slot with
+ * [FallbackTimeStretchAudioProcessor]. Playback parameters and time accounting follow the default
+ * chain contract.
+ */
+@OptIn(UnstableApi::class)
+internal class WsolaAudioProcessorChain : AudioProcessorChain {
+    private val silenceSkippingAudioProcessor = SilenceSkippingAudioProcessor()
+    private val timeStretchProcessor = FallbackTimeStretchAudioProcessor()
+    private val audioProcessors: Array<AudioProcessor> =
+        arrayOf(silenceSkippingAudioProcessor, timeStretchProcessor)
+
+    val timeStretchBackend: FallbackTimeStretchAudioProcessor.Backend
+        get() = timeStretchProcessor.backend
+
+    override fun getAudioProcessors(): Array<AudioProcessor> = audioProcessors
+
+    override fun applyPlaybackParameters(playbackParameters: PlaybackParameters): PlaybackParameters {
+        timeStretchProcessor.setSpeed(playbackParameters.speed)
+        timeStretchProcessor.setPitch(playbackParameters.pitch)
+        return playbackParameters
+    }
+
+    override fun applySkipSilenceEnabled(skipSilenceEnabled: Boolean): Boolean {
+        silenceSkippingAudioProcessor.setEnabled(skipSilenceEnabled)
+        return skipSilenceEnabled
+    }
+
+    override fun getMediaDuration(playoutDurationUs: Long): Long {
+        return if (timeStretchProcessor.isActive) {
+            timeStretchProcessor.getMediaDuration(playoutDurationUs)
+        } else {
+            playoutDurationUs
+        }
+    }
+
+    override fun getSkippedOutputFrameCount(): Long = silenceSkippingAudioProcessor.skippedFrames
+}
+
+/** Installs [WsolaAudioProcessorChain] while keeping Media3's default renderers and audio sink. */
+@OptIn(UnstableApi::class)
+internal class WsolaRenderersFactory(
+    context: Context,
+) : DefaultRenderersFactory(context) {
+    /** The most recently installed chain, exposed for diagnostics and tests. */
+    var audioProcessorChain: WsolaAudioProcessorChain? = null
+        private set
+
+    override fun buildAudioSink(
+        context: Context,
+        enableFloatOutput: Boolean,
+        enableAudioTrackPlaybackParams: Boolean
+    ): AudioSink {
+        val chain = WsolaAudioProcessorChain().also { audioProcessorChain = it }
+        Log.i(TAG, "Installed WSOLA audio processor chain (fallback to Sonic if unavailable)")
+        return DefaultAudioSink.Builder(context)
+            .setEnableFloatOutput(enableFloatOutput)
+            .setEnableAudioOutputPlaybackParameters(enableAudioTrackPlaybackParams)
+            .setAudioProcessorChain(chain)
+            .build()
+    }
+
+    private companion object {
+        private const val TAG = "WsolaRenderersFactory"
+    }
+}

--- a/mediamp-exoplayer/src/androidMain/kotlin/internal/WsolaProcessorNative.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/internal/WsolaProcessorNative.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer.internal
+
+import android.util.Log
+
+/**
+ * JNI contract for `libmediamp_wsola`. Each [create] call returns an opaque handle for one native
+ * WSOLA instance; callers keep the handle and pass it back until [release].
+ *
+ * The library is loaded on first use. External methods require [isAvailable] and direct buffers.
+ * One PCM frame contains one sample for every channel.
+ */
+internal object WsolaProcessorNative {
+    private const val TAG = "WsolaProcessorNative"
+
+    val isAvailable: Boolean by lazy {
+        try {
+            System.loadLibrary("mediamp_wsola")
+            true
+        } catch (e: UnsatisfiedLinkError) {
+            Log.w(TAG, "Native library mediamp_wsola is not available, WSOLA time-stretch disabled", e)
+            false
+        }
+    }
+
+    /** Interleaved signed 16-bit PCM samples (2 bytes per sample). */
+    const val SAMPLE_FORMAT_S16: Int = 0
+
+    /** Interleaved 32-bit float PCM samples (4 bytes per sample). */
+    const val SAMPLE_FORMAT_FLOAT: Int = 1
+
+    /**
+     * Returns an opaque native handle, or `0` when allocation fails.
+     *
+     * [sampleFormat] is one of [SAMPLE_FORMAT_S16] or [SAMPLE_FORMAT_FLOAT] and fixes the
+     * encoding of every buffer passed to [queueInput] and [drainOutput] for this instance.
+     */
+    external fun create(sampleRate: Int, channels: Int, sampleFormat: Int): Long
+
+    external fun setSpeed(handle: Long, speed: Float)
+
+    /**
+     * Queues [frames] frames of interleaved PCM (in the format given to [create]) starting at
+     * [byteOffset] in [buf].
+     */
+    external fun queueInput(handle: Long, buf: java.nio.ByteBuffer, byteOffset: Int, frames: Int)
+
+    /**
+     * Drains up to [maxFrames] frames of processed output (in the format given to [create]) from
+     * the beginning of [buf].
+     * Returns the number written; `0` means more input is needed or an ended stream is drained.
+     */
+    external fun drainOutput(handle: Long, buf: java.nio.ByteBuffer, maxFrames: Int): Int
+
+    /** Input accepted by JNI but not yet represented in WSOLA output. */
+    external fun getPendingInputFrames(handle: Long): Double
+
+    /** Discards buffered audio but keeps the instance, format, and speed. */
+    external fun flush(handle: Long)
+
+    /** Closes input; callers must continue [drainOutput] until it returns `0`. */
+    external fun finishInput(handle: Long)
+
+    external fun release(handle: Long)
+}

--- a/mediamp-exoplayer/src/androidMain/resources/META-INF/licenses/org.openani.mediamp/mediamp-exoplayer/scaletempo2.txt
+++ b/mediamp-exoplayer/src/androidMain/resources/META-INF/licenses/org.openani.mediamp/mediamp-exoplayer/scaletempo2.txt
@@ -1,0 +1,36 @@
+scaletempo2
+
+This implementation is derived from mpv's scaletempo2, which was derived from
+Chromium's AudioRendererAlgorithm:
+
+https://github.com/mpv-player/mpv/blob/41f6a645068483470267271e1d09966ca3b9f413/audio/filter/af_scaletempo2_internals.c
+https://chromium.googlesource.com/chromium/chromium/+/51ed77e3f37a9a9b80d6d0a8259e84a8ca635259/media/filters/audio_renderer_algorithm.cc
+
+MediaMP ports the algorithm core to standalone C++17 and adds its own JNI and
+Media3 integration. The algorithm core retains the following license:
+
+Copyright 2015 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mediamp-exoplayer/src/cpp/scaletempo2.cpp
+++ b/mediamp-exoplayer/src/cpp/scaletempo2.cpp
@@ -1,0 +1,818 @@
+// This file was ported from mpv (https://github.com/mpv-player/mpv),
+// audio/filter/af_scaletempo2_internals.c, which was in turn ported from Chromium
+// (https://chromium.googlesource.com/chromium/chromium/+/51ed77e3f37a9a9b80d6d0a8259e84a8ca635259/media/filters/audio_renderer_algorithm.cc)
+//
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Port notes (mediamp):
+//  - Faithful C++17 port of the WSOLA core only; no mpv infrastructure.
+//  - talloc arrays -> std::vector; MP_TARRAY_GROW -> grow_to_fit; mp_assert -> assert.
+//  - The scalar (non-HAVE_VECTOR) multi_channel_dot_product is used; clang
+//    auto-vectorizes it well enough for 12 ms windows at mono/stereo.
+
+#include "scaletempo2.h"
+
+#include <cassert>
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+
+namespace wsola {
+
+namespace {
+
+#define MPMAX(a, b) ((a) > (b) ? (a) : (b))
+#define MPMIN(a, b) ((a) < (b) ? (a) : (b))
+
+// Algorithm overview (from chromium):
+// Waveform Similarity Overlap-and-add (WSOLA).
+//
+// One WSOLA iteration
+//
+// 1) Extract |target_block| as input frames at indices
+//    [|target_block_index|, |target_block_index| + |ola_window_size|).
+//    Note that |target_block| is the "natural" continuation of the output.
+//
+// 2) Extract |search_block| as input frames at indices
+//    [|search_block_index|,
+//     |search_block_index| + |num_candidate_blocks| + |ola_window_size|).
+//
+// 3) Find a block within the |search_block| that is most similar
+//    to |target_block|. Let |optimal_index| be the index of such block and
+//    write it to |optimal_block|.
+//
+// 4) Update:
+//    |optimal_block| = |transition_window| * |target_block| +
+//    (1 - |transition_window|) * |optimal_block|.
+//
+// 5) Overlap-and-add |optimal_block| to the |wsola_output|.
+//
+// 6) Update:write
+
+struct interval {
+    int lo;
+    int hi;
+};
+
+bool in_interval(int n, interval q)
+{
+    return n >= q.lo && n <= q.hi;
+}
+
+// MP_TARRAY_GROW replacement: ensure the vector can be indexed up to
+// |last_index| (contents preserved, like talloc's GROW).
+void grow_to_fit(std::vector<float> &v, int last_index)
+{
+    if (last_index >= 0 && static_cast<size_t>(last_index) >= v.size()) {
+        v.resize(static_cast<size_t>(last_index) + 1);
+    }
+}
+
+void alloc_sample_buffer(mp_scaletempo2 *p,
+                         std::vector<std::vector<float>> *ptr, size_t size)
+{
+    ptr->assign(static_cast<size_t>(p->channels), std::vector<float>(size, 0.0f));
+}
+
+void zero_2d_partial(std::vector<std::vector<float>> &a, int x, int y)
+{
+    for (int i = 0; i < x; ++i) {
+        std::memset(a[i].data(), 0, sizeof(float) * static_cast<size_t>(y));
+    }
+}
+
+// Energies of sliding windows of channels are interleaved.
+// The number windows is |input_frames| - (|frames_per_window| - 1), hence,
+// the method assumes |energy| must be, at least, of size
+// (|input_frames| - (|frames_per_window| - 1)) * |channels|.
+void multi_channel_moving_block_energies(
+    std::vector<std::vector<float>> &input, int input_frames, int channels,
+    int frames_per_block, float *energy)
+{
+    int num_blocks = input_frames - (frames_per_block - 1);
+
+    for (int k = 0; k < channels; ++k) {
+        const float *input_channel = input[k].data();
+
+        energy[k] = 0;
+
+        // First block of channel |k|.
+        for (int m = 0; m < frames_per_block; ++m) {
+            energy[k] += input_channel[m] * input_channel[m];
+        }
+
+        const float *slide_out = input_channel;
+        const float *slide_in = input_channel + frames_per_block;
+        for (int n = 1; n < num_blocks; ++n, ++slide_in, ++slide_out) {
+            energy[k + n * channels] = energy[k + (n - 1) * channels]
+                - *slide_out * *slide_out + *slide_in * *slide_in;
+        }
+    }
+}
+
+float multi_channel_similarity_measure(
+    const float *dot_prod,
+    const float *energy_target, const float *energy_candidate,
+    int channels)
+{
+    const float epsilon = 1e-12f;
+    float similarity_measure = 0.0f;
+    for (int n = 0; n < channels; ++n) {
+        similarity_measure += dot_prod[n] * energy_target[n]
+            / sqrtf(energy_target[n] * energy_candidate[n] + epsilon);
+    }
+    return similarity_measure;
+}
+
+// Dot-product of channels of two AudioBus. For each AudioBus an offset is
+// given. |dot_product[k]| is the dot-product of channel |k|. The caller should
+// allocate sufficient space for |dot_product|.
+void multi_channel_dot_product(
+    std::vector<std::vector<float>> &a, int frame_offset_a,
+    std::vector<std::vector<float>> &b, int frame_offset_b,
+    int channels,
+    int num_frames, float *dot_product)
+{
+    assert(frame_offset_a >= 0);
+    assert(frame_offset_b >= 0);
+
+    for (int k = 0; k < channels; ++k) {
+        const float *ch_a = a[k].data() + frame_offset_a;
+        const float *ch_b = b[k].data() + frame_offset_b;
+        float sum = 0.0f;
+        for (int n = 0; n < num_frames; n++)
+            sum += *ch_a++ * *ch_b++;
+        dot_product[k] = sum;
+    }
+}
+
+// Fit the curve f(x) = a * x^2 + b * x + c such that
+//   f(-1) = y[0]
+//   f(0) = y[1]
+//   f(1) = y[2]
+// and return the maximum, assuming that y[0] <= y[1] >= y[2].
+void quadratic_interpolation(
+    const float *y_values, float *extremum, float *extremum_value)
+{
+    float a = 0.5f * (y_values[2] + y_values[0]) - y_values[1];
+    float b = 0.5f * (y_values[2] - y_values[0]);
+    float c = y_values[1];
+
+    if (a == 0.f) {
+        // The coordinates are colinear (within floating-point error).
+        *extremum = 0;
+        *extremum_value = y_values[1];
+    } else {
+        *extremum = -b / (2.f * a);
+        *extremum_value = a * (*extremum) * (*extremum) + b * (*extremum) + c;
+    }
+}
+
+// Search a subset of all candid blocks. The search is performed every
+// |decimation| frames. This reduces complexity by a factor of about
+// 1 / |decimation|. A cubic interpolation is used to have a better estimate of
+// the best match.
+int decimated_search(
+    int decimation, interval exclude_interval,
+    std::vector<std::vector<float>> &target_block, int target_block_frames,
+    std::vector<std::vector<float>> &search_segment, int search_segment_frames,
+    int channels,
+    const float *energy_target_block, const float *energy_candidate_blocks)
+{
+    int num_candidate_blocks = search_segment_frames - (target_block_frames - 1);
+    float dot_prod[WSOLA_MAX_CHANNELS];
+    float similarity[3];  // Three elements for cubic interpolation.
+
+    int n = 0;
+    multi_channel_dot_product(
+        target_block, 0,
+        search_segment, n,
+        channels,
+        target_block_frames, dot_prod);
+    similarity[0] = multi_channel_similarity_measure(
+        dot_prod, energy_target_block,
+        &energy_candidate_blocks[n * channels], channels);
+
+    // Set the starting point as optimal point.
+    float best_similarity = similarity[0];
+    int optimal_index = 0;
+
+    n += decimation;
+    if (n >= num_candidate_blocks) {
+        return 0;
+    }
+
+    multi_channel_dot_product(
+        target_block, 0,
+        search_segment, n,
+        channels,
+        target_block_frames, dot_prod);
+    similarity[1] = multi_channel_similarity_measure(
+        dot_prod, energy_target_block,
+        &energy_candidate_blocks[n * channels], channels);
+
+    n += decimation;
+    if (n >= num_candidate_blocks) {
+        // We cannot do any more sampling. Compare these two values and return the
+        // optimal index.
+        return similarity[1] > similarity[0] ? decimation : 0;
+    }
+
+    for (; n < num_candidate_blocks; n += decimation) {
+        multi_channel_dot_product(
+            target_block, 0,
+            search_segment, n,
+            channels,
+            target_block_frames, dot_prod);
+
+        similarity[2] = multi_channel_similarity_measure(
+            dot_prod, energy_target_block,
+            &energy_candidate_blocks[n * channels], channels);
+
+        if ((similarity[1] > similarity[0] && similarity[1] >= similarity[2]) ||
+            (similarity[1] >= similarity[0] && similarity[1] > similarity[2]))
+        {
+            // A local maximum is found. Do a cubic interpolation for a better
+            // estimate of candidate maximum.
+            float normalized_candidate_index;
+            float candidate_similarity;
+            quadratic_interpolation(similarity, &normalized_candidate_index,
+                                    &candidate_similarity);
+
+            int candidate_index = n - decimation
+                 + (int)(normalized_candidate_index * decimation + 0.5f);
+            if (candidate_similarity > best_similarity
+                && !in_interval(candidate_index, exclude_interval)) {
+                optimal_index = candidate_index;
+                best_similarity = candidate_similarity;
+            }
+        } else if (n + decimation >= num_candidate_blocks &&
+                   similarity[2] > best_similarity &&
+                   !in_interval(n, exclude_interval))
+        {
+            // If this is the end-point and has a better similarity-measure than
+            // optimal, then we accept it as optimal point.
+            optimal_index = n;
+            best_similarity = similarity[2];
+        }
+        memmove(similarity, &similarity[1], 2 * sizeof(*similarity));
+    }
+    return optimal_index;
+}
+
+// Search [|low_limit|, |high_limit|] of |search_segment| to find a block that
+// is most similar to |target_block|. |energy_target_block| is the energy of the
+// |target_block|. |energy_candidate_blocks| is the energy of all blocks within
+// |search_block|.
+int full_search(
+    int low_limit, int high_limit,
+    interval exclude_interval,
+    std::vector<std::vector<float>> &target_block, int target_block_frames,
+    std::vector<std::vector<float>> &search_block,
+    int channels,
+    const float *energy_target_block,
+    const float *energy_candidate_blocks)
+{
+    float dot_prod[WSOLA_MAX_CHANNELS];
+
+    float best_similarity = -FLT_MAX;
+    int optimal_index = 0;
+
+    for (int n = low_limit; n <= high_limit; ++n) {
+        if (in_interval(n, exclude_interval)) {
+            continue;
+        }
+        multi_channel_dot_product(target_block, 0, search_block, n, channels,
+            target_block_frames, dot_prod);
+
+        float similarity = multi_channel_similarity_measure(
+            dot_prod, energy_target_block,
+            &energy_candidate_blocks[n * channels], channels);
+
+        if (similarity > best_similarity) {
+            best_similarity = similarity;
+            optimal_index = n;
+        }
+    }
+
+    return optimal_index;
+}
+
+// Find the index of the block, within |search_block|, that is most similar
+// to |target_block|. Obviously, the returned index is w.r.t. |search_block|.
+// |exclude_interval| is an interval that is excluded from the search.
+int compute_optimal_index(
+    std::vector<std::vector<float>> &search_block, int search_block_frames,
+    std::vector<std::vector<float>> &target_block, int target_block_frames,
+    float *energy_candidate_blocks,
+    int channels,
+    interval exclude_interval)
+{
+    int num_candidate_blocks = search_block_frames - (target_block_frames - 1);
+
+    // This is a compromise between complexity reduction and search accuracy. I
+    // don't have a proof that down sample of order 5 is optimal.
+    // One can compute a decimation factor that minimizes complexity given
+    // the size of |search_block| and |target_block|. However, my experiments
+    // show the rate of missing the optimal index is significant.
+    // This value is chosen heuristically based on experiments.
+    const int search_decimation = 5;
+
+    float energy_target_block[WSOLA_MAX_CHANNELS];
+    // energy_candidate_blocks must have at least size
+    // sizeof(float) * channels * num_candidate_blocks
+
+    // Energy of all candid frames.
+    multi_channel_moving_block_energies(
+        search_block,
+        search_block_frames,
+        channels,
+        target_block_frames,
+        energy_candidate_blocks);
+
+    // Energy of target frame.
+    multi_channel_dot_product(
+        target_block, 0,
+        target_block, 0,
+        channels,
+        target_block_frames, energy_target_block);
+
+    int optimal_index = decimated_search(
+        search_decimation, exclude_interval,
+        target_block, target_block_frames,
+        search_block, search_block_frames,
+        channels,
+        energy_target_block,
+        energy_candidate_blocks);
+
+    int lim_low = MPMAX(0, optimal_index - search_decimation);
+    int lim_high = MPMIN(num_candidate_blocks - 1,
+                            optimal_index + search_decimation);
+    return full_search(
+        lim_low, lim_high, exclude_interval,
+        target_block, target_block_frames,
+        search_block,
+        channels,
+        energy_target_block, energy_candidate_blocks);
+}
+
+void peek_buffer(mp_scaletempo2 *p,
+    int frames, int read_offset, int write_offset,
+    std::vector<std::vector<float>> &dest)
+{
+    assert(p->input_buffer_frames >= frames);
+    for (int i = 0; i < p->channels; ++i) {
+        memcpy(dest[i].data() + write_offset,
+            p->input_buffer[i].data() + read_offset,
+            static_cast<size_t>(frames) * sizeof(float));
+    }
+}
+
+void seek_buffer(mp_scaletempo2 *p, int frames)
+{
+    assert(p->input_buffer_frames >= frames);
+    p->input_buffer_frames -= frames;
+    if (p->input_buffer_final_frames > 0) {
+        p->input_buffer_final_frames = MPMAX(0, p->input_buffer_final_frames - frames);
+    }
+    for (int i = 0; i < p->channels; ++i) {
+        memmove(p->input_buffer[i].data(), p->input_buffer[i].data() + frames,
+            static_cast<size_t>(p->input_buffer_frames) * sizeof(float));
+    }
+}
+
+int write_completed_frames_to(mp_scaletempo2 *p,
+    int requested_frames, int dest_offset, float *const *dest)
+{
+    int rendered_frames = MPMIN(p->num_complete_frames, requested_frames);
+
+    if (rendered_frames == 0)
+        return 0;  // There is nothing to read from |wsola_output|, return.
+
+    for (int i = 0; i < p->channels; ++i) {
+        memcpy(dest[i] + dest_offset, p->wsola_output[i].data(),
+            static_cast<size_t>(rendered_frames) * sizeof(float));
+    }
+
+    // Remove the frames which are read.
+    int frames_to_move = p->wsola_output_size - rendered_frames;
+    for (int k = 0; k < p->channels; ++k) {
+        float *ch = p->wsola_output[k].data();
+        memmove(ch, &ch[rendered_frames], sizeof(*ch) * static_cast<size_t>(frames_to_move));
+    }
+    p->num_complete_frames -= rendered_frames;
+    return rendered_frames;
+}
+
+// next output_time for the given playback_rate
+double get_updated_time(mp_scaletempo2 *p, double playback_rate)
+{
+    return p->output_time + p->ola_hop_size * playback_rate;
+}
+
+// search_block_index for the given output_time
+int get_search_block_index(mp_scaletempo2 *p, double output_time)
+{
+    return (int)(output_time - p->search_block_center_offset + 0.5);
+}
+
+// number of frames needed until a wsola iteration can be performed
+int frames_needed(mp_scaletempo2 *p, double playback_rate)
+{
+    int search_block_index =
+        get_search_block_index(p, get_updated_time(p, playback_rate));
+    return MPMAX(0, MPMAX(
+        p->target_block_index + p->ola_window_size - p->input_buffer_frames,
+        search_block_index + p->search_block_size - p->input_buffer_frames));
+}
+
+bool can_perform_wsola(mp_scaletempo2 *p, double playback_rate)
+{
+    return frames_needed(p, playback_rate) <= 0;
+}
+
+// pad end with silence until a wsola iteration can be performed
+void add_input_buffer_final_silence(mp_scaletempo2 *p, double playback_rate)
+{
+    int needed = frames_needed(p, playback_rate);
+    if (needed <= 0)
+        return; // no silence needed for iteration
+
+    int last_index = needed + p->input_buffer_frames - 1;
+    for (int i = 0; i < p->channels; ++i) {
+        grow_to_fit(p->input_buffer[i], last_index);
+        float *ch_input = p->input_buffer[i].data();
+        for (int j = 0; j < needed; ++j) {
+            ch_input[p->input_buffer_frames + j] = 0.0f;
+        }
+    }
+
+    p->input_buffer_added_silence += needed;
+    p->input_buffer_frames += needed;
+}
+
+bool target_is_within_search_region(mp_scaletempo2 *p)
+{
+    return p->target_block_index >= p->search_block_index
+        && p->target_block_index + p->ola_window_size
+            <= p->search_block_index + p->search_block_size;
+}
+
+void peek_audio_with_zero_prepend(mp_scaletempo2 *p,
+    int read_offset_frames, std::vector<std::vector<float>> &dest, int dest_frames)
+{
+    assert(read_offset_frames + dest_frames <= p->input_buffer_frames);
+
+    int write_offset = 0;
+    int num_frames_to_read = dest_frames;
+    if (read_offset_frames < 0) {
+        int num_zero_frames_appended = MPMIN(
+            -read_offset_frames, num_frames_to_read);
+        read_offset_frames = 0;
+        num_frames_to_read -= num_zero_frames_appended;
+        write_offset = num_zero_frames_appended;
+        zero_2d_partial(dest, p->channels, num_zero_frames_appended);
+    }
+    peek_buffer(p, num_frames_to_read, read_offset_frames, write_offset, dest);
+}
+
+void get_optimal_block(mp_scaletempo2 *p)
+{
+    int optimal_index = 0;
+
+    // An interval around last optimal block which is excluded from the search.
+    // This is to reduce the buzzy sound. The number 160 is rather arbitrary and
+    // derived heuristically.
+    const int exclude_interval_length_frames = 160;
+    if (target_is_within_search_region(p)) {
+        optimal_index = p->target_block_index;
+        peek_audio_with_zero_prepend(p,
+            optimal_index, p->optimal_block, p->ola_window_size);
+    } else {
+        peek_audio_with_zero_prepend(p,
+            p->target_block_index, p->target_block, p->ola_window_size);
+        peek_audio_with_zero_prepend(p,
+            p->search_block_index, p->search_block, p->search_block_size);
+        int last_optimal = p->target_block_index
+            - p->ola_hop_size - p->search_block_index;
+        interval exclude_iterval = {
+            .lo = last_optimal - exclude_interval_length_frames / 2,
+            .hi = last_optimal + exclude_interval_length_frames / 2
+        };
+
+        // |optimal_index| is in frames and it is relative to the beginning of the
+        // |search_block|.
+        optimal_index = compute_optimal_index(
+            p->search_block, p->search_block_size,
+            p->target_block, p->ola_window_size,
+            p->energy_candidate_blocks.data(),
+            p->channels,
+            exclude_iterval);
+
+        // Translate |index| w.r.t. the beginning of |audio_buffer| and extract the
+        // optimal block.
+        optimal_index += p->search_block_index;
+        peek_audio_with_zero_prepend(p,
+            optimal_index, p->optimal_block, p->ola_window_size);
+
+        // Make a transition from target block to the optimal block if different.
+        // Target block has the best continuation to the current output.
+        // Optimal block is the most similar block to the target, however, it might
+        // introduce some discontinuity when over-lap-added. Therefore, we combine
+        // them for a smoother transition. The length of transition window is twice
+        // as that of the optimal-block which makes it like a weighting function
+        // where target-block has higher weight close to zero (weight of 1 at index
+        // 0) and lower weight close the end.
+        for (int k = 0; k < p->channels; ++k) {
+            float *ch_opt = p->optimal_block[k].data();
+            float *ch_target = p->target_block[k].data();
+            for (int n = 0; n < p->ola_window_size; ++n) {
+                ch_opt[n] = ch_opt[n] * p->transition_window[n]
+                    + ch_target[n] * p->transition_window[p->ola_window_size + n];
+            }
+        }
+    }
+
+    // Next target is one hop ahead of the current optimal.
+    p->target_block_index = optimal_index + p->ola_hop_size;
+}
+
+void set_output_time(mp_scaletempo2 *p, double output_time)
+{
+    p->output_time = output_time;
+    p->search_block_index = get_search_block_index(p, output_time);
+}
+
+void remove_old_input_frames(mp_scaletempo2 *p)
+{
+    const int earliest_used_index = MPMIN(
+        p->target_block_index, p->search_block_index);
+    if (earliest_used_index <= 0)
+        return;  // Nothing to remove.
+
+    // Remove frames from input and adjust indices accordingly.
+    seek_buffer(p, earliest_used_index);
+    p->target_block_index -= earliest_used_index;
+    p->output_time -= earliest_used_index;
+    p->search_block_index -= earliest_used_index;
+}
+
+bool run_one_wsola_iteration(mp_scaletempo2 *p, double playback_rate)
+{
+    if (!can_perform_wsola(p, playback_rate)) {
+        return false;
+    }
+
+    set_output_time(p, get_updated_time(p, playback_rate));
+    remove_old_input_frames(p);
+
+    assert(p->search_block_index + p->search_block_size <= p->input_buffer_frames);
+
+    get_optimal_block(p);
+
+    // Overlap-and-add.
+    for (int k = 0; k < p->channels; ++k) {
+        float *ch_opt_frame = p->optimal_block[k].data();
+        float *ch_output = p->wsola_output[k].data() + p->num_complete_frames;
+        if (p->wsola_output_started) {
+            for (int n = 0; n < p->ola_hop_size; ++n) {
+                ch_output[n] = ch_output[n] * p->ola_window[p->ola_hop_size + n] +
+                    ch_opt_frame[n] * p->ola_window[n];
+            }
+
+            // Copy the second half to the output.
+            memcpy(&ch_output[p->ola_hop_size], &ch_opt_frame[p->ola_hop_size],
+                   sizeof(*ch_opt_frame) * static_cast<size_t>(p->ola_hop_size));
+        } else {
+            // No overlap for the first iteration.
+            memcpy(ch_output, ch_opt_frame,
+                   sizeof(*ch_opt_frame) * static_cast<size_t>(p->ola_window_size));
+        }
+    }
+
+    p->num_complete_frames += p->ola_hop_size;
+    p->wsola_output_started = true;
+    return true;
+}
+
+int read_input_buffer(mp_scaletempo2 *p, int dest_size, float *const *dest)
+{
+    int frames_to_copy = MPMIN(dest_size, p->input_buffer_frames - p->target_block_index);
+
+    if (frames_to_copy <= 0)
+        return 0; // There is nothing to read from input buffer; return.
+
+    for (int i = 0; i < p->channels; ++i) {
+        memcpy(dest[i], p->input_buffer[i].data() + p->target_block_index,
+               static_cast<size_t>(frames_to_copy) * sizeof(float));
+    }
+    seek_buffer(p, frames_to_copy);
+    return frames_to_copy;
+}
+
+// Return a "periodic" Hann window. This is the first L samples of an L+1
+// Hann window. It is perfect reconstruction for overlap-and-add.
+void get_symmetric_hanning_window(int window_length, float *window)
+{
+    const float scale = 2.0f * static_cast<float>(M_PI) / window_length;
+    for (int n = 0; n < window_length; ++n)
+        window[n] = 0.5f * (1.0f - cosf(n * scale));
+}
+
+} // namespace
+
+void mp_scaletempo2_set_final(mp_scaletempo2 *p)
+{
+    if (p->input_buffer_final_frames <= 0) {
+        p->input_buffer_final_frames = p->input_buffer_frames;
+    }
+}
+
+int mp_scaletempo2_fill_input_buffer(mp_scaletempo2 *p,
+    float *const *planes, int frame_size, double playback_rate)
+{
+    int needed = frames_needed(p, playback_rate);
+    int read = MPMIN(needed, frame_size);
+    if (read == 0)
+        return 0;
+
+    int last_index = read + p->input_buffer_frames - 1;
+    for (int i = 0; i < p->channels; ++i) {
+        grow_to_fit(p->input_buffer[i], last_index);
+        memcpy(p->input_buffer[i].data() + p->input_buffer_frames,
+            planes[i], static_cast<size_t>(read) * sizeof(float));
+    }
+
+    p->input_buffer_frames += read;
+    return read;
+}
+
+int mp_scaletempo2_fill_buffer(mp_scaletempo2 *p,
+    float *const *dest, int dest_size, double playback_rate)
+{
+    if (playback_rate == 0) return 0;
+
+    if (p->input_buffer_final_frames > 0) {
+        add_input_buffer_final_silence(p, playback_rate);
+    }
+
+    // Optimize the muted case to issue a single clear instead of performing
+    // the full crossfade and clearing each crossfaded frame.
+    if (playback_rate < p->opts.min_playback_rate
+        || (playback_rate > p->opts.max_playback_rate
+            && p->opts.max_playback_rate > 0))
+    {
+        int frames_to_render = MPMIN(dest_size,
+            (int)(p->input_buffer_frames / playback_rate));
+
+        // Compute accurate number of frames to actually skip in the source data.
+        // Includes the leftover partial frame from last request. However, we can
+        // only skip over complete frames, so a partial frame may remain for next
+        // time.
+        p->muted_partial_frame += frames_to_render * playback_rate;
+        int seek_frames = (int)(p->muted_partial_frame);
+        for (int i = 0; i < p->channels; ++i) {
+            std::memset(dest[i], 0, sizeof(float) * static_cast<size_t>(frames_to_render));
+        }
+        seek_buffer(p, seek_frames);
+
+        // Determine the partial frame that remains to be skipped for next call. If
+        // the user switches back to playing, it may be off time by this partial
+        // frame, which would be undetectable. If they subsequently switch to
+        // another playback rate that mutes, the code will attempt to line up the
+        // frames again.
+        p->muted_partial_frame -= seek_frames;
+        return frames_to_render;
+    }
+
+    int slower_step = (int)ceilf(p->ola_window_size * playback_rate);
+    int faster_step = (int)ceilf(p->ola_window_size / playback_rate);
+
+    // Optimize the most common |playback_rate| ~= 1 case to use a single copy
+    // instead of copying frame by frame.
+    if (p->ola_window_size <= faster_step && slower_step >= p->ola_window_size) {
+
+        if (p->wsola_output_started) {
+            p->wsola_output_started = false;
+
+            // sync audio precisely again
+            set_output_time(p, p->target_block_index);
+            remove_old_input_frames(p);
+        }
+
+        return read_input_buffer(p, dest_size, dest);
+    }
+
+    int rendered_frames = 0;
+    do {
+        rendered_frames += write_completed_frames_to(p,
+            dest_size - rendered_frames, rendered_frames, dest);
+    } while (rendered_frames < dest_size
+             && run_one_wsola_iteration(p, playback_rate));
+    return rendered_frames;
+}
+
+double mp_scaletempo2_get_latency(mp_scaletempo2 *p, double playback_rate)
+{
+    return p->input_buffer_frames - p->output_time
+        - p->input_buffer_added_silence
+        + p->num_complete_frames * playback_rate;
+}
+
+bool mp_scaletempo2_frames_available(mp_scaletempo2 *p, double playback_rate)
+{
+    return (p->input_buffer_final_frames > p->target_block_index &&
+            p->input_buffer_final_frames > 0)
+        || can_perform_wsola(p, playback_rate)
+        || p->num_complete_frames > 0;
+}
+
+void mp_scaletempo2_reset(mp_scaletempo2 *p)
+{
+    p->input_buffer_frames = 0;
+    p->input_buffer_final_frames = 0;
+    p->input_buffer_added_silence = 0;
+    p->output_time = 0.0;
+    p->search_block_index = 0;
+    p->target_block_index = 0;
+    p->num_complete_frames = 0;
+    p->wsola_output_started = false;
+}
+
+void mp_scaletempo2_init(mp_scaletempo2 *p, int channels, int rate)
+{
+    p->muted_partial_frame = 0;
+    p->output_time = 0;
+    p->search_block_index = 0;
+    p->target_block_index = 0;
+    p->num_complete_frames = 0;
+    p->wsola_output_started = false;
+    p->channels = channels;
+
+    p->samples_per_second = rate;
+    p->num_candidate_blocks = (int)(p->opts.wsola_search_interval_ms
+        * p->samples_per_second / 1000);
+    p->ola_window_size = (int)(p->opts.ola_window_size_ms
+        * p->samples_per_second / 1000);
+    // Make sure window size in an even number.
+    p->ola_window_size += p->ola_window_size & 1;
+    p->ola_hop_size = p->ola_window_size / 2;
+    // |num_candidate_blocks| / 2 is the offset of the center of the search
+    // block to the center of the first (left most) candidate block. The offset
+    // of the center of a candidate block to its left most point is
+    // |ola_window_size| / 2 - 1. Note that |ola_window_size| is even and in
+    // our convention the center belongs to the left half, so we need to subtract
+    // one frame to get the correct offset.
+    p->search_block_center_offset = p->num_candidate_blocks / 2
+        + (p->ola_window_size / 2 - 1);
+    p->ola_window.resize(static_cast<size_t>(p->ola_window_size));
+    get_symmetric_hanning_window(p->ola_window_size, p->ola_window.data());
+    p->transition_window.resize(static_cast<size_t>(p->ola_window_size) * 2);
+    get_symmetric_hanning_window(2 * p->ola_window_size, p->transition_window.data());
+
+    p->wsola_output_size = p->ola_window_size + p->ola_hop_size;
+    alloc_sample_buffer(p, &p->wsola_output, static_cast<size_t>(p->wsola_output_size));
+
+    // Auxiliary containers.
+    alloc_sample_buffer(p, &p->optimal_block, static_cast<size_t>(p->ola_window_size));
+    p->search_block_size = p->num_candidate_blocks + (p->ola_window_size - 1);
+    alloc_sample_buffer(p, &p->search_block, static_cast<size_t>(p->search_block_size));
+    alloc_sample_buffer(p, &p->target_block, static_cast<size_t>(p->ola_window_size));
+
+    p->input_buffer_frames = 0;
+    p->input_buffer_final_frames = 0;
+    p->input_buffer_added_silence = 0;
+    size_t initial_size = 4 * static_cast<size_t>(MPMAX(p->ola_window_size, p->search_block_size));
+    alloc_sample_buffer(p, &p->input_buffer, initial_size);
+
+    p->energy_candidate_blocks.resize(
+        static_cast<size_t>(p->channels) * static_cast<size_t>(p->num_candidate_blocks));
+}
+
+} // namespace wsola

--- a/mediamp-exoplayer/src/cpp/scaletempo2.h
+++ b/mediamp-exoplayer/src/cpp/scaletempo2.h
@@ -1,0 +1,149 @@
+// This file was ported from mpv (https://github.com/mpv-player/mpv),
+// audio/filter/af_scaletempo2.h, which was in turn ported from Chromium
+// (https://chromium.googlesource.com/chromium/chromium/+/51ed77e3f37a9a9b80d6d0a8259e84a8ca635259/media/filters/audio_renderer_algorithm.cc)
+//
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Port notes (mediamp):
+//  - Clean C++17 port; talloc arrays became std::vector, mp_assert became assert.
+//  - No mpv infrastructure (mp_audio, filter framework, talloc) is used.
+//  - Only mono/stereo is supported by the JNI adapter.
+
+#pragma once
+
+#include <vector>
+
+namespace wsola {
+
+// Maximum supported channels (mpv uses MP_NUM_CHANNELS=8; we only need 2).
+constexpr int WSOLA_MAX_CHANNELS = 2;
+
+struct mp_scaletempo2_opts {
+    // Max/min supported playback rates for fast/slow audio. Audio outside of these
+    // ranges are muted.
+    // Audio at these speeds would sound better under a frequency domain algorithm.
+    float min_playback_rate = 0.25f;
+    float max_playback_rate = 8.0f;
+    // Overlap-and-add window size in milliseconds.
+    float ola_window_size_ms = 12.0f;
+    // Size of search interval in milliseconds. The search interval is
+    // [-delta delta] around |output_index| * |playback_rate|. So the search
+    // interval is 2 * delta.
+    float wsola_search_interval_ms = 40.0f;
+};
+
+struct mp_scaletempo2 {
+    mp_scaletempo2_opts opts;
+    // Number of channels in audio stream.
+    int channels = 0;
+    // Sample rate of audio stream.
+    int samples_per_second = 0;
+    // If muted, keep track of partial frames that should have been skipped over.
+    double muted_partial_frame = 0;
+    // Book keeping of the current time of generated audio, in frames.
+    // Corresponds to the center of |search_block|. This is increased in
+    // intervals of |ola_hop_size| multiplied by the current playback_rate,
+    // for every WSOLA iteration. This tracks the number of advanced frames as
+    // a double to achieve accurate playback rates beyond the integer precision
+    // of |search_block_index|.
+    // Needs to be adjusted like any other index when frames are evicted from
+    // |input_buffer|.
+    double output_time = 0;
+    // The offset of the center frame of |search_block| w.r.t. its first frame.
+    int search_block_center_offset = 0;
+    // Index of the beginning of the |search_block|, in frames. This may be
+    // negative, which is handled by |peek_audio_with_zero_prepend|.
+    int search_block_index = 0;
+    // Number of Blocks to search to find the most similar one to the target
+    // frame.
+    int num_candidate_blocks = 0;
+    // Index of the beginning of the target block, counted in frames.
+    int target_block_index = 0;
+    // Overlap-and-add window size in frames.
+    int ola_window_size = 0;
+    // The hop size of overlap-and-add in frames. This implementation assumes 50%
+    // overlap-and-add.
+    int ola_hop_size = 0;
+    // Number of frames in |wsola_output| that overlap-and-add is completed for
+    // them and can be copied to output if fill_buffer() is called. It also
+    // specifies the index where the next WSOLA window has to overlap-and-add.
+    int num_complete_frames = 0;
+    // Whether |wsola_output| contains an additional |ola_hop_size| of overlap
+    // frames for the next iteration.
+    bool wsola_output_started = false;
+    // Overlap-and-add window.
+    std::vector<float> ola_window;
+    // Transition window, used to update |optimal_block| by a weighted sum of
+    // |optimal_block| and |target_block|.
+    std::vector<float> transition_window;
+    // This stores a part of the output that is created but couldn't be rendered.
+    // Output is generated frame-by-frame which at some point might exceed the
+    // number of requested samples. Furthermore, due to overlap-and-add,
+    // the last half-window of the output is incomplete, which is stored in this
+    // buffer.
+    std::vector<std::vector<float>> wsola_output;
+    int wsola_output_size = 0;
+    // Auxiliary variables to avoid allocation in every iteration.
+    // Stores the optimal block in every iteration. This is the most
+    // similar block to |target_block| within |search_block| and it is
+    // overlap-and-added to |wsola_output|.
+    std::vector<std::vector<float>> optimal_block;
+    // A block of data that search is performed over to find the |optimal_block|.
+    std::vector<std::vector<float>> search_block;
+    int search_block_size = 0;
+    // Stores the target block, denoted as |target| above. |search_block| is
+    // searched for a block (|optimal_block|) that is most similar to
+    // |target_block|.
+    std::vector<std::vector<float>> target_block;
+    // Buffered audio data.
+    std::vector<std::vector<float>> input_buffer;
+    int input_buffer_frames = 0;
+    // How many frames in |input_buffer| need to be flushed by padding with
+    // silence to process the final packet. While this is nonzero, the filter
+    // appends silence to |input_buffer| until these frames are processed.
+    int input_buffer_final_frames = 0;
+    // How many additional frames of silence have been added to |input_buffer|
+    // for padding after the final packet.
+    int input_buffer_added_silence = 0;
+    std::vector<float> energy_candidate_blocks;
+};
+
+void mp_scaletempo2_init(mp_scaletempo2 *p, int channels, int rate);
+void mp_scaletempo2_reset(mp_scaletempo2 *p);
+double mp_scaletempo2_get_latency(mp_scaletempo2 *p, double playback_rate);
+int mp_scaletempo2_fill_input_buffer(mp_scaletempo2 *p,
+                                     float *const *planes, int frame_size,
+                                     double playback_rate);
+void mp_scaletempo2_set_final(mp_scaletempo2 *p);
+int mp_scaletempo2_fill_buffer(mp_scaletempo2 *p,
+                               float *const *dest, int dest_size,
+                               double playback_rate);
+bool mp_scaletempo2_frames_available(mp_scaletempo2 *p, double playback_rate);
+
+} // namespace wsola

--- a/mediamp-exoplayer/src/cpp/wsola_jni.cpp
+++ b/mediamp-exoplayer/src/cpp/wsola_jni.cpp
@@ -1,0 +1,413 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+/**
+ * JNI bridge for the WSOLA time-stretch processor (libmediamp_wsola).
+ *
+ * Kotlin contract: org.openani.mediamp.exoplayer.internal.WsolaProcessorNative.
+ *  - Input/output are direct ByteBuffers of interleaved PCM in the sample format fixed at
+ *    create() time (SAMPLE_FORMAT_S16 = signed 16-bit, SAMPLE_FORMAT_FLOAT = 32-bit float).
+ *  - One frame contains one sample for every channel.
+ *  - finishInput signals EOS; drainOutput must keep returning the tail until 0.
+ *  - flush discards all buffered state but keeps the configured speed.
+ *  - All calls are single-threaded; no locking needed.
+ */
+
+#include <jni.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <new>
+#include <vector>
+
+#include "scaletempo2.h"
+
+namespace {
+
+constexpr float kInt16ToFloat = 1.0f / 32768.0f;
+
+// Mirrors WsolaProcessorNative.SAMPLE_FORMAT_S16 / SAMPLE_FORMAT_FLOAT.
+constexpr jint kSampleFormatS16 = 0;
+constexpr jint kSampleFormatFloat = 1;
+
+struct WsolaContext {
+    wsola::mp_scaletempo2 wsola;
+    int channels = 0;
+    int bytes_per_sample = 2;
+    bool is_float = false;
+    double speed = 1.0;
+
+    // Queued, not yet consumed planar float input (queueInput accepts whatever the
+    // caller offers; the WSOLA core only pulls what it currently needs).
+    std::vector<std::vector<float>> pending;
+    int pending_frames = 0;
+
+    bool finish_signaled = false;
+    bool final_set = false; // set_final applied once pending is exhausted
+
+    // Scratch for fill_buffer output, grown on demand (steady-state: no allocation).
+    std::vector<std::vector<float>> dest;
+    std::vector<float *> dest_ptrs;
+    int dest_capacity = 0;
+};
+
+WsolaContext *fromHandle(jlong handle)
+{
+    return reinterpret_cast<WsolaContext *>(handle);
+}
+
+void throwIllegalArgument(JNIEnv *env, const char *message)
+{
+    jclass clazz = env->FindClass("java/lang/IllegalArgumentException");
+    if (clazz != nullptr) {
+        env->ThrowNew(clazz, message);
+    }
+}
+
+void throwIllegalState(JNIEnv *env, const char *message)
+{
+    jclass clazz = env->FindClass("java/lang/IllegalStateException");
+    if (clazz != nullptr) {
+        env->ThrowNew(clazz, message);
+    }
+}
+
+void throwOutOfMemory(JNIEnv *env, const char *message)
+{
+    jclass clazz = env->FindClass("java/lang/OutOfMemoryError");
+    if (clazz != nullptr) {
+        env->ThrowNew(clazz, message);
+    }
+}
+
+float sanitizePcmFloat(float v)
+{
+    // Keep NaN/Inf out of the similarity search and the Android float PCM sink.
+    return std::isfinite(v) ? std::min(std::max(v, -1.0f), 1.0f) : 0.0f;
+}
+
+int16_t floatToInt16(float v)
+{
+    // Clamp before scaling to avoid UB on out-of-range float->int conversion.
+    long sample = lrintf(sanitizePcmFloat(v) * 32767.0f);
+    return static_cast<int16_t>(sample);
+}
+
+/** Moves frames from |pending| into the WSOLA input buffer (as many as it needs). */
+void feedPending(WsolaContext *ctx)
+{
+    if (ctx->pending_frames == 0) {
+        return;
+    }
+    float *planes[wsola::WSOLA_MAX_CHANNELS];
+    for (int i = 0; i < ctx->channels; ++i) {
+        planes[i] = ctx->pending[i].data();
+    }
+    int read = wsola::mp_scaletempo2_fill_input_buffer(
+        &ctx->wsola, planes, ctx->pending_frames, ctx->speed);
+    if (read <= 0) {
+        return;
+    }
+    ctx->pending_frames -= read;
+    for (int i = 0; i < ctx->channels; ++i) {
+        auto &ch = ctx->pending[i];
+        std::memmove(ch.data(), ch.data() + read,
+                     static_cast<size_t>(ctx->pending_frames) * sizeof(float));
+    }
+}
+
+void ensureDestCapacity(WsolaContext *ctx, int frames)
+{
+    if (frames <= ctx->dest_capacity) {
+        return;
+    }
+    for (auto &ch : ctx->dest) {
+        ch.resize(static_cast<size_t>(frames));
+    }
+    for (int i = 0; i < ctx->channels; ++i) {
+        ctx->dest_ptrs[i] = ctx->dest[i].data();
+    }
+    ctx->dest_capacity = frames;
+}
+
+} // namespace
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_create(
+    JNIEnv *env, jclass /* clazz */, jint sampleRate, jint channels, jint sampleFormat)
+{
+    if (sampleRate <= 0 || channels < 1 || channels > wsola::WSOLA_MAX_CHANNELS) {
+        throwIllegalArgument(env, "sampleRate must be > 0 and channels in 1..2");
+        return 0;
+    }
+    if (sampleFormat != kSampleFormatS16 && sampleFormat != kSampleFormatFloat) {
+        throwIllegalArgument(env, "sampleFormat must be SAMPLE_FORMAT_S16 or SAMPLE_FORMAT_FLOAT");
+        return 0;
+    }
+    WsolaContext *ctx = nullptr;
+    try {
+        ctx = new WsolaContext();
+        ctx->channels = channels;
+        ctx->is_float = sampleFormat == kSampleFormatFloat;
+        ctx->bytes_per_sample = ctx->is_float ? 4 : 2;
+        wsola::mp_scaletempo2_init(&ctx->wsola, channels, sampleRate);
+        ctx->pending.assign(static_cast<size_t>(channels), std::vector<float>());
+        ctx->dest.assign(static_cast<size_t>(channels), std::vector<float>());
+        ctx->dest_ptrs.assign(static_cast<size_t>(channels), nullptr);
+    } catch (const std::bad_alloc &) {
+        delete ctx;
+        throwOutOfMemory(env, "Unable to allocate native WSOLA processor");
+        return 0;
+    } catch (const std::exception &e) {
+        delete ctx;
+        throwIllegalState(env, e.what());
+        return 0;
+    } catch (...) {
+        delete ctx;
+        throwIllegalState(env, "Native WSOLA initialization failed");
+        return 0;
+    }
+    return reinterpret_cast<jlong>(ctx);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_setSpeed(
+    JNIEnv *env, jclass /* clazz */, jlong handle, jfloat speed)
+{
+    WsolaContext *ctx = fromHandle(handle);
+    if (ctx == nullptr) {
+        return;
+    }
+    if (!(speed > 0.0f) || !std::isfinite(speed)) {
+        throwIllegalArgument(env, "speed must be finite and positive");
+        return;
+    }
+    ctx->speed = speed;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_queueInput(
+    JNIEnv *env, jclass /* clazz */, jlong handle, jobject buf, jint byteOffset,
+    jint frames)
+{
+    WsolaContext *ctx = fromHandle(handle);
+    if (ctx == nullptr) {
+        return;
+    }
+    if (frames < 0) {
+        throwIllegalArgument(env, "queueInput frames must be non-negative");
+        return;
+    }
+    if (frames == 0) {
+        return;
+    }
+    if (ctx->finish_signaled) {
+        throwIllegalState(env, "queueInput called after finishInput");
+        return;
+    }
+    const auto *base = static_cast<const uint8_t *>(env->GetDirectBufferAddress(buf));
+    if (base == nullptr) {
+        throwIllegalArgument(env, "queueInput requires a direct ByteBuffer");
+        return;
+    }
+    const jlong capacity = env->GetDirectBufferCapacity(buf);
+    const jlong needed = static_cast<jlong>(frames) * ctx->channels *
+                         static_cast<jlong>(ctx->bytes_per_sample);
+    if (byteOffset < 0 || byteOffset % static_cast<jint>(ctx->bytes_per_sample) != 0) {
+        throwIllegalArgument(env, "queueInput byteOffset must be non-negative and sample aligned");
+        return;
+    }
+    if (capacity < 0 || static_cast<jlong>(byteOffset) > capacity ||
+        needed > capacity - static_cast<jlong>(byteOffset)) {
+        throwIllegalArgument(env, "queueInput range exceeds the direct ByteBuffer capacity");
+        return;
+    }
+    const auto address = reinterpret_cast<std::uintptr_t>(base + byteOffset);
+    if (address % static_cast<std::uintptr_t>(ctx->bytes_per_sample) != 0) {
+        throwIllegalArgument(env, "queueInput direct buffer address is not sample aligned");
+        return;
+    }
+    if (frames > std::numeric_limits<int>::max() - ctx->pending_frames) {
+        throwIllegalArgument(env, "queueInput exceeds the native pending-frame limit");
+        return;
+    }
+
+    const int total = ctx->pending_frames + frames;
+    try {
+        for (int ch = 0; ch < ctx->channels; ++ch) {
+            auto &plane = ctx->pending[ch];
+            if (static_cast<int>(plane.size()) < total) {
+                plane.resize(static_cast<size_t>(total));
+            }
+            float *out = plane.data() + ctx->pending_frames;
+            if (ctx->is_float) {
+                const auto *in = reinterpret_cast<const float *>(base + byteOffset) + ch;
+                for (int i = 0; i < frames; ++i, in += ctx->channels) {
+                    out[i] = sanitizePcmFloat(*in);
+                }
+            } else {
+                const auto *in = reinterpret_cast<const int16_t *>(base + byteOffset) + ch;
+                for (int i = 0; i < frames; ++i, in += ctx->channels) {
+                    out[i] = static_cast<float>(*in) * kInt16ToFloat;
+                }
+            }
+        }
+    } catch (const std::bad_alloc &) {
+        throwOutOfMemory(env, "Unable to grow native WSOLA input buffer");
+        return;
+    } catch (const std::exception &e) {
+        throwIllegalState(env, e.what());
+        return;
+    } catch (...) {
+        throwIllegalState(env, "Native WSOLA input buffering failed");
+        return;
+    }
+    ctx->pending_frames = total;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_drainOutput(
+    JNIEnv *env, jclass /* clazz */, jlong handle, jobject buf, jint maxFrames)
+{
+    WsolaContext *ctx = fromHandle(handle);
+    if (ctx == nullptr) {
+        return 0;
+    }
+    if (maxFrames < 0) {
+        throwIllegalArgument(env, "drainOutput maxFrames must be non-negative");
+        return 0;
+    }
+    if (maxFrames == 0) {
+        return 0;
+    }
+    auto *dstBase = static_cast<uint8_t *>(env->GetDirectBufferAddress(buf));
+    if (dstBase == nullptr) {
+        throwIllegalArgument(env, "drainOutput requires a direct ByteBuffer");
+        return 0;
+    }
+    const jlong capacity = env->GetDirectBufferCapacity(buf);
+    const jlong needed = static_cast<jlong>(maxFrames) * ctx->channels *
+                         static_cast<jlong>(ctx->bytes_per_sample);
+    if (capacity < 0 || capacity < needed) {
+        throwIllegalArgument(env, "drainOutput buffer smaller than maxFrames * channels * bytesPerSample");
+        return 0;
+    }
+    if (reinterpret_cast<std::uintptr_t>(dstBase) %
+        static_cast<std::uintptr_t>(ctx->bytes_per_sample) != 0) {
+        throwIllegalArgument(env, "drainOutput direct buffer address is not sample aligned");
+        return 0;
+    }
+
+    try {
+        ensureDestCapacity(ctx, maxFrames);
+
+        int produced = 0;
+        while (produced < maxFrames) {
+            // Feed queued input until the processor can render (or we run out).
+            while (!wsola::mp_scaletempo2_frames_available(&ctx->wsola, ctx->speed)) {
+                if (ctx->pending_frames > 0) {
+                    feedPending(ctx);
+                } else if (ctx->finish_signaled) {
+                    if (ctx->final_set) {
+                        return produced; // EOS tail fully drained
+                    }
+                    wsola::mp_scaletempo2_set_final(&ctx->wsola);
+                    ctx->final_set = true;
+                } else {
+                    return produced; // waiting for more input
+                }
+            }
+            int rendered = wsola::mp_scaletempo2_fill_buffer(
+                &ctx->wsola, ctx->dest_ptrs.data(), maxFrames - produced, ctx->speed);
+            if (rendered <= 0) {
+                break;
+            }
+            for (int ch = 0; ch < ctx->channels; ++ch) {
+                const float *in = ctx->dest[ch].data();
+                if (ctx->is_float) {
+                    auto *out = reinterpret_cast<float *>(dstBase) +
+                                static_cast<size_t>(produced) * ctx->channels + ch;
+                    for (int i = 0; i < rendered; ++i, out += ctx->channels) {
+                        *out = sanitizePcmFloat(in[i]);
+                    }
+                } else {
+                    auto *out = reinterpret_cast<int16_t *>(dstBase) +
+                                static_cast<size_t>(produced) * ctx->channels + ch;
+                    for (int i = 0; i < rendered; ++i, out += ctx->channels) {
+                        *out = floatToInt16(in[i]);
+                    }
+                }
+            }
+            produced += rendered;
+        }
+        return produced;
+    } catch (const std::bad_alloc &) {
+        throwOutOfMemory(env, "Unable to grow native WSOLA processing buffer");
+        return 0;
+    } catch (const std::exception &e) {
+        throwIllegalState(env, e.what());
+        return 0;
+    } catch (...) {
+        throwIllegalState(env, "Native WSOLA processing failed");
+        return 0;
+    }
+}
+
+extern "C" JNIEXPORT jdouble JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_getPendingInputFrames(
+    JNIEnv * /* env */, jclass /* clazz */, jlong handle)
+{
+    WsolaContext *ctx = fromHandle(handle);
+    if (ctx == nullptr) {
+        return 0.0;
+    }
+    // pending is queued in the JNI adapter but has not entered scaletempo2 yet; get_latency
+    // reports the frames already buffered inside scaletempo2 and not represented in its output.
+    const double pending = static_cast<double>(ctx->pending_frames) +
+        mp_scaletempo2_get_latency(&ctx->wsola, ctx->speed);
+    return std::isfinite(pending) ? std::max(0.0, pending) : 0.0;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_flush(
+    JNIEnv * /* env */, jclass /* clazz */, jlong handle)
+{
+    WsolaContext *ctx = fromHandle(handle);
+    if (ctx == nullptr) {
+        return;
+    }
+    wsola::mp_scaletempo2_reset(&ctx->wsola);
+    ctx->pending_frames = 0;
+    ctx->finish_signaled = false;
+    ctx->final_set = false;
+    // Speed is intentionally kept (per Kotlin contract).
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_finishInput(
+    JNIEnv * /* env */, jclass /* clazz */, jlong handle)
+{
+    WsolaContext *ctx = fromHandle(handle);
+    if (ctx == nullptr) {
+        return;
+    }
+    // Actual set_final is applied lazily in drainOutput once queued input is
+    // exhausted, so the tail is padded with silence and fully rendered.
+    ctx->finish_signaled = true;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_openani_mediamp_exoplayer_internal_WsolaProcessorNative_release(
+    JNIEnv * /* env */, jclass /* clazz */, jlong handle)
+{
+    delete fromHandle(handle);
+}


### PR DESCRIPTION
## Summary

Add an opt-in native WSOLA backend for playback-speed changes in the Android ExoPlayer implementation.

The existing Media3 audio pipeline remains the default. Callers can enable WSOLA when creating the player:

```kotlin
val player = ExoPlayerMediampPlayer(
    context,
    parentCoroutineContext,
    ExoPlayerAudioTimeStretch.HighQualityWsola,
)
```

The same option is available through `ExoPlayerMediampPlayerFactory.create`.

## Implementation

`HighQualityWsola` installs a custom Media3 `AudioProcessorChain` that preserves the default silence-skipping behavior and replaces the Sonic time-stretch slot with a WSOLA processor.

The processor supports mono and stereo PCM in 16-bit integer and 32-bit float formats. It converts Media3's interleaved PCM to planar float samples for processing, then converts the result back to the input PCM format.

Backend selection happens when Media3 configures the stream:

- use native WSOLA when the library and audio format are available;
- otherwise configure Media3's `SonicAudioProcessor`;
- send audio only to the selected backend.

The fallback is logged as a warning. The previous two-argument `ExoPlayerMediampPlayer` JVM constructor is retained for binary compatibility.

The WSOLA core is a standalone C++17 port of mpv's `scaletempo2`, originally derived from Chromium's `AudioRendererAlgorithm`. JNI handles streaming buffers, EOS draining, latency reporting, PCM conversion, argument validation, and native exception boundaries.

## Native build

The Android build compiles `libmediamp_wsola.so` with the NDK LLVM toolchain for `arm64-v8a`, `armeabi-v7a`, `x86`, and `x86_64`.

The ABI set can be restricted with:

```text
-Pmediamp.exoplayer.wsola.androidabis=arm64-v8a,x86_64
```

The native build can be disabled with:

```text
-Pmediamp.exoplayer.wsola.skip=true
```

If the NDK or native library is unavailable, playback falls back to Sonic.

## Licensing

The AAR includes the Chromium BSD 3-Clause notice under a component-specific `META-INF/licenses` path. A verification task checks the packaged `classes.jar`, rather than only checking the source tree.

## Validation

- Compiled the native library for all four Android ABIs with `-Wall -Wextra -Werror`.
- Compiled `androidMain`.
- Passed `testAndroidHostTest`.
- Passed `verifyWsolaLicensePackaging`.
- Exercised PCM16 and PCM float through a host JNI smoke test, including non-zero offsets, alignment rejection, non-finite float sanitization, 2x output, latency reporting, and EOS draining.
- Published `0.1.13-local-2` to Maven Local and inspected the resulting AAR for all four native libraries and the BSD notice.

Real-device playback remains to be verified.
