### PR TITLE
fix(mpv): skip event callbacks when no listener is registered

### DIFF
--- a/mediamp-mpv/src/cpp/event_listener.cpp
+++ b/mediamp-mpv/src/cpp/event_listener.cpp
@@ -161,7 +161,8 @@ void *(mpv_handle_t::event_loop)(void *arg) {
             continue;
         }
 
-        if (event->event_id != MPV_EVENT_PROPERTY_CHANGE &&
+        if (event_listener_ &&
+            event->event_id != MPV_EVENT_PROPERTY_CHANGE &&
             event->event_id != MPV_EVENT_LOG_MESSAGE &&
             jni_mediamp_method_EventListener_onEvent
         ) {


### PR DESCRIPTION
## Summary

Guard the generic `onEvent` JNI callback when an mpv handle has no event listener.

`MpvPreviewDecoder` intentionally initializes a headless mpv handle without registering an event listener. After #46, generic mpv events were dispatched with `CallVoidMethod` even when `event_listener_` was null, causing repeated JNI `NullPointerException`s:

```text
java.lang.NullPointerException
JNI exception in EventListener.onEvent
```

Property-change and end-file callbacks already tolerate a missing listener. This change applies the same check to the generic event callback.

## Verification

- `./gradlew :mediamp-mpv:desktopTest`
- Compiled `event_listener.cpp` with `g++ -fsyntax-only`