### PR TITLE
fix(mpv): default hwdec-threads=1 on Windows ARM64

### DIFF
--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -24,6 +24,7 @@ import org.openani.mediamp.features.PlayerFeatures
 import org.openani.mediamp.features.Screenshots
 import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.features.buildPlayerFeatures
+import org.openani.mediamp.internal.Arch
 import org.openani.mediamp.internal.Platform
 import org.openani.mediamp.internal.currentPlatform
 import org.openani.mediamp.metadata.MediaProperties
@@ -276,6 +277,16 @@ abstract class JvmMpvMediampPlayer(
         }
 
         handle.option("hwdec", "auto")
+        if (currentPlatform().let { it is Platform.Windows && it.arch == Arch.AARCH64 }) {
+            // TODO: restore multi-threaded hwdec once FFmpeg fixes the race this works
+            // around: dxva2/d3d11va hwaccels attach the decoder interface ref to
+            // frame->buf[1] in end_frame, and FFmpeg frame threading copies that frame
+            // concurrently (update_thread_context DPB copy). The AVBufferRef publication
+            // is unfenced, so on ARM64's weak memory model the copy can observe the
+            // pointer before the ref contents, yielding a blank ref and crashing
+            // av_buffer_replace (NULL AVBuffer->refcount). x86 TSO hides this.
+            handle.option("hwdec-threads", "1")
+        }
         handle.option("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
         handle.option("input-default-bindings", "no")
         handle.option("volume-max", "200")


### PR DESCRIPTION
WoA64 上 d3d11va 播放 1~4 分钟后必然崩溃：JVM 在 `avutil-60.dll` 中读空指针，每次崩溃位置相同。

根因：dxva2/d3d11va 在 `end_frame` 时把解码器接口 ref 写入 `frame->buf[1]`；FFmpeg 帧线程流水线会同时在另一线程拷贝该帧（`update_thread_context` 的 DPB 拷贝，经 `av_frame_replace` 到 `av_buffer_replace`）。`AVBufferRef` 的发布没有 release/acquire 语义，ARM64 弱内存序下，读取方可能先观察到指针更新、后观察到内容更新，得到 `buffer` 为 NULL 的引用，在原子增加引用计数时解引用 `NULL+0x10`。x86 的 TSO 掩盖了该问题，因此仅在 WoA64 复现。

本 PR 在 Windows ARM64 上固定 `hwdec-threads=1`，消除上述并发拷贝；代码中以 TODO 标注了恢复多线程的条件。硬件解码的主要计算由 GPU 完成，单线程提交在 1080p 及以下内容上的额外开销可以忽略。

验证（Snapdragon 8cx Gen 3, Windows 11）：修复前每次运行均在 1~4 分钟内于同一位置崩溃；修复后 d3d11va 连续播放 10 分钟至 EOF，零解码错误；软解路径不受影响。