### PR TITLE
fix(mpv): fail fast on Kotlin<->native JNI version mismatch

### DIFF
--- a/mediamp-mpv/src/cpp/include/method_cache.h
+++ b/mediamp-mpv/src/cpp/include/method_cache.h
@@ -36,7 +36,11 @@ UTIL_EXTERN jmethodID jni_mediamp_method_SeekableInput_close;
 UTIL_EXTERN jclass jni_mediamp_clazz_android_Surface;
 #endif
 
-void jni_cache_classes(JNIEnv *env, const void *instance_handle = nullptr);
+// Resolves and caches every JNI class/method the native<->Kotlin bridge dispatches to.
+// All-or-nothing: returns true when the cache is populated (possibly by an earlier call),
+// false when any class or method failed to resolve — e.g. the Kotlin mediamp-mpv artifact
+// on the classpath does not match the version this native library was built against.
+bool jni_cache_classes(JNIEnv *env, const void *instance_handle = nullptr);
 
 // Raises a Java exception of `class_name` (e.g. "java/lang/IllegalStateException") carrying
 // `message`. The native method must return promptly afterwards; the exception is delivered

--- a/mediamp-mpv/src/cpp/method_cache.cpp
+++ b/mediamp-mpv/src/cpp/method_cache.cpp
@@ -97,14 +97,14 @@ void throw_illegal_argument(JNIEnv *env, const char *message, const void *instan
     throw_java_exception(env, "java/lang/IllegalArgumentException", message, instance_handle);
 }
 
-void jni_cache_classes(JNIEnv *env, const void *instance_handle) {
+bool jni_cache_classes(JNIEnv *env, const void *instance_handle) {
     if (!env) {
-        return;
+        return false;
     }
 
     std::lock_guard<std::mutex> guard(jni_cache_mutex);
     if (jni_class_cached) {
-        return;
+        return true;
     }
 
     jclass event_listener_class = find_global_class(env, instance_handle, "org/openani/mediamp/mpv/EventListener");
@@ -132,7 +132,7 @@ void jni_cache_classes(JNIEnv *env, const void *instance_handle) {
 #ifdef __ANDROID__
         delete_global_ref(env, surface_class);
 #endif
-        return;
+        return false;
     }
 
     jmethodID on_property_change_none =
@@ -185,7 +185,7 @@ void jni_cache_classes(JNIEnv *env, const void *instance_handle) {
 #ifdef __ANDROID__
         delete_global_ref(env, surface_class);
 #endif
-        return;
+        return false;
     }
 
     jni_mediamp_clazz_EventListener = event_listener_class;
@@ -209,6 +209,7 @@ void jni_cache_classes(JNIEnv *env, const void *instance_handle) {
 #endif
 
     jni_class_cached = true;
+    return true;
 }
     
 } // namespace mediampv

--- a/mediamp-mpv/src/cpp/mpv_handle_t.cpp
+++ b/mediamp-mpv/src/cpp/mpv_handle_t.cpp
@@ -337,7 +337,16 @@ void mpv_handle_t::create(JNIEnv *env, jobject app_context) {
     }
 
     jvm_ = global_jvm;
-    jni_cache_classes(env, this);
+    // Fail fast on a Kotlin<->native version mismatch: with an unpopulated method cache
+    // every event/log/stream callback silently no-ops, which surfaces as a "zombie" player
+    // (mpv plays, but currentPositionMillis stays 0 and the state never reaches FINISHED).
+    // A hard construction failure is diagnosable; the silent degradation is not.
+    if (!jni_cache_classes(env, this)) {
+        throw std::runtime_error(
+                "cannot create mpv handle: failed to resolve the mediamp JNI classes/methods. "
+                "The libmediampv native library does not match the mediamp-mpv Kotlin artifact "
+                "on the classpath (version mismatch); rebuild or realign the native runtime");
+    }
     event_loop_request_exit.store(false, std::memory_order_release);
 
     // libmpv hard-requires LC_NUMERIC == "C": mp_create() returns NULL on any other numeric

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvHeadlessEofTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvHeadlessEofTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.openani.mediamp.InternalMediampApi
+import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.source.MediaExtraFiles
+import org.openani.mediamp.source.UriMediaData
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Playback progress and end-of-file state transitions, in both render modes:
+ *
+ * - fully headless (no surface ring configured — e.g. probing tools that never compose a
+ *   surface): the macOS/Windows render thread must drain video frames so playback and
+ *   `time-pos` property events keep flowing;
+ * - with the headless surface ring (the regular rendered path).
+ *
+ * In both modes [MpvMediampPlayer.currentPositionMillis] must advance (open-ani/animeko
+ * headless probing regression: the position flow stayed at 0 while polling `time-pos`
+ * worked) and natural EOF must transition the playback state to [PlaybackState.FINISHED]
+ * (the existing smoke tests only reach FINISHED via `stopPlayback`).
+ */
+class MpvHeadlessEofTest {
+
+    private fun devNativeDir(): File? =
+        System.getProperty("mediamp.mpv.dev.native.dir")
+            ?.let(::File)
+            ?.takeIf {
+                it.resolve("libmediampv.dylib").isFile || it.resolve("libmediampv.so").isFile ||
+                        it.resolve("mediampv.dll").isFile
+            }
+
+    private fun skip(reason: String): Boolean {
+        System.err.println("[HeadlessEofTest] setup skipped: $reason")
+        check(System.getProperty("mediamp.mpv.test.required") != "true") {
+            "mpv headless tests are required on this runner but would be skipped: $reason"
+        }
+        return false
+    }
+
+    private fun prepareOrSkip(): Boolean {
+        val osName = System.getProperty("os.name")
+        if (!osName.contains("Mac") && !osName.contains("Windows")) {
+            return skip("no desktop render path on $osName")
+        }
+        val dir = devNativeDir()
+            ?: return skip(
+                "dev native dir not usable " +
+                        "(mediamp.mpv.dev.native.dir=${System.getProperty("mediamp.mpv.dev.native.dir")})",
+            )
+        runCatching { MpvMediampPlayer.prepareLibraries(dir.absolutePath, extractRuntimeLibrary = false) }
+            .onFailure { return skip("prepareLibraries failed: $it") }
+        return true
+    }
+
+    private fun findFfmpeg(): String? =
+        listOfNotNull(
+            devNativeDir()?.resolve("ffmpeg.exe")?.absolutePath,
+            "/opt/homebrew/bin/ffmpeg",
+            "/usr/local/bin/ffmpeg",
+            "ffmpeg",
+            "ffmpeg.exe",
+        )
+            .firstOrNull { runCatching { ProcessBuilder(it, "-version").start().waitFor() }.getOrNull() == 0 }
+
+    /**
+     * Short clip with both a video and an audio track: whichever track the headless
+     * environment can play (video decode may be unavailable without a GPU context)
+     * keeps the playback clock advancing to EOF.
+     */
+    private fun generateShortAvVideo(): File? {
+        val target = File(System.getProperty("java.io.tmpdir"), "mediamp-mpv-test-av-short.mp4")
+        if (target.isFile && target.length() > 0) return target
+        val ffmpeg = findFfmpeg() ?: return null
+        val process = ProcessBuilder(
+            ffmpeg, "-y",
+            "-f", "lavfi", "-i", "testsrc2=size=320x180:rate=30",
+            "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=44100",
+            "-t", "4", "-c:v", "mpeg4", "-q:v", "5", "-c:a", "aac",
+            target.absolutePath,
+        ).redirectErrorStream(true).start()
+        process.inputStream.readAllBytes()
+        if (!process.waitFor(60, TimeUnit.SECONDS) || process.exitValue() != 0) return null
+        return target
+    }
+
+    @OptIn(InternalMediampApi::class)
+    private fun runPlayToEof(useSurfaceRing: Boolean) {
+        if (!prepareOrSkip()) return
+        val video = generateShortAvVideo()
+            ?: run { skip("ffmpeg unavailable or test video generation failed"); return }
+
+        runBlocking(Dispatchers.Default) {
+            val player = MpvMediampPlayer(Any(), coroutineContext)
+            val renderer = if (useSurfaceRing) {
+                check(player.createRenderContext()) { "createRenderContext failed" }
+                check(player.requestSurface(320, 180, 0L)) { "requestSurface failed" }
+                AutoCloseable {
+                    player.releaseSurface()
+                    player.releaseRenderContext()
+                }
+            } else null
+            try {
+                player.setMediaData(UriMediaData(video.absolutePath, emptyMap(), MediaExtraFiles.EMPTY))
+                player.resume()
+
+                // The position flow (not just the polled property) must advance.
+                withTimeout(15_000) {
+                    var done = false
+                    player.currentPositionMillis.collectWhile {
+                        if (it > 1_000) done = true
+                        !done
+                    }
+                }
+
+                // Natural EOF must surface as FINISHED.
+                withTimeout(20_000) {
+                    var done = false
+                    player.playbackState.collectWhile {
+                        if (it == PlaybackState.FINISHED) done = true
+                        !done
+                    }
+                }
+                assertTrue(
+                    player.currentPositionMillis.value > 1_000,
+                    "position should stay at the played value after EOF, " +
+                            "got ${player.currentPositionMillis.value}",
+                )
+            } finally {
+                renderer?.close()
+                player.close()
+            }
+        }
+    }
+
+    @Test
+    fun `position advances and EOF finishes - headless without surface`() {
+        runPlayToEof(useSurfaceRing = false)
+    }
+
+    @Test
+    fun `position advances and EOF finishes - with surface ring`() {
+        runPlayToEof(useSurfaceRing = true)
+    }
+
+    private suspend fun <T> kotlinx.coroutines.flow.StateFlow<T>.collectWhile(predicate: (T) -> Boolean) {
+        try {
+            collect { if (!predicate(it)) throw StopCollecting }
+        } catch (e: StopCollecting) {
+            // done
+        }
+    }
+
+    private object StopCollecting : Exception() {
+        private fun readResolve(): Any = StopCollecting
+    }
+}


### PR DESCRIPTION
## Problem

Reported as: in headless mode (no render surface attached), `MpvMediampPlayer.currentPositionMillis` stays at 0 and playback never transitions to `FINISHED` on EOF, while polling `time-pos` directly works fine (observed in animeko's `MpvVideoAnalyzer`).

## Investigation

The suspected seek gate (`MpvPlaybackStateMachine.shouldIgnoreTimePos`) is **not** the cause — headless playback on matched versions works correctly: the macOS render thread drains frames with `MPV_RENDER_PARAM_SKIP_RENDERING` even with no surface configured, keeping mpv's TICK-driven `time-pos` observe notifications flowing.

The real root cause is a **Kotlin↔native version mismatch**: the failing environment loaded `libmediampv` built from current `main` against the published `mediamp-mpv:0.1.16` Kotlin artifact. `main` added `EventListener.onEvent(I)V` (#46), which 0.1.16's interface lacks; `jni_cache_classes` is all-or-nothing, so the whole method cache failed and **every** event/log/stream callback silently became a no-op:

- `currentPositionMillis` stuck at 0, playback state stuck at `PLAYING` (no property / end-file events at all);
- direct property polling unaffected — matching the reported symptoms exactly;
- logs fell back to the raw-stderr path (`[cplayer] ...` format at verbose level), which is how verbose lines like `EOF code: 4` showed up despite the Kotlin log handler filtering at warn+.

Reproduced exactly with a standalone harness (published 0.1.16 + main-built natives), and confirmed unreproducible with matched versions.

## Fix

- `jni_cache_classes` now returns whether the cache is populated.
- `mpv_handle_t::create` throws on failure, so `nMake` surfaces an `IllegalStateException` naming the version mismatch at `MPVHandle` construction — a diagnosable hard failure (the JNI `ExceptionDescribe` output additionally names the exact missing method) instead of a zombie player.

## Tests

- New `MpvHeadlessEofTest`: in both render modes (fully headless with no surface, and the headless surface ring), the `currentPositionMillis` **flow** must advance and natural EOF must reach `FINISHED` (existing smoke tests only reached `FINISHED` via `stopPlayback`).
- `./gradlew :mediamp-mpv:desktopTest` and `-Pmediamp.mpv.test.required=true` (assembled runtime): 44 tests, 0 failures, 0 skipped.
- Mismatch harness after the fix: construction throws `IllegalStateException: ... version mismatch ...` instead of silently degrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)