### PR TITLE
feat(ffmpeg): bundle dav1d for AV1 software decoding on desktop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = mediamp-mpv/mpv
 	url = https://github.com/mpv-player/mpv
 	branch = release/0.41
+[submodule "mediamp-ffmpeg/dav1d"]
+	path = mediamp-ffmpeg/dav1d
+	url = https://github.com/videolan/dav1d.git

--- a/buildSrc/src/main/kotlin/ffmpeg/Dav1dTasks.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/Dav1dTasks.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package ffmpeg
+
+import nativebuild.makePkgConfigRelocatable
+import nativebuild.pathForShell
+import nativebuild.recreateDirectory
+import nativebuild.shellQuote
+import nativebuild.shellScriptWithExports
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import java.io.File
+import javax.inject.Inject
+
+internal fun missingDav1dSourceTreeMessage(sourceDir: File): String = """
+    dav1d source tree is missing at ${sourceDir.absolutePath}.
+
+    The dav1d sources are a git submodule and have not been checked out.
+
+    If you already cloned this repository, run:
+      git submodule update --init --recursive mediamp-ffmpeg/dav1d
+
+    For a fresh checkout, clone with submodules:
+      git clone --recursive git@github.com:open-ani/mediamp.git
+""".trimIndent()
+
+/**
+ * Builds dav1d (AV1 software decoder) with meson and installs it as a static library.
+ *
+ * FFmpeg 8 removed the native AV1 software decoder — `libavcodec/av1dec.c` is now a
+ * hwaccel-only shim that returns ENOSYS when no hwaccel is available — so software AV1
+ * playback needs the external `libdav1d` decoder. FFmpeg links it statically into
+ * `libavcodec`, which keeps runtime packaging unchanged: no extra dll/dylib/so to ship,
+ * no install-name rewriting, no new entries in the Windows runtime DLL collection.
+ *
+ * This is a single task (setup + compile + install) rather than the configure/build split
+ * used for FFmpeg and mpv: dav1d compiles in seconds, so the extra layer would only add
+ * bookkeeping. The task is still the cache boundary for the FFmpeg build — [FfmpegBuildTask]
+ * keys on this install directory.
+ */
+@CacheableTask
+abstract class Dav1dBuildTask : DefaultTask() {
+    /** dav1d submodule source content — the "what are we building" cache key input. */
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceDir: DirectoryProperty
+
+    /** Extra `meson setup` arguments (per-target, e.g. macOS version-min c_args). */
+    @get:Input
+    abstract val mesonArgs: ListProperty<String>
+
+    @get:Input
+    abstract val shell: Property<String>
+
+    @get:Input
+    abstract val envVars: MapProperty<String, String>
+
+    @get:Input
+    abstract val hostOsName: Property<String>
+
+    @get:Input
+    abstract val msys2Packages: ListProperty<String>
+
+    /** See [nativebuild.ToolchainFingerprintValueSource]. */
+    @get:Input
+    abstract val toolchainFingerprint: Property<String>
+
+    /** Meson scratch directory; not an input or output. */
+    @get:Internal
+    abstract val buildDirPath: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val installDir: DirectoryProperty
+
+    @get:OutputFile
+    abstract val buildStamp: RegularFileProperty
+
+    /** Tool location, not content input: versions are captured by the toolchain fingerprint. */
+    @get:Internal
+    abstract val msys2Dir: DirectoryProperty
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    @TaskAction
+    fun run() {
+        val source = sourceDir.get().asFile
+        val mesonBuildDir = buildDirPath.get().asFile
+        val install = installDir.get().asFile
+        val windowsMsys = hostOsName.get() == "Windows"
+
+        require(source.resolve("meson.build").isFile) {
+            missingDav1dSourceTreeMessage(source)
+        }
+
+        if (windowsMsys) {
+            val msys2Root = msys2Dir.orNull?.asFile
+                ?: error("MSYS2 directory must be configured for Windows dav1d builds.")
+            val packages = msys2Packages.get()
+            if (packages.isNotEmpty()) {
+                logger.lifecycle("Ensuring MSYS2 packages: ${packages.joinToString()}")
+                execOperations.exec {
+                    commandLine(
+                        shell.get(),
+                        "-l",
+                        "-c",
+                        "pacman -S --needed --noconfirm ${packages.joinToString(" ")}",
+                    )
+                    environment(envVars.get())
+                    workingDir = msys2Root
+                }
+            }
+        }
+
+        recreateDirectory(mesonBuildDir)
+        recreateDirectory(install)
+
+        val setupArgs = buildList {
+            add("setup")
+            add(pathForShell(mesonBuildDir, windowsMsys))
+            add(pathForShell(source, windowsMsys))
+            add("--prefix")
+            add(pathForShell(install, windowsMsys))
+            // Debian/Ubuntu meson defaults libdir to the multiarch subdirectory
+            // (lib/x86_64-linux-gnu); the FFmpeg build expects a flat lib/.
+            add("--libdir=lib")
+            add("--buildtype=release")
+            add("--default-library=static")
+            add("-Denable_tools=false")
+            add("-Denable_tests=false")
+            add("-Denable_examples=false")
+            add("--wrap-mode=nodownload")
+            addAll(mesonArgs.get())
+        }.joinToString(" ") { shellQuote(it) }
+
+        execOperations.exec {
+            commandLine(
+                shell.get(),
+                "-l",
+                "-c",
+                shellScriptWithExports(
+                    envVars.get(),
+                    "meson $setupArgs && " +
+                        "meson compile -C ${shellQuote(pathForShell(mesonBuildDir, windowsMsys))} && " +
+                        "meson install -C ${shellQuote(pathForShell(mesonBuildDir, windowsMsys))}",
+                ),
+            )
+            environment(envVars.get())
+        }
+
+        require(install.resolve("lib/pkgconfig/dav1d.pc").isFile) {
+            "dav1d install did not produce lib/pkgconfig/dav1d.pc under ${install.absolutePath}"
+        }
+        makePkgConfigRelocatable(install, logger)
+        buildStamp.get().asFile.writeText(System.currentTimeMillis().toString())
+        logger.lifecycle("dav1d installed to: ${install.absolutePath}")
+    }
+}

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegBuildTasks.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegBuildTasks.kt
@@ -112,12 +112,50 @@ private fun registerFfmpegTasks(
     val buildStamp = project.layout.buildDirectory.file("ffmpeg/${target.name}/.build_stamp")
     val msys2Dir = if (context.hostOs == Os.Windows) context.project.resolveMsys2Dir() else null
     val toolchainFingerprint = project.toolchainFingerprint(target.toolchainProbes)
-    val toolchainConfigSummary = buildDir.map { sanitizedFfmpegToolchainSummary(it.asFile) }
+
+    val dav1dInstall = project.layout.buildDirectory.dir("dav1d/${target.name}/install")
+    val dav1dBuildTask = if (target.dav1dEnabled) {
+        val dav1dProbes = if (msys2Dir != null) {
+            listOf(listOf(msys2Dir.resolve("usr/bin/pacman.exe").absolutePath, "-Q") + target.dav1dMsys2Packages)
+        } else {
+            listOf(listOf("meson", "--version"), listOf("cc", "--version"))
+        }
+        project.tasks.register<Dav1dBuildTask>("dav1dBuild${target.name}") {
+            group = "ffmpeg"
+            description = "Build dav1d (AV1 software decoder) for ${target.name}"
+            sourceDir.set(context.dav1dSrcDir)
+            mesonArgs.set(target.dav1dMesonArgs)
+            shell.set(target.shell)
+            envVars.set(target.env)
+            hostOsName.set(context.hostOs.name)
+            msys2Packages.set(target.dav1dMsys2Packages)
+            this.toolchainFingerprint.set(project.toolchainFingerprint(dav1dProbes))
+            buildDirPath.set(project.layout.buildDirectory.dir("dav1d/${target.name}/meson"))
+            this.installDir.set(dav1dInstall)
+            this.buildStamp.set(project.layout.buildDirectory.file("dav1d/${target.name}/.build_stamp"))
+            if (msys2Dir != null) {
+                this.msys2Dir.set(msys2Dir)
+            }
+        }
+    } else {
+        null
+    }
+
+    val toolchainConfigSummary = buildDir.map {
+        sanitizedFfmpegToolchainSummary(
+            it.asFile,
+            extraRoots = if (target.dav1dEnabled) listOf(dav1dInstall.get().asFile) else emptyList(),
+        )
+    }
 
     val configureTask = project.tasks.register<FfmpegConfigureTask>("ffmpegConfigure${target.name}") {
         group = "ffmpeg"
         description = "Run FFmpeg configure for ${target.name}"
         dependsOn(sourceTemplateTask)
+        if (dav1dBuildTask != null) {
+            dependsOn(dav1dBuildTask)
+            this.dav1dInstallDir.set(dav1dInstall)
+        }
         this.sourceTemplateDir.set(templateSnapshotDir)
         configureFlags.set(commonConfigureFlags + target.configureFlags)
         shell.set(target.shell)
@@ -138,6 +176,9 @@ private fun registerFfmpegTasks(
         description = "Build FFmpeg for ${target.name}"
         dependsOn(configureTask)
         stagedSourceDir.set(configureTask.flatMap { it.stagedSourceDir })
+        if (dav1dBuildTask != null) {
+            this.dav1dInstallDir.set(dav1dInstall)
+        }
         this.configStamp.set(configStamp)
         shell.set(target.shell)
         envVars.set(target.env)

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegSupport.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegSupport.kt
@@ -61,6 +61,8 @@ internal class FfmpegBuildContext(
 
     val ffmpegSrcDir: File = project.projectDir.resolve("ffmpeg")
 
+    val dav1dSrcDir: File = project.projectDir.resolve("dav1d")
+
     val appleFrameworkName: String = "MediampFFmpegKit"
     val commandWrapperSource: File = project.projectDir.resolve("src/appleMain/c/ffmpegkit_wrapper.c")
     val applePublicHeaderSource: File = project.projectDir.resolve("src/appleMain/include/MediampFFmpegKit.h")

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTargets.kt
@@ -59,6 +59,21 @@ internal data class FfmpegBuildTarget(
     val rewriteAppleInstallNames: Boolean = false,
     /** Copy the ffmpeg CLI binary into the runtime output when the build produced one. */
     val bundleFfmpegExecutable: Boolean = true,
+
+    // ---- dav1d (AV1 software decoding) ----
+
+    /**
+     * Build dav1d from the `mediamp-ffmpeg/dav1d` submodule and statically link it into
+     * libavcodec (`--enable-libdav1d --enable-decoder=libdav1d`). Required for software
+     * AV1 playback: FFmpeg 8 removed the native AV1 software decoder, leaving
+     * `libavcodec/av1dec.c` as a hwaccel-only shim that fails with ENOSYS when no AV1
+     * hardware decoder exists on the machine.
+     */
+    val dav1dEnabled: Boolean = false,
+    /** Extra `meson setup` arguments for the dav1d build (e.g. macOS version-min flags). */
+    val dav1dMesonArgs: List<String> = emptyList(),
+    /** MSYS2 packages the dav1d meson build needs (Windows targets). */
+    val dav1dMsys2Packages: List<String> = emptyList(),
 )
 
 // ---------------------------------------------------------------------------------------
@@ -206,6 +221,16 @@ private val linuxRuntimeSearchPathFlags: List<String> = listOf(
     "--extra-ldflags=-Wl,-rpath,'${'$'}ORIGIN'",
 )
 
+// dav1d software AV1 decoding. FFmpeg 8 removed the native AV1 software decoder (the
+// remaining `av1` decoder is a hwaccel-only shim), so software AV1 needs the external
+// libdav1d decoder, built from the mediamp-ffmpeg/dav1d submodule and linked statically
+// into libavcodec. The native `av1` decoder stays enabled: the AV1 hwaccels
+// (d3d11va/videotoolbox/nvdec/vaapi) attach to it.
+private val dav1dFlags: List<String> = listOf(
+    "--enable-libdav1d",
+    "--enable-decoder=libdav1d",
+)
+
 // ---------------------------------------------------------------------------------------
 // Windows
 // ---------------------------------------------------------------------------------------
@@ -232,7 +257,7 @@ private fun FfmpegBuildContext.windowsX64Target(): FfmpegBuildTarget {
             "--target-os=mingw32",
             "--cc=${msys2Dir.resolve("ucrt64/bin/gcc.exe").absolutePath.toMsysPath()}",
             "--cxx=${msys2Dir.resolve("ucrt64/bin/g++.exe").absolutePath.toMsysPath()}",
-        ) + opensslHttpTlsFlags + windowsD3d11vaFlags,
+        ) + opensslHttpTlsFlags + windowsD3d11vaFlags + dav1dFlags,
         env = mapOf("MSYSTEM" to "UCRT64"),
         shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
         libExtension = "dll",
@@ -245,6 +270,13 @@ private fun FfmpegBuildContext.windowsX64Target(): FfmpegBuildTarget {
         jniWrapperExtraLibs = listOf("-lstdc++"),
         msysSubsystem = "ucrt64",
         collectWindowsRuntime = true,
+        dav1dEnabled = true,
+        dav1dMsys2Packages = listOf(
+            "mingw-w64-ucrt-x86_64-gcc",
+            "mingw-w64-ucrt-x86_64-meson",
+            "mingw-w64-ucrt-x86_64-ninja",
+            "mingw-w64-ucrt-x86_64-nasm",
+        ),
     )
 }
 
@@ -266,7 +298,7 @@ private fun FfmpegBuildContext.windowsArm64Target(): FfmpegBuildTarget {
             "--target-os=mingw32",
             "--cc=${msys2Dir.resolve("clangarm64/bin/clang.exe").absolutePath.toMsysPath()}",
             "--cxx=${msys2Dir.resolve("clangarm64/bin/clang++.exe").absolutePath.toMsysPath()}",
-        ) + opensslHttpTlsFlags + windowsD3d11vaFlags,
+        ) + opensslHttpTlsFlags + windowsD3d11vaFlags + dav1dFlags,
         env = mapOf("MSYSTEM" to "CLANGARM64"),
         shell = msys2Dir.resolve("usr/bin/bash.exe").absolutePath,
         libExtension = "dll",
@@ -279,6 +311,12 @@ private fun FfmpegBuildContext.windowsArm64Target(): FfmpegBuildTarget {
         jniWrapperExtraLibs = listOf("-lstdc++"),
         msysSubsystem = "clangarm64",
         collectWindowsRuntime = true,
+        dav1dEnabled = true,
+        dav1dMsys2Packages = listOf(
+            "mingw-w64-clang-aarch64-clang",
+            "mingw-w64-clang-aarch64-meson",
+            "mingw-w64-clang-aarch64-ninja",
+        ),
     )
 }
 
@@ -308,7 +346,7 @@ internal fun FfmpegBuildContext.linuxX64Target(): FfmpegBuildTarget = FfmpegBuil
         "--enable-hwaccel=hevc_vaapi",
         "--enable-hwaccel=vp9_vaapi",
         "--enable-hwaccel=av1_vaapi",
-    ) + opensslHttpTlsFlags + linuxRuntimeSearchPathFlags,
+    ) + opensslHttpTlsFlags + linuxRuntimeSearchPathFlags + dav1dFlags,
     libExtension = "so",
     toolchainProbes = listOf(
         listOf("cc", "--version"),
@@ -316,6 +354,7 @@ internal fun FfmpegBuildContext.linuxX64Target(): FfmpegBuildTarget = FfmpegBuil
         listOf("pkg-config", "--modversion", "openssl"),
     ),
     jniWrapperName = "libffmpegkitjni.so",
+    dav1dEnabled = true,
 )
 
 // ---------------------------------------------------------------------------------------
@@ -337,7 +376,7 @@ private fun macosTarget(name: String, arch: String): FfmpegBuildTarget = FfmpegB
         "--cxx=clang++",
         "--extra-cflags=-arch $arch -mmacosx-version-min=12.0",
         "--extra-ldflags=-arch $arch -mmacosx-version-min=12.0",
-    ) + secureTransportHttpTlsFlags + macosVideotoolboxFlags,
+    ) + secureTransportHttpTlsFlags + macosVideotoolboxFlags + dav1dFlags,
     libExtension = "dylib",
     toolchainProbes = listOf(
         listOf("clang", "--version"),
@@ -345,6 +384,13 @@ private fun macosTarget(name: String, arch: String): FfmpegBuildTarget = FfmpegB
     jniWrapperName = "libffmpegkitjni.dylib",
     jniWrapperLinkFlags = listOf("-dynamiclib", "-Wl,-install_name,@loader_path/libffmpegkitjni.dylib"),
     rewriteAppleInstallNames = true,
+    dav1dEnabled = true,
+    // Match the FFmpeg deployment target so the linker does not warn about object files
+    // built for a newer macOS version than the libraries they end up in.
+    dav1dMesonArgs = listOf(
+        "-Dc_args=-mmacosx-version-min=12.0",
+        "-Dc_link_args=-mmacosx-version-min=12.0",
+    ),
 )
 
 // ---------------------------------------------------------------------------------------

--- a/buildSrc/src/main/kotlin/ffmpeg/FfmpegTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/ffmpeg/FfmpegTaskTypes.kt
@@ -12,6 +12,7 @@ import nativebuild.restoreExecutablePermissions
 import nativebuild.rewriteMachOToLoaderPath
 import nativebuild.sanitizeAbsolutePaths
 import nativebuild.shellQuote
+import nativebuild.shellScriptWithExports
 import nativebuild.toMsysPath
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -81,6 +82,16 @@ abstract class FfmpegConfigureTask : DefaultTask() {
     @get:OutputFile
     abstract val configStamp: RegularFileProperty
 
+    /**
+     * dav1d install prefix for targets with dav1d enabled. Its `lib/pkgconfig` is
+     * prepended to `PKG_CONFIG_PATH` so configure's `require_pkg_config libdav1d`
+     * finds the statically built decoder.
+     */
+    @get:Optional
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val dav1dInstallDir: DirectoryProperty
+
     /** Tool location, not content input: versions are captured by the toolchain fingerprint. */
     @get:Internal
     abstract val msys2Dir: DirectoryProperty
@@ -142,11 +153,28 @@ abstract class FfmpegConfigureTask : DefaultTask() {
         val buildDirShellPath = if (hostOs == "Windows") buildDir.absolutePath.toMsysPath() else buildDir.absolutePath
         val flagsStr = allFlags.joinToString(" ") { flag -> if (' ' in flag) "'$flag'" else flag }
 
+        val configureEnv = envVars.get().toMutableMap()
+        dav1dInstallDir.orNull?.let { dav1dInstall ->
+            val pkgConfigDir = dav1dInstall.asFile.resolve("lib/pkgconfig")
+            require(pkgConfigDir.isDirectory) {
+                "dav1d pkg-config directory not found at ${pkgConfigDir.absolutePath}. " +
+                    "Run the matching dav1dBuild task first."
+            }
+            val pkgConfigPath = if (hostOs == "Windows") pkgConfigDir.absolutePath.toMsysPath() else pkgConfigDir.absolutePath
+            val existing = configureEnv["PKG_CONFIG_PATH"]?.takeIf { it.isNotBlank() }
+            configureEnv["PKG_CONFIG_PATH"] = listOfNotNull(pkgConfigPath, existing).joinToString(":")
+        }
+
         val configureCommand = "cd '$buildDirShellPath' && bash '$configurePath' $flagsStr"
 
+        // NOTE: PKG_CONFIG_PATH must be exported *inside* the shell, not merely passed in
+        // the process environment: on Windows this runs through `bash -l`, and MSYS2's
+        // login profile overwrites PKG_CONFIG_PATH with the subsystem defaults
+        // (/clangarm64/lib/pkgconfig:...), discarding the inherited value (the same
+        // reason MpvConfigureTask exports via shellScriptWithExports).
         execOperations.exec {
-            commandLine(shell.get(), "-l", "-c", configureCommand)
-            environment(envVars.get())
+            commandLine(shell.get(), "-l", "-c", shellScriptWithExports(configureEnv, configureCommand))
+            environment(configureEnv)
         }
 
         // The stamp feeds the build task's cache key, so it must not contain the
@@ -183,6 +211,15 @@ abstract class FfmpegBuildTask : DefaultTask() {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val configStamp: RegularFileProperty
+
+    /**
+     * dav1d install prefix for targets with dav1d enabled. Static-linked into libavcodec,
+     * so its content participates in the cache key like the staged FFmpeg source.
+     */
+    @get:Optional
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val dav1dInstallDir: DirectoryProperty
 
     @get:Input
     abstract val shell: Property<String>
@@ -246,13 +283,13 @@ abstract class FfmpegBuildTask : DefaultTask() {
  * place of the raw file, which embeds worktree-absolute paths and would defeat
  * cross-worktree cache hits.
  */
-internal fun sanitizedFfmpegToolchainSummary(buildDir: File): String {
+internal fun sanitizedFfmpegToolchainSummary(buildDir: File, extraRoots: List<File> = emptyList()): String {
     val configFile = buildDir.resolve("ffbuild/config.mak")
     if (!configFile.isFile) return "config.mak missing"
     val config = readFfmpegConfig(configFile)
     val summary = listOf("CC", "CPPFLAGS", "CFLAGS", "LDFLAGS", "EXTRALIBS")
         .joinToString("\n") { key -> "$key=${expandMakeVariables(config[key].orEmpty(), config)}" }
-    return sanitizeAbsolutePaths(summary, listOf(buildDir))
+    return sanitizeAbsolutePaths(summary, listOf(buildDir) + extraRoots)
 }
 
 /**

--- a/ci-helper/install-ffmpeg-deps-ubuntu.sh
+++ b/ci-helper/install-ffmpeg-deps-ubuntu.sh
@@ -18,4 +18,6 @@ sudo apt-get install -y --no-install-recommends \
     build-essential \
     pkg-config \
     nasm \
+    meson \
+    ninja-build \
     make

--- a/mediamp-mpv/dependency.md
+++ b/mediamp-mpv/dependency.md
@@ -16,6 +16,7 @@
 - [buildSrc/src/main/kotlin/mpv/MpvSupport.kt](/C:/Users/StageGuard/Desktop/Projects/mediamp/buildSrc/src/main/kotlin/mpv/MpvSupport.kt)
 - [buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt](/C:/Users/StageGuard/Desktop/Projects/mediamp/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt)
 - [buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt](/C:/Users/StageGuard/Desktop/Projects/mediamp/buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt)
+- [buildSrc/src/main/kotlin/ffmpeg/Dav1dTasks.kt](/C:/Users/StageGuard/Desktop/Projects/mediamp/buildSrc/src/main/kotlin/ffmpeg/Dav1dTasks.kt)
 - [mediamp-mpv/src/cpp](/C:/Users/StageGuard/Desktop/Projects/mediamp/mediamp-mpv/src/cpp)
 
 ## 总览
@@ -23,6 +24,7 @@
 当前 `libmpv` 构建链中显式进入依赖声明的核心第三方库有：
 
 - `FFmpeg`
+- `dav1d`
 - `libass`
 - `libplacebo`
 - `zlib`
@@ -30,6 +32,10 @@
 其中：
 
 - `FFmpeg` 来自 `mediamp-ffmpeg`，通过 `pkg-config` 提供给 mpv。
+- `dav1d` 提供 AV1 软件解码。FFmpeg 8 起原生 `av1` 解码器退化为纯硬解壳
+  （无 hwaccel 时解码直接失败），软件 AV1 必须走外部解码器；`dav1d` 由
+  `mediamp-ffmpeg/dav1d` submodule 以 meson 静态编译，随 `--enable-libdav1d`
+  链接进 `libavcodec`，因此不新增任何运行时库文件。
 - `libass` 用于字幕和 OSD 文本渲染。
 - `libplacebo` 用于 GPU 渲染路径。
 - `zlib` 在当前配置里被显式启用，同时也被部分 Android fallback 子项目间接使用。
@@ -57,6 +63,7 @@
 | 依赖 | 作用 | Windows | Linux | macOS | Android | 最终产物情况 |
 |---|---|---|---|---|---|---|
 | `FFmpeg` | 解复用、解码、滤镜、缩放、重采样等核心媒体能力 | 来自 `mediamp-ffmpeg` 安装目录，通过 `pkg-config` 导入 | 来自 `mediamp-ffmpeg` 安装目录，通过 `pkg-config` 导入 | 来自 `mediamp-ffmpeg` 安装目录，通过 `pkg-config` 导入 | 来自 `mediamp-ffmpeg` 安装目录，通过 cross file 的 `pkg_config_libdir` 导入 | Win: `av*.dll` / `sw*.dll`；macOS: `libav*.dylib` / `libsw*.dylib`；Android: `libav*.so` / `libsw*.so` |
+| `dav1d` | AV1 软件解码（`--enable-libdav1d`，FFmpeg 8 原生 `av1` 解码器仅剩硬解壳） | `mediamp-ffmpeg/dav1d` submodule，meson 静态编译，链接进 `libavcodec` | 同左 | 同左 | 未启用 | 静态链接进 `av*` 库，无额外运行时文件 |
 | `libass` | 字幕、OSD 文本渲染 | MSYS2 UCRT64 包，通过 `pkg-config` 导入 | 预期由 Linux 系统开发包提供，通过 `pkg-config` 导入 | 预期由 macOS 系统包管理器提供，通过 `pkg-config` 导入 | Git wrap fallback 交叉编译 | Win: `libass-9.dll`；macOS: `libass*.dylib`；Android: `libass.so` |
 | `libplacebo` | GPU 渲染后端 | MSYS2 UCRT64 包，通过 `pkg-config` 导入 | 预期由 Linux 系统开发包提供，通过 `pkg-config` 导入 | 预期由 macOS 系统包管理器提供，通过 `pkg-config` 导入 | Git wrap fallback 交叉编译 | Win: `libplacebo-351.dll`；macOS: `libplacebo*.dylib`；Android: 当前安装为 `libplacebo.a` |
 | `zlib` | 压缩基础库；同时被部分子项目传递使用 | MSYS2 / 系统路径传递提供 | 预期由 Linux 系统包提供 | 预期由 macOS 系统 / 包管理器提供 | WrapDB fallback | Win: `zlib1.dll`；macOS: `libz*.dylib`；Android: `libz.so` |

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
@@ -71,6 +71,9 @@ internal class MpvPreviewDecoder(
         handle.option("target-trc", "srgb")
         handle.option("hwdec", "auto")
         handle.option("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
+        // Prefer libdav1d for software AV1 — same rationale as the main player (see
+        // JvmMpvMediampPlayer.configureNativeHandle).
+        handle.option("vd", "libdav1d")
         // workaround for <https://github.com/mpv-player/mpv/issues/14651>
         handle.option("vd-lavc-film-grain", "cpu")
 

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -277,6 +277,14 @@ abstract class JvmMpvMediampPlayer(
 
         handle.option("hwdec", "auto")
         handle.option("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
+        // FFmpeg 8 removed the native AV1 software decoder: the remaining "av1" decoder
+        // is a hwaccel-only shim (upstream registers it after the external decoders with
+        // "hwaccel hooks only, so prefer external decoders"). Software AV1 therefore goes
+        // through libdav1d, which is statically linked into our desktop FFmpeg builds.
+        // State the preference explicitly so decoder selection does not silently depend
+        // on FFmpeg's registration order; harmless on runtimes without libdav1d, and the
+        // hwdec path is unaffected (it binds hwaccels to the native "av1" decoder).
+        handle.option("vd", "libdav1d")
         handle.option("input-default-bindings", "no")
         handle.option("volume-max", "200")
 


### PR DESCRIPTION
## 问题

FFmpeg 8 起原生 `av1` 解码器退化为纯硬解壳(上游注释:"hwaccel hooks only, so prefer external decoders"),在没有 AV1 硬解的机器上解码直接失败(`ENOSYS`,"Your platform doesn't support hardware accelerated AV1 decoding")。mpv 后端因此完全无法播放 AV1;旧 VLC 后端自带软解,不存在此问题。

## 改动

- 新增 `mediamp-ffmpeg/dav1d` submodule(dav1d 1.5.4),经 meson 静态编译(`dav1dBuild<Target>` 任务),通过 `--enable-libdav1d --enable-decoder=libdav1d` 链进 `libavcodec`,覆盖 WindowsX64 / WindowsArm64 / LinuxX64 / MacosX64 / MacosArm64 五个桌面 target;iOS / Android 不变。
- 静态链接,运行时打包零改动:不新增 DLL/dylib/so,不涉及 install-name 重写和 Windows DLL 收集。
- 保留原生 `av1` 解码器:AV1 硬解(d3d11va / videotoolbox / nvdec / vaapi)挂载在它上面,硬解路径不受影响。
- mpv 显式设置 `vd=libdav1d`,使软解选择不依赖 FFmpeg 注册顺序;对没有 libdav1d 的旧 runtime 无副作用。
- 修复 Windows 构建:`PKG_CONFIG_PATH` 必须在 MSYS2 登录 shell 内 export(profile 会覆盖继承的环境变量)。
- CI:`install-ffmpeg-deps-ubuntu.sh` 补 meson / ninja-build。

## 验证情况

| 变体 | 状态 |
|---|---|
| WindowsX64 | ✅ CI(构建 + 冒烟测试 + zeroConfigTest) |
| WindowsArm64 | ✅ CI + WoA 实机 AV1 播放验证 |
| LinuxX64 | ✅ CI + 本机 libmpv 播放实测(`Selected decoder: libdav1d`,48/48 帧) |
| MacosX64 | ✅ CI 构建通过(未做实机播放验证) |
| MacosArm64 | ✅ dav1d/FFmpeg/mpv 原生构建 + mpv 冒烟测试通过(self-hosted;job 因无关的 WasmJS 编译 OOM 标红,未做实机播放验证) |

macOS 两个变体没有实机播放验证,建议 release 前在 Mac 上补一轮 AV1 播放确认。

## 范围外

Android / iOS 的 FFmpeg 同样缺 AV1 软解(同一个上游变更),本 PR 未处理;需要时可以按同样的路子加交叉构建。
