### PR TITLE
refactor(mpv): decouple Linux GLX render path behind platform interfaces

### DIFF
--- a/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
@@ -26,8 +26,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import org.jetbrains.skiko.OS
-import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.PreviewFrame
@@ -116,14 +114,16 @@ internal class MpvFramePreview(
             if (existing.mediaData === data) return existing
             discardSessionLocked()
         }
-        // A new Linux preview player needs a GLX environment before vo=libmpv can load.
-        val renderEnvironment = (mainPlayer as? MpvMediampPlayer)?.currentOpenGLRenderEnvironment()
-        if (hostOs == OS.Linux && renderEnvironment == null) return null
+        // A new preview decoder can only be provisioned once the main player's render
+        // prerequisites exist (environment-bound backends need their attached render
+        // environment before vo=libmpv can load); null means they are not available yet.
+        val provisioning = (mainPlayer as? MpvMediampPlayer)
+            ?.renderContextLifecycle?.captureProvisioning() ?: return null
         return try {
             // NonCancellable: decoder creation is expensive shared state; a cancelled first
             // request must not abort it half-way (the next request reuses the session).
             withContext(NonCancellable) {
-                val decoder = MpvPreviewDecoder(context, ringBackend, renderEnvironment)
+                val decoder = MpvPreviewDecoder(context, ringBackend, provisioning)
                 try {
                     PreviewSession(data, decoder, scope)
                 } catch (e: Throwable) {

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
@@ -12,14 +12,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.Image
-import org.jetbrains.skiko.OS
-import org.jetbrains.skiko.hostOs
+import org.jetbrains.skiko.SkiaLayer
 import org.openani.mediamp.InternalMediampApi
+import org.openani.mediamp.mpv.internal.MpvRenderContextHost
+import org.openani.mediamp.mpv.internal.MpvRenderContextLifecycle
 import org.openani.mediamp.mpv.internal.MpvSurfaceRing
 import org.openani.mediamp.mpv.internal.MpvSurfaceRingBackend
-import org.openani.mediamp.mpv.internal.OpenGLSurfaceRingBackend
-import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
 import org.openani.mediamp.mpv.internal.currentSurfaceRingBackend
+import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
 import kotlin.coroutines.CoroutineContext
 
 @OptIn(InternalMediampApi::class)
@@ -31,19 +31,31 @@ actual class MpvMediampPlayer(
     // Native surface-ring render path; the consumer state machine is shared (MpvSurfaceRing).
     private val ringBackend: MpvSurfaceRingBackend? = currentSurfaceRingBackend()
     private val surfaceRing: MpvSurfaceRing? = ringBackend?.let { MpvSurfaceRing(handle.ptr, it) }
-    private var attachedOpenGLEnvironment: OpenGLRenderEnvironment? = null
+
+    /**
+     * Producer-context lifecycle chosen by the backend: eager where the backend owns its
+     * producer device (macOS/Windows), environment-bound on Linux. Platform-specific
+     * operations (such as the Linux GLX attach) exist only on the platform
+     * implementation, so other platforms cannot call them by mistake.
+     */
+    internal val renderContextLifecycle: MpvRenderContextLifecycle? =
+        ringBackend?.createRenderContextLifecycle(
+            object : MpvRenderContextHost {
+                override val handle: MPVHandle get() = this@MpvMediampPlayer.handle
+
+                override fun hasActivePlaybackSession(): Boolean =
+                    this@MpvMediampPlayer.hasActivePlaybackSession()
+
+                override fun onRenderContextReady() = renderContextBecameReady()
+
+                override fun invalidateSurfaceRingForEnvironmentChange() {
+                    surfaceRing?.invalidateForRenderEnvironmentChange()
+                }
+            },
+        )
 
     init {
-        if (hostOs == OS.Linux) {
-            // Prefer the two Linux paths mediamp validates: NVIDIA can keep decoded
-            // frames on-GPU through CUDA/OpenGL, while Intel/AMD use stable VAAPI
-            // decode with a system-memory copy. Only then try mpv's safe auto list.
-            check(handle.setPropertyString("hwdec", "nvdec,vaapi-copy,auto-safe"))
-        }
-        // macOS and Windows own their producer device. Linux must first attach the live
-        // Skiko GLX environment, otherwise `vo=libmpv` would be asked to load before its
-        // required render context can exist.
-        if (hostOs != OS.Linux) createRenderContext()
+        renderContextLifecycle?.initialize()
     }
 
     /** Creates the native render context and starts the render thread. Idempotent. */
@@ -53,50 +65,12 @@ actual class MpvMediampPlayer(
     internal fun releaseRenderContext(): Boolean =
         ringBackend?.destroyRenderContext(handle.ptr) ?: false
 
-    /**
-     * Attaches Skiko's current GLX share environment. A new identity is a device
-     * recreation: native code must discard its old producer context/share group before
-     * the next `createRenderContext`, and the ring recreates its consumer wrappers on
-     * the next published generation.
-     */
-    internal fun attachOpenGLRenderEnvironment(environment: OpenGLRenderEnvironment): Boolean {
-        if (hostOs != OS.Linux) return false
-        if (attachedOpenGLEnvironment?.identity == environment.identity) {
-            return createRenderContext().also { if (it) renderContextBecameReady() }
-        }
-        if (attachedOpenGLEnvironment != null) {
-            // mpv's render.h states that freeing mpv_render_context while video is active
-            // forcibly disables video. Replacing Skiko's GLX share group therefore cannot
-            // be handled by merely destroying and recreating context B: recovery would
-            // require a separately verified video-output reload that preserves position,
-            // pause state, selected track, and hwdec state.
-            check(!hasActivePlaybackSession()) {
-                "Skiko replaced its GLX share context during active playback. " +
-                    "Transparent mpv video-output recovery is not supported."
-            }
-            // The native OpenGL renderer owns its GLX context and must release it before
-            // accepting a new Skiko share context. The old GLX context owns its stale
-            // FBOs; closing Skia wrappers below makes their texture references disappear.
-            surfaceRing?.invalidateForRenderEnvironmentChange()
-            releaseRenderContext()
-        }
-        val attached = (ringBackend as OpenGLSurfaceRingBackend)
-            .attachRenderEnvironment(handle.ptr, environment)
-        if (attached) {
-            attachedOpenGLEnvironment = environment
-            if (createRenderContext()) renderContextBecameReady()
-        }
-        return attached
-    }
+    override fun ensureRenderContextForLoad(): Boolean =
+        renderContextLifecycle?.ensureReadyForLoad() ?: true
 
-    override fun ensureRenderContextForLoad(): Boolean = when (hostOs) {
-        OS.Linux -> attachedOpenGLEnvironment != null && createRenderContext()
-        // Eager platforms keep the established load behavior even when a headless CI
-        // environment cannot create an accelerated producer context.
-        else -> true
-    }
-
-    internal fun currentOpenGLRenderEnvironment(): OpenGLRenderEnvironment? = attachedOpenGLEnvironment
+    /** See [MpvSurfaceRingBackend.createSkiaInterop]. */
+    internal fun createSkiaInterop(layer: SkiaLayer): SkiaRenderDeviceInterop? =
+        ringBackend?.createSkiaInterop(layer)
 
     /** See [MpvSurfaceRing.requestSurface]. */
     internal fun requestSurface(width: Int, height: Int, devicePtr: Long): Boolean =

--- a/mediamp-mpv/src/desktopMain/kotlin/compose/MpvMediampPlayerSurface.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/compose/MpvMediampPlayerSurface.desktop.kt
@@ -32,16 +32,11 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.SamplingMode
-import org.jetbrains.skiko.OS
-import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.MPVLog
 import org.openani.mediamp.mpv.MpvMediampPlayer
-import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
-import org.openani.mediamp.mpv.utils.OpenGLRenderSnapshot
-import org.openani.mediamp.mpv.utils.SkiaDirectXInterop
-import org.openani.mediamp.mpv.utils.SkiaMetalInterop
-import org.openani.mediamp.mpv.utils.SkiaOpenGLInterop
+import org.openani.mediamp.mpv.internal.MpvSurfaceDrawResolver
+import org.openani.mediamp.mpv.internal.currentSurfaceRingBackend
 import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
 import org.openani.mediamp.mpv.utils.findSkiaLayer
 import kotlin.time.Duration.Companion.milliseconds
@@ -51,9 +46,10 @@ actual fun MpvMediampPlayerSurface(
     player: MpvMediampPlayer,
     modifier: Modifier,
 ) {
-    when (hostOs) {
-        OS.MacOS, OS.Windows, OS.Linux -> MpvMediampPlayerSurfaceRing(player, modifier)
-        else -> Box(modifier)
+    if (currentSurfaceRingBackend() != null) {
+        MpvMediampPlayerSurfaceRing(player, modifier)
+    } else {
+        Box(modifier)
     }
 }
 
@@ -66,6 +62,9 @@ actual fun MpvMediampPlayerSurface(
  * shared handles opened as ID3D12Resources on Windows (hwdec=d3d11va, libmpv D3D11
  * render API). The video becomes a regular draw call in the Compose scene graph, zero
  * extra CPU copies end to end, and this thread never renders or blocks.
+ *
+ * All platform differences live behind [MpvSurfaceDrawResolver] and the player's
+ * render-context lifecycle; this composable contains no host checks.
  */
 @OptIn(InternalMediampApi::class)
 @Composable
@@ -84,60 +83,28 @@ private fun MpvMediampPlayerSurfaceRing(
             MPVLog.warn(player.handle.ptr, "no SkiaLayer found in window $window; video stays black")
             return@remember null
         }
-        runCatching {
-            when (hostOs) {
-                OS.MacOS -> SkiaMetalInterop(layer)
-                OS.Windows -> SkiaDirectXInterop(layer)
-                OS.Linux -> SkiaOpenGLInterop(layer)
-                else -> null
-            }
-        }
+        runCatching { player.createSkiaInterop(layer) }
             .onFailure { MPVLog.error(player.handle.ptr, "Skia device interop init failed; video stays black", it) }
             .getOrNull()
     }
+    val drawResolver: MpvSurfaceDrawResolver? = remember(player, interop) {
+        interop?.let { player.renderContextLifecycle?.createDrawResolver(it) }
+    }
     val frameTick = remember { mutableLongStateOf(0L) }
     val canvasSize = remember { mutableStateOf(IntSize.Zero) }
-    // macOS/Windows create their producer context eagerly. Linux intentionally waits for
-    // the live LinuxOpenGLRedrawer so `vo=libmpv` never sees loadfile before GLX sharing
-    // has been attached.
+    // Whether the player's producer render context exists. Eager backends decide this
+    // when the surface enters composition; deferred-readiness backends (Linux GLX)
+    // intentionally wait for the live redrawer so `vo=libmpv` never sees loadfile
+    // before its render environment has been attached — they become ready from the
+    // first successful draw pass instead.
     var renderContextReady by remember(player) { mutableStateOf(false) }
     val loggedStates = remember(player) { mutableSetOf<String>() }
     fun logOnce(state: String, level: Int = MPVLog.DEBUG) {
         if (loggedStates.add(state)) MPVLog.log(player.handle.ptr, level, state)
     }
-    // Linux re-checks the live GLX identity because Skiko may replace its redrawer.
-    fun ensureRenderContext(environment: OpenGLRenderEnvironment? = null): Boolean {
-        if (hostOs != OS.Linux) return renderContextReady
-        environment ?: return false
-        if (renderContextReady &&
-            player.currentOpenGLRenderEnvironment()?.identity == environment.identity
-        ) {
-            return true
-        }
-        val ready = runCatching {
-            player.attachOpenGLRenderEnvironment(environment)
-        }.onFailure {
-            MPVLog.error(player.handle.ptr, "Linux GLX render context unavailable; video stays black", it)
-        }.getOrDefault(false)
-        if (ready && !renderContextReady) {
-            player.setRenderUpdateListener { frameTick.longValue++ }
-            renderContextReady = true
-        }
-        return ready
-    }
-
-    fun currentOpenGLSnapshot(): OpenGLRenderSnapshot? {
-        if (hostOs != OS.Linux) return null
-        val glInterop = interop as? SkiaOpenGLInterop ?: return null
-        val snapshot = runCatching { glInterop.renderSnapshot() }
-            .onFailure { MPVLog.error(player.handle.ptr, "Linux GLX render context unavailable; video stays black", it) }
-            .getOrNull() ?: return null
-        return snapshot.takeIf { ensureRenderContext(it.environment) }
-    }
 
     DisposableEffect(player) {
-        // Linux creates its shared context later, from the live redrawer in Canvas.
-        renderContextReady = hostOs != OS.Linux && player.createRenderContext()
+        renderContextReady = player.renderContextLifecycle?.createEagerly() ?: false
         if (renderContextReady) {
             player.setRenderUpdateListener { frameTick.longValue++ }
         }
@@ -148,19 +115,21 @@ private fun MpvMediampPlayerSurfaceRing(
         }
     }
 
-    // Linux waits for GLX attachment; Metal/D3D keep their existing readiness retry.
-    // The first ready layout configures immediately; later size changes
-    // (window resize, overlay-driven relayout) settle for 150ms first. The reallocation
-    // itself happens between frames on the native render thread, and the draw pass
-    // letterboxes whatever the ring currently contains, so resizes cost no visible
-    // frames — the video keeps playing at the old size until the new ring has content.
+    // Deferred-readiness backends wait for the render context; eager backends keep
+    // their existing readiness retry. The first ready layout configures immediately;
+    // later size changes (window resize, overlay-driven relayout) settle for 150ms
+    // first. The reallocation itself happens between frames on the native render
+    // thread, and the draw pass letterboxes whatever the ring currently contains, so
+    // resizes cost no visible frames — the video keeps playing at the old size until
+    // the new ring has content.
     LaunchedEffect(player, interop) {
         val deviceInterop = interop ?: return@LaunchedEffect
+        val deferredReadiness = player.renderContextLifecycle?.deferredReadiness == true
         var configured = false
         snapshotFlow { canvasSize.value }
             .filter { it.width > 0 && it.height > 0 }
             .collectLatest { size ->
-                if (hostOs == OS.Linux) {
+                if (deferredReadiness) {
                     snapshotFlow { renderContextReady }.first { it }
                 }
                 if (configured) delay(150.milliseconds)
@@ -172,7 +141,7 @@ private fun MpvMediampPlayerSurfaceRing(
                         configured = true
                         break
                     }
-                    if (hostOs == OS.Linux) break
+                    if (deferredReadiness) break
                     delay(50.milliseconds)
                 }
             }
@@ -181,25 +150,23 @@ private fun MpvMediampPlayerSurfaceRing(
     Canvas(modifier.onSizeChanged { canvasSize.value = it }) {
         frameTick.longValue // subscribe: redraw whenever mpv publishes a new frame
 
-        if (interop == null) {
+        if (drawResolver == null) {
             logOnce("skia interop unavailable; video stays black (frames are drained)", MPVLog.ERROR)
             return@Canvas
         }
-        val openGLSnapshot = currentOpenGLSnapshot()
-        val renderReady = if (hostOs == OS.Linux) {
-            openGLSnapshot != null
-        } else {
-            renderContextReady
+        val drawPass = drawResolver.resolveDrawPass(renderContextReady)
+        if (drawPass != null && !renderContextReady) {
+            // Deferred-readiness backends attach inside resolveDrawPass: the first
+            // successful pass is the readiness transition, so hook the frame listener
+            // here.
+            player.setRenderUpdateListener { frameTick.longValue++ }
+            renderContextReady = true
         }
-        if (!renderReady) {
+        if (drawPass == null) {
             logOnce("render context not ready")
             return@Canvas
         }
-        val directContext = if (hostOs == OS.Linux) {
-            openGLSnapshot?.directContext
-        } else {
-            interop.directContext
-        }
+        val directContext = drawPass.directContext
         if (directContext == null) {
             logOnce("DirectContext not initialized yet")
             return@Canvas
@@ -209,19 +176,11 @@ private fun MpvMediampPlayerSurfaceRing(
         if (width <= 0 || height <= 0) return@Canvas
         // Skiko can recreate its redrawer (and render device) at runtime; the ring's
         // textures must live on Skia's current device.
-        val renderDevicePtr = openGLSnapshot?.environment?.shareContext
-            ?: runCatching { interop.renderDevicePtr }.getOrNull()
-        renderDevicePtr?.let {
+        drawPass.renderDevicePtr()?.let {
             player.refreshDeviceIfChanged(it)
         }
 
-        val renderer = when (hostOs) {
-            OS.MacOS -> "Metal"
-            OS.Windows -> "D3D12"
-            OS.Linux -> "OpenGL/GLX"
-            else -> "unknown"
-        }
-        logOnce("rendering ${width}x${height} via $renderer surface", MPVLog.INFO)
+        logOnce("rendering ${width}x${height} via ${drawResolver.rendererName} surface", MPVLog.INFO)
         // Draw through Compose so the op survives RenderNode display-list recording
         // (raw nativeCanvas draws are dropped there). The image is a Skia-owned texture:
         // snapshots of the BRT-wrapped surface itself do not render. The frame normally

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
@@ -9,13 +9,10 @@
 package org.openani.mediamp.mpv.internal
 
 import kotlinx.coroutines.currentCoroutineContext
-import org.jetbrains.skiko.OS
-import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.io.SeekableInput
 import org.openani.mediamp.mpv.MPVHandle
 import org.openani.mediamp.mpv.RenderUpdateListener
-import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
 import org.openani.mediamp.source.MediaData
 import org.openani.mediamp.source.SeekableInputMediaData
 import org.openani.mediamp.source.UriMediaData
@@ -37,7 +34,7 @@ private const val FRAME_PREVIEW_LOAD_TARGET_PREFIX = "mediamp://frame_preview/"
 internal class MpvPreviewDecoder(
     context: Any,
     private val ringBackend: MpvSurfaceRingBackend,
-    renderEnvironment: OpenGLRenderEnvironment? = null,
+    provisioning: MpvRenderContextProvisioning,
 ) : AutoCloseable {
     val handle = MPVHandle(context)
 
@@ -48,14 +45,9 @@ internal class MpvPreviewDecoder(
     init {
         try {
             configure()
-            if (hostOs == OS.Linux) {
-                checkNotNull(renderEnvironment) {
-                    "Linux frame preview requires the main player's GLX environment"
-                }
-                check((ringBackend as OpenGLSurfaceRingBackend).attachRenderEnvironment(handle.ptr, renderEnvironment)) {
-                    "Could not attach the main player's GLX environment to the preview decoder"
-                }
-            }
+            // Environment-bound backends attach the main player's render environment
+            // before the decoder's own render context can exist.
+            provisioning.prepare(handle.ptr)
             check(ringBackend.createRenderContext(handle.ptr)) {
                 "Failed to create the mpv render context for frame preview"
             }

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvRenderContextLifecycle.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvRenderContextLifecycle.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.internal
+
+import org.openani.mediamp.mpv.MPVHandle
+import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
+
+/**
+ * Player-side dependencies of a [MpvRenderContextLifecycle]: the native handle plus the
+ * deferred-load hooks of `JvmMpvMediampPlayer`. Implemented by `MpvMediampPlayer`.
+ */
+internal interface MpvRenderContextHost {
+    val handle: MPVHandle
+
+    /** True while a playback session is active; see `JvmMpvMediampPlayer`. */
+    fun hasActivePlaybackSession(): Boolean
+
+    /** Completes a load deferred until the render context became ready. */
+    fun onRenderContextReady()
+
+    /** Drops consumer-side Skia wraps before the producer replaces its render environment. */
+    fun invalidateSurfaceRingForEnvironmentChange()
+}
+
+/**
+ * Everything a second mpv instance (the frame-preview decoder) must attach before it can
+ * create its own render context. Captured from the main player's
+ * [MpvRenderContextLifecycle] at session-creation time, so a concurrent environment
+ * replacement cannot change what gets attached.
+ */
+internal fun interface MpvRenderContextProvisioning {
+    /** Attaches the captured prerequisites to [handlePtr]; throws when attachment fails. */
+    fun prepare(handlePtr: Long)
+}
+
+/**
+ * Per-player lifecycle of the backend's producer render context: WHEN
+ * [MpvSurfaceRingBackend.createRenderContext] may run. Backends that own their producer
+ * device ([EagerRenderContextLifecycle]) create it at player construction; backends whose
+ * producer context must join an externally owned render environment
+ * (`OpenGLRenderContextLifecycle`) create it only once that environment has been attached
+ * and gate `loadfile` on it. Chosen by [MpvSurfaceRingBackend], so the shared player and
+ * composable contain no platform checks — and platform-specific operations (such as the
+ * Linux GLX attach) exist only on the platform implementation, where other platforms
+ * cannot call them by mistake.
+ */
+internal interface MpvRenderContextLifecycle {
+    /**
+     * One-time backend setup at player construction (after mpv initialization): eager
+     * backends create the producer context and start the render thread now;
+     * environment-bound backends apply their decode constraints and wait for the attach.
+     */
+    fun initialize()
+
+    /**
+     * Creates the producer context when the compose surface enters composition, returning
+     * the initial "render context ready" state. Environment-bound backends return false
+     * without touching native state: readiness arrives from the first successful draw
+     * pass instead.
+     */
+    fun createEagerly(): Boolean
+
+    /**
+     * Whether the producer context may exist for `loadfile` right now; see
+     * `JvmMpvMediampPlayer.ensureRenderContextForLoad`.
+     */
+    fun ensureReadyForLoad(): Boolean
+
+    /**
+     * True when readiness arrives from a draw pass rather than from [createEagerly]. The
+     * surface-config loop then waits for readiness before its first request and does not
+     * poll after a failed request (the environment went away; a later draw pass
+     * re-attaches and state changes retrigger the loop).
+     */
+    val deferredReadiness: Boolean
+
+    /** The per-draw resolver matching this lifecycle; [interop] comes from the same backend. */
+    fun createDrawResolver(interop: SkiaRenderDeviceInterop): MpvSurfaceDrawResolver
+
+    /**
+     * Captures what the frame-preview decoder must attach before creating its own render
+     * context, or null when that is unavailable (environment-bound backends before their
+     * first attach) — the decoder cannot be created then.
+     */
+    fun captureProvisioning(): MpvRenderContextProvisioning?
+}
+
+/**
+ * Lifecycle for backends that own their producer device (macOS Metal, Windows D3D11):
+ * the render context is created eagerly at player construction and needs nothing from
+ * the live Skiko renderer.
+ */
+internal class EagerRenderContextLifecycle(
+    private val backend: MpvSurfaceRingBackend,
+    private val host: MpvRenderContextHost,
+) : MpvRenderContextLifecycle {
+    override fun initialize() {
+        backend.createRenderContext(host.handle.ptr)
+    }
+
+    override fun createEagerly(): Boolean = backend.createRenderContext(host.handle.ptr)
+
+    // Eager platforms keep the established load behavior even when a headless CI
+    // environment cannot create an accelerated producer context.
+    override fun ensureReadyForLoad(): Boolean = true
+
+    override val deferredReadiness: Boolean get() = false
+
+    override fun createDrawResolver(interop: SkiaRenderDeviceInterop): MpvSurfaceDrawResolver =
+        EagerSurfaceDrawResolver(backend, interop)
+
+    override fun captureProvisioning(): MpvRenderContextProvisioning =
+        MpvRenderContextProvisioning { }
+}

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceDrawResolver.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceDrawResolver.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.internal
+
+import org.jetbrains.skia.DirectContext
+import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
+
+/**
+ * What one compose draw pass renders against. [directContext] is Skia's current
+ * GrDirectContext (null until the window rendered its first frame). [renderDevicePtr] is
+ * deliberately a deferred read: the draw pass resolves the consumer render device only
+ * after its size checks, against the live redrawer.
+ */
+internal class MpvSurfaceDrawPass(
+    val directContext: DirectContext?,
+    val renderDevicePtr: () -> Long?,
+)
+
+/**
+ * Platform half of the compose draw pass, mirroring [MpvSurfaceRingBackend]: how each
+ * draw resolves readiness and Skia's current target. Environment-bound backends may
+ * (re)attach their render environment inside [resolveDrawPass]; eager backends only gate
+ * on the readiness established when the surface entered composition.
+ */
+internal interface MpvSurfaceDrawResolver {
+    /** Renderer name for the one-time "rendering WxH via X surface" log line. */
+    val rendererName: String
+
+    /**
+     * Resolves what this draw pass may render with, or null when the render context is
+     * not ready. [renderContextReady] is the composable's current readiness state; a
+     * non-null result while it is still false means readiness just arrived with this
+     * pass.
+     */
+    fun resolveDrawPass(renderContextReady: Boolean): MpvSurfaceDrawPass?
+}
+
+/** Draw resolver for eagerly-created contexts: readiness was decided at composition start. */
+internal class EagerSurfaceDrawResolver(
+    backend: MpvSurfaceRingBackend,
+    private val interop: SkiaRenderDeviceInterop,
+) : MpvSurfaceDrawResolver {
+    override val rendererName: String = backend.rendererName
+
+    override fun resolveDrawPass(renderContextReady: Boolean): MpvSurfaceDrawPass? {
+        if (!renderContextReady) return null
+        return MpvSurfaceDrawPass(interop.directContext) {
+            runCatching { interop.renderDevicePtr }.getOrNull()
+        }
+    }
+}

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
@@ -19,6 +19,7 @@ import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
 import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.MPVLog
@@ -53,6 +54,10 @@ import org.openani.mediamp.mpv.nSetSurfaceConfigMacos
 import org.openani.mediamp.mpv.nSetSurfaceConfigOpenGL
 import org.openani.mediamp.mpv.nAttachRenderEnvironmentOpenGL
 import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
+import org.openani.mediamp.mpv.utils.SkiaDirectXInterop
+import org.openani.mediamp.mpv.utils.SkiaMetalInterop
+import org.openani.mediamp.mpv.utils.SkiaOpenGLInterop
+import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
 
 internal const val SURFACE_RING_BUFFER_COUNT = 3
 
@@ -88,14 +93,30 @@ internal fun currentSurfaceRingBackend(): MpvSurfaceRingBackend? = when (hostOs)
 }
 
 /**
- * Platform half of the native surface-ring render path: the JNI entry points plus how
- * a ring buffer's native texture is wrapped for Skia. The consumer state machine on top
- * ([MpvSurfaceRing]) is capability-based: Metal/IOSurface on macOS, D3D11/D3D12 shared
- * textures on Windows, and shared OpenGL textures on Linux/GLX.
+ * Platform half of the native surface-ring render path: the JNI entry points, how a
+ * ring buffer's native texture is wrapped for Skia, which reflective Skia interop reads
+ * the consumer device, and which [MpvRenderContextLifecycle] governs the producer
+ * context. The consumer state machine on top ([MpvSurfaceRing]) is capability-based:
+ * Metal/IOSurface on macOS, D3D11/D3D12 shared textures on Windows, and shared OpenGL
+ * textures on Linux/GLX.
  */
 internal interface MpvSurfaceRingBackend {
     fun createRenderContext(ptr: Long): Boolean
     fun destroyRenderContext(ptr: Long): Boolean
+
+    /** Renderer name for user-facing logs: what Compose draws the ring's frames with. */
+    val rendererName: String
+
+    /** Creates the reflective interop reading the consumer render device of [layer]. */
+    fun createSkiaInterop(layer: SkiaLayer): SkiaRenderDeviceInterop
+
+    /**
+     * Creates the per-player producer-context lifecycle. Backends owning their producer
+     * device are eager; environment-bound backends override (see
+     * [OpenGLRenderContextLifecycle]).
+     */
+    fun createRenderContextLifecycle(host: MpvRenderContextHost): MpvRenderContextLifecycle =
+        EagerRenderContextLifecycle(this, host)
 
     /**
      * [devicePtr] is the consumer-side render device: an MTLDevice pointer on macOS or a
@@ -140,6 +161,8 @@ internal object MacosSurfaceRingBackend : MpvSurfaceRingBackend {
         MpvConsumerRenderTarget(BackendRenderTarget.makeMetal(width, height, texturePtr))
 
     override val wrapColorFormat: SurfaceColorFormat get() = SurfaceColorFormat.BGRA_8888
+    override val rendererName: String get() = "Metal"
+    override fun createSkiaInterop(layer: SkiaLayer): SkiaRenderDeviceInterop = SkiaMetalInterop(layer)
 }
 
 @OptIn(InternalMediampApi::class)
@@ -174,6 +197,11 @@ internal object D3D11SurfaceRingBackend : MpvSurfaceRingBackend {
     // so wrap as RGBA_8888. mpv's d3d11 renderer writes alpha=1 for opaque video
     // (verified by the demo pixel readback), so premultiplied sampling is safe.
     override val wrapColorFormat: SurfaceColorFormat get() = SurfaceColorFormat.RGBA_8888
+
+    // The producer renders through D3D11, but the consumer side Compose draws with is
+    // Skiko's D3D12 device.
+    override val rendererName: String get() = "D3D12"
+    override fun createSkiaInterop(layer: SkiaLayer): SkiaRenderDeviceInterop = SkiaDirectXInterop(layer)
 }
 
 /**
@@ -236,6 +264,11 @@ internal object OpenGLSurfaceRingBackend : MpvSurfaceRingBackend {
 
     override val wrapColorFormat: SurfaceColorFormat get() = SurfaceColorFormat.RGBA_8888
     override val skiaSurfaceOrigin: SurfaceOrigin get() = SurfaceOrigin.BOTTOM_LEFT
+    override val rendererName: String get() = "OpenGL/GLX"
+    override fun createSkiaInterop(layer: SkiaLayer): SkiaRenderDeviceInterop = SkiaOpenGLInterop(layer)
+
+    override fun createRenderContextLifecycle(host: MpvRenderContextHost): MpvRenderContextLifecycle =
+        OpenGLRenderContextLifecycle(this, host)
 }
 
 /**

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/OpenGLRenderContextLifecycle.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/OpenGLRenderContextLifecycle.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.internal
+
+import org.openani.mediamp.mpv.MPVLog
+import org.openani.mediamp.mpv.utils.OpenGLRenderEnvironment
+import org.openani.mediamp.mpv.utils.SkiaOpenGLInterop
+import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
+
+/**
+ * Linux GLX lifecycle: the producer context must join Skiko's live GLX share group, so it
+ * can only be created after [attachRenderEnvironment], and `loadfile` is gated on that
+ * (`vo=libmpv` requires the render context to exist first).
+ */
+internal class OpenGLRenderContextLifecycle(
+    private val backend: OpenGLSurfaceRingBackend,
+    private val host: MpvRenderContextHost,
+) : MpvRenderContextLifecycle {
+
+    private var attachedEnvironment: OpenGLRenderEnvironment? = null
+
+    override fun initialize() {
+        // Prefer the two Linux paths mediamp validates: NVIDIA can keep decoded
+        // frames on-GPU through CUDA/OpenGL, while Intel/AMD use stable VAAPI
+        // decode with a system-memory copy. Only then try mpv's safe auto list.
+        check(host.handle.setPropertyString("hwdec", "nvdec,vaapi-copy,auto-safe"))
+        // No producer context yet: the live Skiko GLX environment must be attached
+        // first, otherwise `vo=libmpv` would be asked to load before its required
+        // render context can exist.
+    }
+
+    override fun createEagerly(): Boolean = false
+
+    override fun ensureReadyForLoad(): Boolean =
+        attachedEnvironment != null && backend.createRenderContext(host.handle.ptr)
+
+    override val deferredReadiness: Boolean get() = true
+
+    override fun createDrawResolver(interop: SkiaRenderDeviceInterop): MpvSurfaceDrawResolver =
+        OpenGLSurfaceDrawResolver(interop as SkiaOpenGLInterop, this, host)
+
+    override fun captureProvisioning(): MpvRenderContextProvisioning? {
+        val environment = attachedEnvironment ?: return null
+        return MpvRenderContextProvisioning { handlePtr ->
+            check(backend.attachRenderEnvironment(handlePtr, environment)) {
+                "Could not attach the main player's GLX environment to the preview decoder"
+            }
+        }
+    }
+
+    /** The currently attached GLX environment, or null before the first attach. */
+    fun currentRenderEnvironment(): OpenGLRenderEnvironment? = attachedEnvironment
+
+    /**
+     * Attaches Skiko's current GLX share environment. A new identity is a device
+     * recreation: native code must discard its old producer context/share group before
+     * the next `createRenderContext`, and the ring recreates its consumer wrappers on
+     * the next published generation.
+     */
+    fun attachRenderEnvironment(environment: OpenGLRenderEnvironment): Boolean {
+        if (attachedEnvironment?.identity == environment.identity) {
+            return backend.createRenderContext(host.handle.ptr)
+                .also { if (it) host.onRenderContextReady() }
+        }
+        if (attachedEnvironment != null) {
+            // mpv's render.h states that freeing mpv_render_context while video is active
+            // forcibly disables video. Replacing Skiko's GLX share group therefore cannot
+            // be handled by merely destroying and recreating context B: recovery would
+            // require a separately verified video-output reload that preserves position,
+            // pause state, selected track, and hwdec state.
+            check(!host.hasActivePlaybackSession()) {
+                "Skiko replaced its GLX share context during active playback. " +
+                    "Transparent mpv video-output recovery is not supported."
+            }
+            // The native OpenGL renderer owns its GLX context and must release it before
+            // accepting a new Skiko share context. The old GLX context owns its stale
+            // FBOs; closing Skia wrappers below makes their texture references disappear.
+            host.invalidateSurfaceRingForEnvironmentChange()
+            backend.destroyRenderContext(host.handle.ptr)
+        }
+        val attached = backend.attachRenderEnvironment(host.handle.ptr, environment)
+        if (attached) {
+            attachedEnvironment = environment
+            if (backend.createRenderContext(host.handle.ptr)) host.onRenderContextReady()
+        }
+        return attached
+    }
+}
+
+/**
+ * Linux GLX draw resolver: Skiko may replace its redrawer (and with it the GLX share
+ * group) at runtime, so every draw re-reads the live snapshot and re-attaches when the
+ * identity changed.
+ */
+internal class OpenGLSurfaceDrawResolver(
+    private val interop: SkiaOpenGLInterop,
+    private val lifecycle: OpenGLRenderContextLifecycle,
+    private val host: MpvRenderContextHost,
+) : MpvSurfaceDrawResolver {
+    override val rendererName: String get() = OpenGLSurfaceRingBackend.rendererName
+
+    override fun resolveDrawPass(renderContextReady: Boolean): MpvSurfaceDrawPass? {
+        val snapshot = runCatching { interop.renderSnapshot() }
+            .onFailure {
+                MPVLog.error(host.handle.ptr, "Linux GLX render context unavailable; video stays black", it)
+            }
+            .getOrNull() ?: return null
+        val environment = snapshot.environment
+        val attached = if (renderContextReady &&
+            lifecycle.currentRenderEnvironment()?.identity == environment.identity
+        ) {
+            true
+        } else {
+            runCatching { lifecycle.attachRenderEnvironment(environment) }
+                .onFailure {
+                    MPVLog.error(host.handle.ptr, "Linux GLX render context unavailable; video stays black", it)
+                }
+                .getOrDefault(false)
+        }
+        if (!attached) return null
+        return MpvSurfaceDrawPass(snapshot.directContext) { environment.shareContext }
+    }
+}

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -68,8 +68,9 @@ abstract class JvmMpvMediampPlayer(
     internal val handle by lazy { MPVHandle(context) }
     private val stateMachine = MpvPlaybackStateMachine()
 
-    // Linux may resume before Skiko exposes its GLX share context. Preserve that load
-    // until surface attachment; eager macOS/Windows contexts never use this state.
+    // Platforms whose render context depends on an externally attached environment may
+    // resume before that environment exists. Preserve that load until the context
+    // becomes ready; eagerly-created contexts never use this state.
     private val pendingLoadLock = Any()
     private var pendingPlaybackLoad: MPVPlayerData? = null
 
@@ -321,15 +322,22 @@ abstract class JvmMpvMediampPlayer(
     }
 
     /**
-     * Linux overrides this because its GLX context is unavailable before surface attach.
-     * `vo=libmpv` requires it before `loadfile`; false defers the load while staying READY.
+     * Platform subclasses whose render context is unavailable until an external render
+     * environment is attached override this. `vo=libmpv` requires the context before
+     * `loadfile`; false defers the load while staying READY.
      */
     protected open fun ensureRenderContextForLoad(): Boolean = true
 
-    /** Linux rejects GLX share-group replacement while this playback session is active. */
+    /**
+     * Environment-bound render backends reject render-environment replacement while
+     * this playback session is active.
+     */
     protected fun hasActivePlaybackSession(): Boolean = stateMachine.playbackSessionActive
 
-    /** Completes a Linux load deferred until GLX attach; shares a lock with [resumeImpl]. */
+    /**
+     * Completes a load deferred until the render context became ready; shares a lock
+     * with [resumeImpl].
+     */
     protected fun renderContextBecameReady() {
         synchronized(pendingLoadLock) {
             val pending = pendingPlaybackLoad ?: return
@@ -339,13 +347,13 @@ abstract class JvmMpvMediampPlayer(
         }
     }
 
-    // Clear deferred Linux loads on replace/stop/close so a later GLX attach cannot
-    // resurrect a cancelled request.
+    // Clear deferred loads on replace/stop/close so a later render-context attach
+    // cannot resurrect a cancelled request.
     private fun cancelPendingPlaybackLoad() {
         synchronized(pendingLoadLock) { pendingPlaybackLoad = null }
     }
 
-    // Shared by the eager path and Linux's deferred path so state transitions stay equal.
+    // Shared by the eager path and the deferred path so state transitions stay equal.
     private fun loadForPlayback(media: MPVPlayerData): Boolean {
         handle.setPropertyBoolean("pause", false)
         if (!handle.command("loadfile", media.loadTarget, "replace")) return false
@@ -356,7 +364,7 @@ abstract class JvmMpvMediampPlayer(
 
     override suspend fun setMediaDataImpl(data: MediaData): MPVPlayerData = when (data) {
         is UriMediaData -> {
-            // Do not let a later Linux GLX attach load the resource being replaced.
+            // Do not let a later render-context attach load the resource being replaced.
             cancelPendingPlaybackLoad()
             clearPlaybackSession(resetPosition = true)
             handle.command("stop")
@@ -372,7 +380,7 @@ abstract class JvmMpvMediampPlayer(
         }
 
         is SeekableInputMediaData -> {
-            // Do not let a later Linux GLX attach load the resource being replaced.
+            // Do not let a later render-context attach load the resource being replaced.
             cancelPendingPlaybackLoad()
             clearPlaybackSession(resetPosition = true)
             handle.command("stop")
@@ -395,8 +403,9 @@ abstract class JvmMpvMediampPlayer(
         when (playbackState.value) {
             PlaybackState.READY -> {
                 val media = openResource.value ?: return
-                // Atomic with renderContextBecameReady(): GLX may become ready between
-                // the check and recording the pending load, which would lose the wake-up.
+                // Atomic with renderContextBecameReady(): the render context may become
+                // ready between the check and recording the pending load, which would
+                // lose the wake-up.
                 synchronized(pendingLoadLock) {
                     if (!ensureRenderContextForLoad()) {
                         pendingPlaybackLoad = media
@@ -445,7 +454,7 @@ abstract class JvmMpvMediampPlayer(
     }
 
     override fun stopPlaybackImpl() {
-        // Linux may still have a load waiting for GLX attach.
+        // A load may still be waiting for the render context.
         cancelPendingPlaybackLoad()
         handle.command("stop")
         clearPlaybackSession(resetPosition = true)
@@ -453,7 +462,7 @@ abstract class JvmMpvMediampPlayer(
     }
 
     override fun closeImpl() {
-        // Prevent a late Linux GLX attach from loading into a closing player.
+        // Prevent a late render-context attach from loading into a closing player.
         cancelPendingPlaybackLoad()
         (framePreview as? AutoCloseable)?.close()
         clearPlaybackSession(resetPosition = true)


### PR DESCRIPTION
## Summary

PR #40 added Linux OpenGL/GLX playback, but wired its logic directly into the three shared desktop files — `MpvMediampPlayer.jvm.kt`, `MpvMediampPlayer.desktop.kt`, and `MpvMediampPlayerSurface.desktop.kt` — as `hostOs == OS.Linux` branches and GLX-typed player APIs, while the Windows D3D11 and macOS Metal paths stayed cleanly behind `MpvSurfaceRingBackend`. This PR moves Linux behind the same kind of platform seam. **Pure decoupling — no rendering behavior changes on any platform.**

## What changed

Platform selection still happens in exactly one place (`currentSurfaceRingBackend()`); the backend now also creates two new per-platform collaborators:

- **`MpvRenderContextLifecycle`** (new, neutral): per-player producer-context policy — construction-time setup, compose-enter creation, `loadfile` gating, and provisioning capture for the preview decoder. macOS/Windows share `EagerRenderContextLifecycle` (context created eagerly, as before).
- **`MpvSurfaceDrawResolver`** (new, neutral): the platform half of each compose draw pass — resolves the `DirectContext` and consumer render-device pointer.
- **`OpenGLRenderContextLifecycle`** (new, Linux-only): all GLX logic that previously lived in the shared files — the hwdec constraint (`nvdec,vaapi-copy,auto-safe`), environment attach with identity comparison and share-group replacement handling, per-draw GLX snapshot re-resolution, and preview-decoder provisioning.
- **Frame preview** (`MpvFramePreview` / `MpvPreviewDecoder`) now receives a neutral `MpvRenderContextProvisioning` captured from the main player instead of an `OpenGLRenderEnvironment?` parameter plus `hostOs` checks.
- **jvmMain** keeps its deferred-load mechanism (it is platform-neutral; Android uses the default eager path), with comments reworded away from Linux/GLX specifics. The `Platform.Linux` branch in `configureNativeHandle` stays — it is the per-platform mpv option table, symmetric with the Windows/macOS branches.

A concrete benefit: platform-dependent operations such as the GLX attach now exist **only on the Linux implementation class**, so other platforms cannot call them by mistake — the previous runtime guard (`if (hostOs != OS.Linux) return false`) becomes a compile-time impossibility.

## Behavior preservation notes for reviewers

Checked line-by-line against the original:

- Attach fast path (same GLX identity) still performs no native calls; the frame listener is still registered exactly once, on the first successful readiness transition.
- Eager platforms keep unwrapped `interop.directContext` reads (same exception semantics), the 50 ms surface-config retry loop, and `ensureRenderContextForLoad() == true` even when headless context creation failed.
- Linux keeps single-shot surface config after awaiting readiness, per-draw snapshot/re-attach, and the active-playback `check` on share-group replacement.
- All log messages, levels, and once-only conditions are unchanged, including `"Linux GLX render context unavailable; video stays black"` and the `"rendering WxH via X surface"` renderer names (`Metal` / `D3D12` / `OpenGL/GLX`).
- With no Skia interop, eager platforms still create the render context so frames keep draining.
- Preview provisioning captures the environment at session-creation time, matching the original read-once semantics.

## Testing

- `./gradlew :mediamp-mpv:desktopTest` — passes (native smoke tests skip without the dev runtime, as designed; the smoke tests' `createRenderContext`/`releaseRenderContext` internals are kept).
- `./gradlew :mediamp-mpv:compileAndroidMain` — passes.
- No references to the removed player APIs remain anywhere in the repo (demo apps only use the public composable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)