### PR TITLE
feat(mpv): bundle non-baseline Linux runtime dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
@@ -2,6 +2,7 @@ package mpv
 
 import nativebuild.copyTreePreservingLinks
 import nativebuild.deleteRecursivelyForce
+import nativebuild.isLinuxSystemLibrary
 import nativebuild.isWindowsSystemLibrary
 import nativebuild.jniIncludeFlags
 import nativebuild.makePkgConfigRelocatable
@@ -32,7 +33,9 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Files
 import javax.inject.Inject
 
 /**
@@ -606,6 +609,11 @@ abstract class MpvAssembleTask : DefaultTask() {
             }
 
             MpvRuntimePostProcessing.LINUX_RUNPATH_ORIGIN -> {
+                bundleLinuxExternalDependencies(
+                    execOperations = execOperations,
+                    logger = logger,
+                    libDir = runtimeDir,
+                )
                 setLinuxRunpathOrigin(
                     execOperations = execOperations,
                     logger = logger,
@@ -623,16 +631,167 @@ abstract class MpvAssembleTask : DefaultTask() {
     }
 }
 
+// Matches the language-independent parts of a `readelf -d` NEEDED line: the entry type
+// and the bracketed soname. The descriptive text between them ("Shared library") is a
+// translated string in binutils and must not be relied on; `readelf` is additionally
+// invoked with LC_ALL=C.
+private val ELF_NEEDED_ENTRY = Regex("""\(NEEDED\)[^\[]*\[([^]]+)]""")
+
+// ldconfig -p line: soname, parenthesized ABI info, resolved path. The ABI info is kept
+// so same-soname candidates of different architectures are not conflated.
+private val LDCONFIG_ENTRY = Regex("""^(\S+)\s+\(([^)]*)\)\s+=>\s+(/\S+)$""")
+
+/**
+ * Makes the Linux runtime self-contained: recursively copies every non-baseline shared
+ * library dependency (libplacebo, libass and their transitive deps) into [libDir],
+ * mirroring what [bundleAppleExternalDependencies] does for macOS and
+ * [collectWindowsRuntimeDlls] does for Windows.
+ *
+ * Only DIRECT `DT_NEEDED` entries of bundled libraries are considered (via `readelf -d`
+ * with `LC_ALL=C`), so dependencies of system-baseline libraries (e.g. libpulse's
+ * private `libpulsecommon`) never leak into the package. A candidate soname is resolved
+ * first against [libDir] itself (already-bundled siblings like libmpv and the ffmpeg
+ * libraries), then against the build machine's loader cache (`ldconfig -p`); when the
+ * cache lists several candidates for one soname (multi-arch or glibc-hwcaps variants),
+ * only those whose ELF class/machine match the consuming library are eligible, and
+ * hardware-capability variants are avoided in favour of the baseline build. The system
+ * baseline (glibc, X11, the GL / VAAPI driver stack, audio servers, fontconfig, ...) is
+ * skipped per [isLinuxSystemLibrary] and stays resolved via the system linker.
+ *
+ * Each dependency is copied under the exact soname the loader asks for (e.g.
+ * `libplacebo.so.338`), so `RUNPATH=$ORIGIN` (applied afterwards by
+ * [setLinuxRunpathOrigin]) picks the bundled copy up regardless of the library versions
+ * installed on the target machine. A non-baseline dependency that does not resolve on
+ * the build machine fails the build instead of shipping a broken runtime.
+ */
+private fun bundleLinuxExternalDependencies(
+    execOperations: ExecOperations,
+    logger: Logger,
+    libDir: File,
+) {
+    if (!libDir.isDirectory) return
+
+    fun listSharedObjects(): List<File> =
+        libDir.listFiles()
+            ?.filter { it.isFile && !Files.isSymbolicLink(it.toPath()) && it.name.contains(".so") }
+            .orEmpty()
+
+    fun runTool(executable: String, vararg args: String): String {
+        val output = ByteArrayOutputStream()
+        execOperations.exec {
+            this.executable = executable
+            this.args(*args)
+            // binutils/glibc tools translate parts of their output; pin the C locale so
+            // parsing does not depend on the build machine's language settings.
+            environment("LC_ALL", "C")
+            standardOutput = output
+        }
+        return output.toString()
+    }
+
+    /** Direct `DT_NEEDED` sonames of [library]. */
+    fun directDependencies(library: File): List<String> =
+        runTool("readelf", "-d", library.absolutePath).lineSequence()
+            .mapNotNull { line -> ELF_NEEDED_ENTRY.find(line)?.groupValues?.get(1) }
+            .distinct()
+            .toList()
+
+    val elfHeaderCache = mutableMapOf<String, String>()
+
+    /** ELF class and machine of [path], e.g. "ELF64 Advanced Micro Devices X86-64". */
+    fun elfClassMachine(path: String): String = elfHeaderCache.getOrPut(path) {
+        var elfClass = ""
+        var machine = ""
+        runTool("readelf", "-h", path).lineSequence().forEach { line ->
+            val trimmed = line.trim()
+            when {
+                trimmed.startsWith("Class:") -> elfClass = trimmed.substringAfter("Class:").trim()
+                trimmed.startsWith("Machine:") -> machine = trimmed.substringAfter("Machine:").trim()
+            }
+        }
+        "$elfClass $machine"
+    }
+
+    // soname -> candidate paths on the build machine, from the loader cache. A soname is
+    // NOT unique: multi-arch installs and glibc-hwcaps variants coexist under one name.
+    val systemLibraryCandidates: Map<String, List<String>> = run {
+        val output = ByteArrayOutputStream()
+        execOperations.exec {
+            executable = "ldconfig"
+            args("-p")
+            environment("LC_ALL", "C")
+            standardOutput = output
+        }
+        output.toString().lineSequence()
+            .map { it.trim() }
+            .mapNotNull { line ->
+                LDCONFIG_ENTRY.matchEntire(line)
+                    ?.let { it.groupValues[1] to it.groupValues[3] }
+            }
+            .groupBy({ it.first }, { it.second })
+    }
+
+    /**
+     * Picks the candidate for [soname] whose ELF class/machine matches [consumerHeader],
+     * preferring the baseline build over glibc-hwcaps variants (which may require a newer
+     * CPU than the runtime targets).
+     */
+    fun resolveCandidate(soname: String, consumerHeader: String): String? {
+        val eligible = systemLibraryCandidates[soname].orEmpty()
+            .filter { elfClassMachine(it) == consumerHeader }
+        return eligible.firstOrNull { !it.contains("hwcap") } ?: eligible.firstOrNull()
+    }
+
+    val bundled = mutableListOf<String>()
+    val missing = sortedSetOf<String>()
+    val processed = mutableSetOf<String>()
+    val pending = ArrayDeque(listSharedObjects())
+
+    while (pending.isNotEmpty()) {
+        val library = pending.removeFirst()
+        if (!processed.add(library.canonicalPath)) continue
+        val consumerHeader = elfClassMachine(library.absolutePath)
+
+        directDependencies(library).forEach { soname ->
+            if (isLinuxSystemLibrary(soname)) return@forEach
+            if (libDir.listFiles()?.any { it.name == soname } == true) return@forEach
+            val path = resolveCandidate(soname, consumerHeader)
+            if (path == null) {
+                missing += soname
+                return@forEach
+            }
+            val real = File(path).canonicalFile
+            require(real.isFile) {
+                "Shared library dependency '$soname' of ${library.name} resolved to '$path', which does not exist."
+            }
+            val target = libDir.resolve(soname)
+            real.copyTo(target, overwrite = false)
+            bundled += soname
+            pending.addLast(target)
+        }
+    }
+
+    require(missing.isEmpty()) {
+        "Linux mpv runtime has unresolved non-system dependencies: ${missing.joinToString()}. " +
+                "Install the corresponding development packages (see ci-helper/install-mpv-deps-ubuntu.sh) " +
+                "or extend isLinuxSystemLibrary if they belong to the system baseline."
+    }
+
+    if (bundled.isNotEmpty()) {
+        logger.lifecycle(
+            "Bundled Linux external dependencies into ${libDir.name}/: ${bundled.sorted().joinToString()}",
+        )
+    }
+}
+
 /**
  * Makes the bundled Linux libraries load their siblings from the same directory: sets
  * `RUNPATH=$ORIGIN` on every regular `.so`, the ELF equivalent of macOS `@loader_path`
  * and the Windows `SetDllDirectory` path. Without it, `System.load(libmediampv.so)` cannot
  * resolve `libmpv.so.2` and the bundled ffmpeg libraries that sit next to it.
  *
- * System libraries (libass, libplacebo, glibc, X11, ...) are intentionally NOT bundled and
- * are still resolved via the system linker; the Linux runtime is therefore not fully
- * self-contained (documented limitation), but it is loadable wherever those system libraries
- * are present.
+ * Only the system baseline (see [isLinuxSystemLibrary]) is still resolved via the system
+ * linker; everything else is bundled by [bundleLinuxExternalDependencies] before this runs.
  */
 private fun setLinuxRunpathOrigin(
     execOperations: ExecOperations,

--- a/buildSrc/src/main/kotlin/nativebuild/SharedLibraryManifest.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/SharedLibraryManifest.kt
@@ -136,3 +136,93 @@ internal fun isWindowsSystemLibrary(dllName: String): Boolean {
             "ws2_32.dll",
         )
 }
+
+/**
+ * Linux system-baseline libraries that the desktop runtime intentionally does NOT bundle.
+ * They are either not safely relocatable (glibc and the dynamic loader), coupled to the
+ * machine's drivers or desktop services (GL/Vulkan/VAAPI, X11, audio servers, D-Bus,
+ * fontconfig), or universally present with a long-stable soname (zlib, libstdc++).
+ * Everything else reported by `ldd` (libplacebo, libass, libshaderc, ...) is collected
+ * into the runtime directory so the package does not depend on the sonames installed on
+ * the target machine.
+ */
+internal fun isLinuxSystemLibrary(soname: String): Boolean {
+    val name = soname.lowercase(Locale.ROOT)
+    return name in LINUX_SYSTEM_LIBRARY_NAMES ||
+            LINUX_SYSTEM_LIBRARY_PREFIXES.any { name.startsWith(it) }
+}
+
+private val LINUX_SYSTEM_LIBRARY_NAMES = setOf(
+    // Dynamic loader / glibc. Not relocatable, always resolved via the system loader.
+    "linux-vdso.so.1",
+    "libc.so.6",
+    "libm.so.6",
+    "libmvec.so.1",
+    "libdl.so.2",
+    "librt.so.1",
+    "libpthread.so.0",
+    "libresolv.so.2",
+    "libutil.so.1",
+    "libnsl.so.2",
+    "libanl.so.1",
+    // Toolchain runtime. Backward compatible like glibc; the build machine is the floor.
+    "libstdc++.so.6",
+    "libgcc_s.so.1",
+    // zlib's soname has been stable for decades; part of every desktop baseline.
+    "libz.so.1",
+    // GPU/driver stack. Coupled to the machine's drivers, never relocatable.
+    "libgl.so.1",
+    "libegl.so.1",
+    "libglesv2.so.2",
+    "libglx.so.0",
+    "libgldispatch.so.0",
+    "libopengl.so.0",
+    "libvulkan.so.1",
+    "libdrm.so.2",
+    "libgbm.so.1",
+    "libva.so.2",
+    "libva-x11.so.2",
+    "libva-drm.so.2",
+    "libva-wayland.so.2",
+    "libvdpau.so.1",
+    "libcuda.so.1",
+    // X11 client libraries. Part of the desktop baseline.
+    "libx11.so.6",
+    "libx11-xcb.so.1",
+    "libxext.so.6",
+    "libxrandr.so.2",
+    "libxss.so.1",
+    "libxpresent.so.1",
+    "libxfixes.so.3",
+    "libxinerama.so.1",
+    "libxrender.so.1",
+    "libxdamage.so.1",
+    "libxcomposite.so.1",
+    "libxcursor.so.1",
+    "libxi.so.6",
+    "libxtst.so.6",
+    "libxau.so.6",
+    "libxdmcp.so.6",
+    "libice.so.6",
+    "libsm.so.6",
+    // Audio servers. Coupled to the running sound daemon.
+    "libasound.so.2",
+    "libpulse.so.0",
+    "libpulse-simple.so.0",
+    "libpipewire-0.3.so.0",
+    // Desktop services / configuration-coupled.
+    "libdbus-1.so.3",
+    "libsystemd.so.0",
+    "libfontconfig.so.1",
+    "libexpat.so.1",
+    "libuuid.so.1",
+)
+
+private val LINUX_SYSTEM_LIBRARY_PREFIXES = listOf(
+    "ld-linux",
+    "ld-musl",
+    "libnss_",
+    "libxcb",
+    "libwayland-",
+    "libnvidia-",
+)

--- a/mediamp-mpv/dependency.md
+++ b/mediamp-mpv/dependency.md
@@ -126,7 +126,7 @@
    - 通过 `pkg-config` 导入
 
 2. 其他三方库
-   - 当前设计为依赖 Linux 主机的系统开发包
+   - 编译期依赖 Linux 主机的系统开发包（通过 `pkg-config` 导入）
    - 主要包括：
      - `libass`
      - `libplacebo`
@@ -137,10 +137,11 @@
 当前边界：
 
 - Linux 构建逻辑已接通，但尚未在 Linux 主机上实跑验证。
-- 目前 Linux 组装阶段只会复制：
+- Linux 组装阶段会复制：
   - `mpv install prefix`
   - FFmpeg 的 `lib`
-- 不会额外把系统 `libX11/libEGL/libGL/libass/libplacebo` 一起 vendoring 到输出目录。
+  - 通过 `readelf` 解析直接 `DT_NEEDED`、`ldconfig -p` 在构建机上解析路径，递归收集的非系统基线库（`libass`、`libplacebo` 及其传递依赖，如 `libshaderc`、`libfreetype`、`libharfbuzz` 等），按 soname 文件名放入输出目录，配合 `RUNPATH=$ORIGIN` 加载；同一 soname 存在多架构/hwcaps 候选时按 ELF class/machine 与使用方匹配
+- 系统基线库（glibc、`libstdc++`、`libX11`/`libEGL`/`libGL` 等驱动与桌面服务耦合的库，见 `isLinuxSystemLibrary`）不会 vendoring 到输出目录，运行时仍由系统提供。
 
 ### Android
 


### PR DESCRIPTION
本 PR 将 libplacebo、libass 及其传递依赖打入 Linux 平台的 mpv runtime jar，使其与 macOS、Windows 平台的 runtime 行为一致。

此前 jar 仅包含 `libav*`、`libmpv` 与 `libmediampv`，libplacebo 与 libass 在运行时由目标系统提供。由于 libplacebo 的 soname 随版本发布逐次变更，该前提在跨发行版场景下不成立：基于 Ubuntu 24.04 构建的 libmpv 依赖 `libplacebo.so.338`，而滚动发行版已升级至 `.360`，加载时即抛出 `UnsatisfiedLinkError`；反之，在较新系统上构建的包在较旧系统上同样无法加载。

实现上，assemble 任务在 `meson install` 完成后执行依赖收集：对每个已打包的库读取其直接 `DT_NEEDED` 条目（使用 `readelf`，并强制 `LC_ALL=C`，避免解析被本地化的输出文本）；通过 `ldconfig -p` 将 soname 解析为构建机上的实际路径，存在多个候选时按 ELF class/machine 过滤，并排除 hwcaps 变体；随后按 soname 将库复制到 runtime 目录，递归直至依赖闭包完整。系统基线库（glibc、libstdc++、X11、GL/VAAPI 驱动栈、音频服务、fontconfig）不在收集范围内：这些库与驱动或桌面服务耦合，不适宜随包分发。已有的 `RUNPATH=$ORIGIN` 确保加载器优先解析同目录下的 bundled 副本。无法解析的非基线依赖将导致构建失败，避免产出不完整的 runtime。

glibc 不予打包，构建机因此决定运行环境的下限：继续在 Ubuntu 24.04 上构建，即可保证 runtime 在更新的发行版上可用。

体积方面，runtime jar 增大约 10 MB（压缩后）。

验证：在装有 `libplacebo.so.360` 的 CachyOS 上，使用 Ubuntu 24.04 CI 构建的 jar 可正常加载并播放视频（mpv 0.41，nvdec 硬解）；旧包在同一环境下加载即失败。依赖收集逻辑亦已在滚动发行版主机上验证，能够针对该主机的 soname 集合生成正确的依赖闭包。
