### PR TITLE
fix(mpv): bundle portable Linux runtime dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvBuildTasks.kt
@@ -201,6 +201,9 @@ private fun registerMpvTasks(
         jniLibrary.set(jniOutputFile)
         runtimeDirName.set(target.runtime.runtimeDirName)
         postProcessing.set(target.runtime.postProcessing.name)
+        if (target.runtime.postProcessing == MpvRuntimePostProcessing.LINUX_BUNDLE_ELF_DEPENDENCIES) {
+            doNotTrackState("Linux runtime assembly discovers dependency files from the build host")
+        }
         target.msysSubsystem?.let { msysSubsystem.set(it) }
         this.outputDir.set(outputDirProvider)
         if (msys2Dir != null) {

--- a/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
@@ -52,8 +52,8 @@ internal enum class MpvRuntimePostProcessing {
     /** Rewrite install names to @loader_path, bundle external dylibs, re-sign. */
     MACOS_BUNDLE_DYLIBS,
 
-    /** Set `RUNPATH=$ORIGIN` so bundled `.so` files resolve their siblings. */
-    LINUX_RUNPATH_ORIGIN,
+    /** Bundle portable ELF dependencies and set `RUNPATH=$ORIGIN` on the resulting closure. */
+    LINUX_BUNDLE_ELF_DEPENDENCIES,
 
     /** Copy `libc++_shared.so` from the NDK next to the runtime. */
     ANDROID_BUNDLE_LIBCXX,
@@ -313,7 +313,7 @@ internal fun MpvBuildContext.linuxX64Target(): MpvBuildTarget = MpvBuildTarget(
     ),
     runtime = MpvRuntimeLayout(
         runtimeDirName = "lib",
-        postProcessing = MpvRuntimePostProcessing.LINUX_RUNPATH_ORIGIN,
+        postProcessing = MpvRuntimePostProcessing.LINUX_BUNDLE_ELF_DEPENDENCIES,
     ),
 )
 

--- a/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
@@ -32,7 +32,10 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Files
+import java.util.ArrayDeque
 import javax.inject.Inject
 
 /**
@@ -605,8 +608,8 @@ abstract class MpvAssembleTask : DefaultTask() {
                 )
             }
 
-            MpvRuntimePostProcessing.LINUX_RUNPATH_ORIGIN -> {
-                setLinuxRunpathOrigin(
+            MpvRuntimePostProcessing.LINUX_BUNDLE_ELF_DEPENDENCIES -> {
+                bundleLinuxElfDependencies(
                     execOperations = execOperations,
                     logger = logger,
                     libDir = runtimeDir,
@@ -623,37 +626,172 @@ abstract class MpvAssembleTask : DefaultTask() {
     }
 }
 
-/**
- * Makes the bundled Linux libraries load their siblings from the same directory: sets
- * `RUNPATH=$ORIGIN` on every regular `.so`, the ELF equivalent of macOS `@loader_path`
- * and the Windows `SetDllDirectory` path. Without it, `System.load(libmediampv.so)` cannot
- * resolve `libmpv.so.2` and the bundled ffmpeg libraries that sit next to it.
- *
- * System libraries (libass, libplacebo, glibc, X11, ...) are intentionally NOT bundled and
- * are still resolved via the system linker; the Linux runtime is therefore not fully
- * self-contained (documented limitation), but it is loadable wherever those system libraries
- * are present.
- */
-private fun setLinuxRunpathOrigin(
+/** Closes the portable ELF dependency graph and makes every bundled library load siblings. */
+private fun bundleLinuxElfDependencies(
     execOperations: ExecOperations,
     logger: Logger,
     libDir: File,
 ) {
     if (!libDir.isDirectory) return
-    val soFiles = libDir.listFiles()
-        ?.filter { it.isFile && !java.nio.file.Files.isSymbolicLink(it.toPath()) && it.name.contains(".so") }
-        .orEmpty()
 
-    soFiles.forEach { so ->
-        execOperations.exec {
-            commandLine("patchelf", "--set-rpath", "\$ORIGIN", so.absolutePath)
+    val queue = ArrayDeque<File>()
+    val visited = mutableSetOf<String>()
+    val copiedSources = mutableMapOf<String, File>()
+    libDir.listFiles()
+        ?.filter { it.isFile && it.name.contains(".so") }
+        ?.map(File::getCanonicalFile)
+        ?.distinctBy(File::getAbsolutePath)
+        ?.forEach(queue::addLast)
+
+    while (queue.isNotEmpty()) {
+        val binary = queue.removeFirst().canonicalFile
+        if (!visited.add(binary.absolutePath)) continue
+
+        val resolvedDependencies = resolveLinuxElfDependencies(execOperations, binary, libDir)
+        printLinuxNeededLibraries(execOperations, binary).forEach { neededName ->
+            require('/' !in neededName) {
+                "Unsupported path-based ELF dependency '$neededName' required by ${binary.absolutePath}"
+            }
+
+            val bundled = libDir.resolve(neededName)
+            if (bundled.isFile) {
+                queue.addLast(bundled.canonicalFile)
+                return@forEach
+            }
+            if (isLinuxHostLibrary(neededName)) return@forEach
+
+            val source = resolvedDependencies[neededName]
+                ?: error("Unresolved Linux runtime dependency '$neededName' required by ${binary.absolutePath}")
+            val canonicalSource = source.canonicalFile
+            copiedSources[neededName]?.let { previous ->
+                require(previous == canonicalSource) {
+                    "Conflicting Linux runtime dependency '$neededName': " +
+                            "${previous.absolutePath} and ${canonicalSource.absolutePath}"
+                }
+            }
+            copiedSources[neededName] = canonicalSource
+            canonicalSource.copyTo(bundled, overwrite = false)
+            bundled.setExecutable(true, false)
+            queue.addLast(bundled)
         }
     }
 
-    if (soFiles.isNotEmpty()) {
-        logger.lifecycle("Set RUNPATH=\$ORIGIN on Linux runtime libraries: ${soFiles.map { it.name }.sorted().joinToString()}")
+    val bundledLibraries = libDir.listFiles()
+        ?.filter { it.isFile && it.name.contains(".so") && !Files.isSymbolicLink(it.toPath()) }
+        .orEmpty()
+    bundledLibraries.forEach { library ->
+        execOperations.exec {
+            commandLine("patchelf", "--set-rpath", "\$ORIGIN", library.absolutePath)
+        }
+    }
+
+    bundledLibraries.forEach { library ->
+        printLinuxNeededLibraries(execOperations, library).forEach { neededName ->
+            require(isLinuxHostLibrary(neededName) || libDir.resolve(neededName).isFile) {
+                "Linux runtime closure is incomplete: '${library.name}' requires '$neededName'"
+            }
+        }
+    }
+
+    if (bundledLibraries.isNotEmpty()) {
+        logger.lifecycle(
+            "Bundled Linux ELF dependency closure and set RUNPATH=\$ORIGIN: " +
+                    bundledLibraries.map { it.name }.sorted().joinToString(),
+        )
     }
 }
+
+private fun printLinuxNeededLibraries(execOperations: ExecOperations, binary: File): List<String> {
+    val stdout = ByteArrayOutputStream()
+    execOperations.exec {
+        commandLine("patchelf", "--print-needed", binary.absolutePath)
+        standardOutput = stdout
+    }
+    return stdout.toString(Charsets.UTF_8)
+        .lineSequence()
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .toList()
+}
+
+private fun resolveLinuxElfDependencies(
+    execOperations: ExecOperations,
+    binary: File,
+    libDir: File,
+): Map<String, File> {
+    val stdout = ByteArrayOutputStream()
+    val stderr = ByteArrayOutputStream()
+    val inheritedLibraryPath = System.getenv("LD_LIBRARY_PATH").orEmpty()
+    val libraryPath = listOf(libDir.absolutePath, inheritedLibraryPath)
+        .filter(String::isNotEmpty)
+        .joinToString(File.pathSeparator)
+    val result = execOperations.exec {
+        commandLine("ldd", binary.absolutePath)
+        environment("LC_ALL", "C")
+        environment("LD_LIBRARY_PATH", libraryPath)
+        standardOutput = stdout
+        errorOutput = stderr
+        isIgnoreExitValue = true
+    }
+    require(result.exitValue == 0) {
+        "Failed to inspect ELF dependencies of ${binary.absolutePath}: " +
+                stderr.toString(Charsets.UTF_8).trim()
+    }
+
+    return buildMap {
+        stdout.toString(Charsets.UTF_8).lineSequence().forEach { line ->
+            val match = LDD_RESOLVED_LIBRARY.matchEntire(line.trim()) ?: return@forEach
+            val name = match.groupValues[1]
+            val path = match.groupValues[2]
+            if (path != "not found") {
+                val file = File(path)
+                if (file.isFile) put(name, file)
+            }
+        }
+    }
+}
+
+private val LDD_RESOLVED_LIBRARY = Regex("^(\\S+)\\s+=>\\s+(\\S+)(?:\\s+\\(.*)?$")
+
+/** Libraries that must stay matched to the host ABI, loader, JVM, or graphics driver stack. */
+private fun isLinuxHostLibrary(name: String): Boolean {
+    if (name.startsWith("linux-vdso.so") || name.startsWith("ld-linux-")) return true
+    if (name.startsWith("libnss_") || name.startsWith("libcuda.so")) return true
+    return name in LINUX_HOST_LIBRARIES
+}
+
+private val LINUX_HOST_LIBRARIES = setOf(
+    // glibc and its loader/runtime family
+    "libc.so.6",
+    "libm.so.6",
+    "libmvec.so.1",
+    "libdl.so.2",
+    "libpthread.so.0",
+    "librt.so.1",
+    "libresolv.so.2",
+    "libanl.so.1",
+    "libutil.so.1",
+    "libBrokenLocale.so.1",
+    "libthread_db.so.1",
+    // compiler runtimes may already be loaded by the JVM
+    "libstdc++.so.6",
+    "libgcc_s.so.1",
+    // base X11 ABI used by the Compose process
+    "libX11.so.6",
+    "libX11-xcb.so.1",
+    "libxcb.so.1",
+    // GL/EGL dispatch and hardware-facing libraries must match the host driver stack
+    "libGL.so.1",
+    "libEGL.so.1",
+    "libGLX.so.0",
+    "libOpenGL.so.0",
+    "libGLdispatch.so.0",
+    "libGLX_mesa.so.0",
+    "libglapi.so.0",
+    "libdrm.so.2",
+    "libgbm.so.1",
+    "libvulkan.so.1",
+)
 
 /**
  * Makes the macOS runtime self-contained: recursively copies every non-system dylib

--- a/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTaskTypes.kt
@@ -2,6 +2,7 @@ package mpv
 
 import nativebuild.copyTreePreservingLinks
 import nativebuild.deleteRecursivelyForce
+import nativebuild.isLinuxHostLibrary
 import nativebuild.isWindowsSystemLibrary
 import nativebuild.jniIncludeFlags
 import nativebuild.makePkgConfigRelocatable
@@ -752,46 +753,6 @@ private fun resolveLinuxElfDependencies(
 }
 
 private val LDD_RESOLVED_LIBRARY = Regex("^(\\S+)\\s+=>\\s+(\\S+)(?:\\s+\\(.*)?$")
-
-/** Libraries that must stay matched to the host ABI, loader, JVM, or graphics driver stack. */
-private fun isLinuxHostLibrary(name: String): Boolean {
-    if (name.startsWith("linux-vdso.so") || name.startsWith("ld-linux-")) return true
-    if (name.startsWith("libnss_") || name.startsWith("libcuda.so")) return true
-    return name in LINUX_HOST_LIBRARIES
-}
-
-private val LINUX_HOST_LIBRARIES = setOf(
-    // glibc and its loader/runtime family
-    "libc.so.6",
-    "libm.so.6",
-    "libmvec.so.1",
-    "libdl.so.2",
-    "libpthread.so.0",
-    "librt.so.1",
-    "libresolv.so.2",
-    "libanl.so.1",
-    "libutil.so.1",
-    "libBrokenLocale.so.1",
-    "libthread_db.so.1",
-    // compiler runtimes may already be loaded by the JVM
-    "libstdc++.so.6",
-    "libgcc_s.so.1",
-    // base X11 ABI used by the Compose process
-    "libX11.so.6",
-    "libX11-xcb.so.1",
-    "libxcb.so.1",
-    // GL/EGL dispatch and hardware-facing libraries must match the host driver stack
-    "libGL.so.1",
-    "libEGL.so.1",
-    "libGLX.so.0",
-    "libOpenGL.so.0",
-    "libGLdispatch.so.0",
-    "libGLX_mesa.so.0",
-    "libglapi.so.0",
-    "libdrm.so.2",
-    "libgbm.so.1",
-    "libvulkan.so.1",
-)
 
 /**
  * Makes the macOS runtime self-contained: recursively copies every non-system dylib

--- a/buildSrc/src/main/kotlin/nativebuild/SharedLibraryManifest.kt
+++ b/buildSrc/src/main/kotlin/nativebuild/SharedLibraryManifest.kt
@@ -136,3 +136,51 @@ internal fun isWindowsSystemLibrary(dllName: String): Boolean {
             "ws2_32.dll",
         )
 }
+
+/** Libraries that must stay matched to the host ABI, services, configuration, or driver stack. */
+internal fun isLinuxHostLibrary(name: String): Boolean {
+    if (name.startsWith("linux-vdso.so") || name.startsWith("ld-linux-")) return true
+    if (name.startsWith("libnss_") || name.startsWith("libcuda.so")) return true
+    if (name.startsWith("libpulsecommon-") && name.endsWith(".so")) return true
+    return name in LINUX_HOST_LIBRARIES
+}
+
+private val LINUX_HOST_LIBRARIES = setOf(
+    // glibc and its loader/runtime family
+    "libc.so.6",
+    "libm.so.6",
+    "libmvec.so.1",
+    "libdl.so.2",
+    "libpthread.so.0",
+    "librt.so.1",
+    "libresolv.so.2",
+    "libanl.so.1",
+    "libutil.so.1",
+    "libBrokenLocale.so.1",
+    "libthread_db.so.1",
+    // compiler runtimes may already be loaded by the JVM
+    "libstdc++.so.6",
+    "libgcc_s.so.1",
+    // audio, fonts, and service clients must use the host configuration and plugins
+    "libpulse.so.0",
+    "libsystemd.so.0",
+    "libasound.so.2",
+    "libdbus-1.so.3",
+    "libudev.so.1",
+    "libfontconfig.so.1",
+    // base X11 ABI used by the Compose process
+    "libX11.so.6",
+    "libX11-xcb.so.1",
+    "libxcb.so.1",
+    // GL/EGL dispatch and hardware-facing libraries must match the host driver stack
+    "libGL.so.1",
+    "libEGL.so.1",
+    "libGLX.so.0",
+    "libOpenGL.so.0",
+    "libGLdispatch.so.0",
+    "libGLX_mesa.so.0",
+    "libglapi.so.0",
+    "libdrm.so.2",
+    "libgbm.so.1",
+    "libvulkan.so.1",
+)

--- a/mediamp-mpv/dependency.md
+++ b/mediamp-mpv/dependency.md
@@ -136,11 +136,13 @@
 
 当前边界：
 
-- Linux 构建逻辑已接通，但尚未在 Linux 主机上实跑验证。
-- 目前 Linux 组装阶段只会复制：
+- Linux 组装阶段会先复制：
   - `mpv install prefix`
   - FFmpeg 的 `lib`
-- 不会额外把系统 `libX11/libEGL/libGL/libass/libplacebo` 一起 vendoring 到输出目录。
+- 随后递归分析 ELF `DT_NEEDED`，把 `libass`、`libplacebo`、X11 扩展、音频客户端等
+  可移植依赖复制到输出目录，并为所有打包库设置 `RUNPATH=$ORIGIN`。
+- glibc、JVM 已加载的编译器 runtime、基础 X11 ABI，以及 GL/EGL/驱动调度栈继续由宿主提供，
+  避免将构建机 ABI 或 GPU 驱动实现带到用户系统。
 
 ### Android
 

--- a/mediamp-mpv/dependency.md
+++ b/mediamp-mpv/dependency.md
@@ -139,10 +139,11 @@
 - Linux 组装阶段会先复制：
   - `mpv install prefix`
   - FFmpeg 的 `lib`
-- 随后递归分析 ELF `DT_NEEDED`，把 `libass`、`libplacebo`、X11 扩展、音频客户端等
-  可移植依赖复制到输出目录，并为所有打包库设置 `RUNPATH=$ORIGIN`。
-- glibc、JVM 已加载的编译器 runtime、基础 X11 ABI，以及 GL/EGL/驱动调度栈继续由宿主提供，
-  避免将构建机 ABI 或 GPU 驱动实现带到用户系统。
+- 随后递归分析 ELF `DT_NEEDED`，把 `libass`、`libplacebo`、X11 扩展等可移植依赖
+  复制到输出目录，并为所有打包库设置 `RUNPATH=$ORIGIN`。
+- glibc、JVM 已加载的编译器 runtime、基础 X11 ABI、GL/EGL/驱动调度栈，以及依赖
+  宿主配置、插件或服务的 PulseAudio、ALSA、D-Bus、systemd、udev 和 fontconfig
+  继续由宿主提供，避免将构建机 ABI 或系统集成实现带到用户系统。
 
 ### Android
 


### PR DESCRIPTION
## Summary

- recursively resolve and bundle portable ELF dependencies required by the Linux mpv runtime
- set `RUNPATH=$ORIGIN` on every bundled shared library
- keep host-sensitive libraries such as glibc, the JVM compiler runtime, base X11 ABI, and the GL/EGL driver stack provided by the target system
- fail the build when the resulting runtime dependency closure is incomplete or ambiguous
- document the Linux runtime bundling boundary

## Motivation

The Linux runtime jar previously included `libmpv` and FFmpeg libraries but still depended on libraries from the build host, such as `libplacebo` and X11 extension libraries.

As a result, the zero-config runtime could pass classpath discovery and then fail during native loading on systems that did not provide exactly the same dependency set:

```text
java.lang.UnsatisfiedLinkError: libplacebo.so...: cannot open shared object file
```

Bundling every system library would not be portable either, especially for glibc and the graphics driver stack. This change therefore computes the ELF dependency closure while preserving an explicit host-library boundary.

## Implementation

For Linux x64 runtime assembly:

1. Start from the generated mpv, FFmpeg, and JNI shared libraries.
2. Read each library's `DT_NEEDED` entries with `patchelf`.
3. Resolve dependencies through `ldd`.
4. Recursively copy non-host dependencies into the runtime directory.
5. Set `RUNPATH=$ORIGIN` on all bundled ELF libraries.
6. Verify that every remaining dependency is either bundled or explicitly classified as host-provided.

The task is marked as untracked because dependency discovery depends on files available on the Linux build host.

## Compatibility

The runtime intentionally does not bundle:

- glibc and the ELF loader
- compiler runtimes that may already be loaded by the JVM
- base X11 ABI libraries
- GL, EGL, Vulkan, DRM, and GPU-driver dispatch libraries
- dynamically selected NSS and CUDA libraries

This avoids coupling the artifact to the build machine's libc or graphics-driver implementation while still bundling portable dependencies such as libass, libplacebo, X11 extensions, and audio client libraries.

## Verification

- buildSrc Kotlin compilation passed
- Linux runtime assembly completed successfully
- the generated runtime jar contains the complete verified dependency closure, including `libplacebo.so.338`, `libXpresent.so.1`, `libmpv.so*`, and `libmediampv.so`
- `:mediamp-mpv:zeroConfigTest` passed
- the generated runtime was loaded by Animeko without a global `LD_LIBRARY_PATH`
- mpv successfully opened and played a video on Linux
