### PR TITLE
feat(mpv): Windows OpenGL readback fallback render path

### DIFF
--- a/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
+++ b/buildSrc/src/main/kotlin/mpv/MpvTargets.kt
@@ -242,8 +242,14 @@ private fun MpvBuildContext.windowsTarget(
         jni = MpvJniToolchain(
             compilerCommand = pathForShell(msys2Root.resolve("$msysSubsystem/bin/$compilerExecutable"), true),
             compilerArgs = listOf(CPP_STANDARD_FLAG, "-fPIC", "-shared", "-D_WIN32_WINNT=0x0A00"),
-            // D3D11 render path (render_d3d11.cpp); windowscodecs/ole32 are for the WIC PNG readback.
-            linkerArgs = listOf("-ld3d11", "-ld3d12", "-ldxgi", "-ldxguid", "-lwindowscodecs", "-lole32"),
+            // D3D11 render path (render_d3d11.cpp); windowscodecs/ole32 are for the WIC
+            // PNG readback; opengl32/gdi32 are for the OpenGL fallback render path
+            // (render_opengl_win.cpp, wgl_offscreen_context.cpp), which drives mpv when
+            // Compose renders with Skiko's OpenGL backend instead of Direct3D.
+            linkerArgs = listOf(
+                "-ld3d11", "-ld3d12", "-ldxgi", "-ldxguid", "-lwindowscodecs", "-lole32",
+                "-lopengl32", "-lgdi32",
+            ),
             outputFileName = "mediampv.dll",
             sourceExtensions = setOf("cpp"),
             useJdkIncludes = true,

--- a/mediamp-mpv-demo/build.gradle.kts
+++ b/mediamp-mpv-demo/build.gradle.kts
@@ -53,11 +53,9 @@ tasks.matching { it.name == "run" }.configureEach {
     dependsOn(compileNativeBridge)
 }
 
-// Production mediamp-mpv path (Windows D3D11 / macOS Metal / Linux GLX) against a locally
-// assembled runtime: ./gradlew :mediamp-mpv-demo:runD3D11 [-Pvideo=/path/to.mp4]
-tasks.register<JavaExec>("runD3D11") {
+// Production mediamp-mpv path against a locally assembled runtime.
+fun JavaExec.configureProductionDemo() {
     group = "mediamp"
-    description = "Run the production mediamp-mpv demo (D3D11 on Windows, Metal on macOS, GLX on Linux)"
     mainClass = "org.openani.mediamp.mpvdemo.MpvD3D11MainKt"
     classpath = sourceSets["main"].runtimeClasspath
     val runtimeTarget = when {
@@ -81,4 +79,20 @@ tasks.register<JavaExec>("runD3D11") {
     (findProperty("runtimeDir") as? String)?.let { systemProperty("mediamp.mpv.runtime.dir", it) }
     // -PdebugProps=1 logs every mpv property notification to stderr.
     (findProperty("debugProps") as? String)?.let { systemProperty("mediamp.mpv.debug.props", it) }
+}
+
+// ./gradlew :mediamp-mpv-demo:runD3D11 [-Pvideo=/path/to.mp4]
+tasks.register<JavaExec>("runD3D11") {
+    description = "Run the production mediamp-mpv demo (D3D11 on Windows, Metal on macOS, GLX on Linux)"
+    configureProductionDemo()
+}
+
+// Same demo with Compose forced onto Skiko's OpenGL backend, which is what selects the
+// mpv OpenGL readback fallback on Windows (render_opengl_win.cpp). On Linux this is
+// already the default; on macOS Skiko stays on Metal.
+// ./gradlew :mediamp-mpv-demo:runOpenGL [-Pvideo=/path/to.mp4]
+tasks.register<JavaExec>("runOpenGL") {
+    description = "Run the production mediamp-mpv demo with Compose rendering through OpenGL"
+    configureProductionDemo()
+    systemProperty("skiko.renderApi", "OPENGL")
 }

--- a/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/DemoOverlay.kt
+++ b/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/DemoOverlay.kt
@@ -50,6 +50,8 @@ fun DemoOverlay(
     durationSeconds: Double,
     onTogglePause: () -> Unit,
     onSeek: (seconds: Double) -> Unit,
+    onRestart: () -> Unit,
+    onStop: () -> Unit,
     modifier: Modifier = Modifier,
     /** Shows a loading spinner (media opening or playback stalled for data). */
     isLoading: Boolean = false,
@@ -69,6 +71,14 @@ fun DemoOverlay(
                 color = if (statusOk) Color(0xFF7CFC00) else Color.Yellow,
                 style = MaterialTheme.typography.bodyMedium,
             )
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Button(onClick = onRestart) {
+                    Text("Restart")
+                }
+                Button(onClick = onStop) {
+                    Text("Stop")
+                }
+            }
         }
 
         // Continuously animating Compose elements over the video.

--- a/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/Main.kt
+++ b/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/Main.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.singleWindowApplication
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.openani.mediamp.PlaybackException
 
 fun main(args: Array<String>) {
     val videoPath = args.firstOrNull()
@@ -37,6 +40,7 @@ fun main(args: Array<String>) {
         title = "mediamp mpv+Metal prototype",
         state = WindowState(size = DpSize(1280.dp, 800.dp)),
     ) {
+        val scope = rememberCoroutineScope()
         val player = remember { MpvPlayer().also { it.loadFile(videoPath) } }
         DisposableEffect(Unit) {
             onDispose { player.close() }
@@ -73,6 +77,22 @@ fun main(args: Array<String>) {
                     durationSeconds = duration,
                     onTogglePause = { player.togglePause() },
                     onSeek = { player.seekAbsolute(it) },
+                    onRestart = {
+                        scope.launch {
+                            player.close()
+                            delay(3000)
+                            try {
+                                player.loadFile(videoPath)
+                            } catch (e: PlaybackException) {
+                                println(e)
+                            }
+                        }
+                    },
+                    onStop = {
+                        scope.launch {
+                            player.close()
+                        }
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/MpvD3D11Main.kt
+++ b/mediamp-mpv-demo/src/main/kotlin/org/openani/mediamp/mpvdemo/MpvD3D11Main.kt
@@ -8,18 +8,26 @@
 
 package org.openani.mediamp.mpvdemo
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpSize
@@ -27,11 +35,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.singleWindowApplication
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import org.openani.mediamp.PlaybackEvent
 import org.openani.mediamp.PlaybackException
 import org.openani.mediamp.isLoadingOrBuffering
+import org.openani.mediamp.mpv.MPVHandle
 import org.openani.mediamp.mpv.MpvMediampPlayer
 import org.openani.mediamp.mpv.compose.MpvMediampPlayerSurface
 import org.openani.mediamp.source.MediaExtraFiles
@@ -63,120 +74,184 @@ fun main(args: Array<String>) {
             "(run :mediamp-mpv:$hostRuntimeTask first)"
     }
     MpvMediampPlayer.prepareLibraries(runtimeDir, extractRuntimeLibrary = false)
+    MPVHandle.setLogHandler {
+        val prefix = it.prefix.padStart(9, ' ')
+        val handle = "0x${it.instanceHandle.toHexString().trimStart('0')}"
+        if (it.level in 1..20) {
+            println ( "[$prefix@$handle][error] ${it.line}" )
+        } else if (it.level <= 30) {
+            println ( "[$prefix@$handle][warn] ${it.line}" )
+        } else if (it.level <= 40) {
+            println ( "[$prefix@$handle][info] ${it.line}" )
+        } else if (it.level <= 50) {
+            println ( "[$prefix@$handle][debug] ${it.line}" )
+        } else {
+            println ( "[$prefix@$handle][trace] ${it.line}" )
+        }
+    }
 
     singleWindowApplication(
         title = "mediamp mpv production renderer (D3D11 / Metal / GLX)",
         state = WindowState(size = DpSize(1280.dp, 800.dp)),
     ) {
-        val player = remember { MpvMediampPlayer(Any(), Dispatchers.Default) }
-        DisposableEffect(Unit) {
-            onDispose { player.close() }
+        var entered by remember { mutableStateOf(false) }
+        val smoking = remember { System.getProperty("mpvdemo.script") == "smoke" }
+        
+        val visible by remember {
+            derivedStateOf { entered || smoking }
         }
 
-        var loadError by remember { mutableStateOf<String?>(null) }
-        LaunchedEffect(player) {
-            try {
-                player.setMediaData(
-                    UriMediaData(videoUri, emptyMap(), MediaExtraFiles.EMPTY),
-                    playWhenReady = true,
-                )
-            } catch (e: PlaybackException) {
-                loadError = e.toString()
+        AnimatedVisibility(visible, modifier = Modifier.fillMaxSize(), enter = fadeIn(), exit = fadeOut()) {
+            if (visible) {
+                MainVideoFrame(videoUri, Modifier.fillMaxSize().background(Color.Black))
+            } else {
+                Box(Modifier.fillMaxSize().background(Color.Black))
             }
         }
-        // Loop for sustained smoke runs. Session-advancing reactions use `events`, not the
-        // conflated `state`; at Ended, play() replays from the beginning (state-spec v2).
-        LaunchedEffect(player) {
-            player.events.filterIsInstance<PlaybackEvent.MediaEnded>().collect {
-                player.play()
+        Box(Modifier.fillMaxSize()) {
+            Button(
+                { entered = !entered }, 
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(16.dp)
+            ) {
+                Text("Toggle")
             }
         }
+    }
+}
 
-        // Smoke-test hook: every state snapshot and event on stdout, so playback state
-        // transitions can be verified from the run log without a visible window.
-        LaunchedEffect(player) {
-            player.state.collect { println("[demo] state: $it") }
+@Composable
+private fun MainVideoFrame(
+    videoUri: String,
+    modifier: Modifier = Modifier
+) {
+    val scope = rememberCoroutineScope()
+    val player = remember { MpvMediampPlayer(Any(), Dispatchers.Default) }
+    DisposableEffect(Unit) {
+        onDispose { player.close() }
+    }
+
+    var loadError by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(player) {
+        try {
+            player.setMediaData(
+                UriMediaData(videoUri, emptyMap(), MediaExtraFiles.EMPTY),
+                playWhenReady = true,
+            )
+        } catch (e: PlaybackException) {
+            loadError = e.toString()
         }
-        LaunchedEffect(player) {
-            player.events.collect { println("[demo] event: $it") }
+    }
+    // Loop for sustained smoke runs. Session-advancing reactions use `events`, not the
+    // conflated `state`; at Ended, play() replays from the beginning (state-spec v2).
+    LaunchedEffect(player) {
+        player.events.filterIsInstance<PlaybackEvent.MediaEnded>().collect {
+            player.play()
         }
-        LaunchedEffect(player) {
-            var last = -1L
-            player.currentPositionMillis.collect { pos ->
-                if (pos / 1000 != last) {
-                    last = pos / 1000
-                    println("[demo] position: ${pos}ms")
-                }
+    }
+
+    // Smoke-test hook: every state snapshot and event on stdout, so playback state
+    // transitions can be verified from the run log without a visible window.
+    LaunchedEffect(player) {
+        player.state.collect { println("[demo] state: $it") }
+    }
+    LaunchedEffect(player) {
+        player.events.collect { println("[demo] event: $it") }
+    }
+    LaunchedEffect(player) {
+        var last = -1L
+        player.currentPositionMillis.collect { pos ->
+            if (pos / 1000 != last) {
+                last = pos / 1000
+                println("[demo] position: ${pos}ms")
             }
         }
+    }
 
-        // Self-driving smoke scenario: -Dmpvdemo.script=smoke drives the player through a
-        // scripted pause/play/seek/EOF sequence against the real backend, logging every
-        // state/event. Turns manual playback verification into a repeatable check:
-        // expected log shape: Ready(playing) -> pause -> play -> seek (SeekCompleted)
-        // -> seek-to-near-end -> MediaEnded -> replay via the events loop above.
-        if (System.getProperty("mpvdemo.script") == "smoke") {
-            LaunchedEffect(player) {
-                player.state.first { it.mediaStatus == org.openani.mediamp.MediaStatus.Ready }
-                kotlinx.coroutines.delay(5_000)
-                println("[demo][script] pause()")
-                player.pause()
+    // Self-driving smoke scenario: -Dmpvdemo.script=smoke drives the player through a
+    // scripted pause/play/seek/EOF sequence against the real backend, logging every
+    // state/event. Turns manual playback verification into a repeatable check:
+    // expected log shape: Ready(playing) -> pause -> play -> seek (SeekCompleted)
+    // -> seek-to-near-end -> MediaEnded -> replay via the events loop above.
+    if (System.getProperty("mpvdemo.script") == "smoke") {
+        LaunchedEffect(player) {
+            player.state.first { it.mediaStatus == org.openani.mediamp.MediaStatus.Ready }
+            kotlinx.coroutines.delay(5_000)
+            println("[demo][script] pause()")
+            player.pause()
+            kotlinx.coroutines.delay(2_000)
+            println("[demo][script] play()")
+            player.play()
+            kotlinx.coroutines.delay(2_000)
+            println("[demo][script] seekTo(current + 30s)")
+            player.skip(30_000)
+            kotlinx.coroutines.delay(3_000)
+            val duration = player.mediaProperties.value?.durationMillis
+            if (duration != null) {
+                println("[demo][script] seekTo(duration - 2s) — expecting MediaEnded soon")
+                player.seekTo(duration - 2_000)
+            } else {
+                println("[demo][script] duration unknown (live source) — skipping EOF leg")
+            }
+        }
+    }
+
+    // Smoke-test hook: -Dmpvdemo.screenshot.dir=<dir> dumps a frame readback every
+    // 2s (native surface-ring PNG path), so playback can be pixel-verified.
+    val screenshotDir = remember { System.getProperty("mpvdemo.screenshot.dir") }
+    if (screenshotDir != null) {
+        LaunchedEffect(player) {
+            val screenshots = player.features[org.openani.mediamp.features.Screenshots.Key] ?: return@LaunchedEffect
+            var index = 0
+            while (true) {
                 kotlinx.coroutines.delay(2_000)
-                println("[demo][script] play()")
-                player.play()
-                kotlinx.coroutines.delay(2_000)
-                println("[demo][script] seekTo(current + 30s)")
-                player.skip(30_000)
-                kotlinx.coroutines.delay(3_000)
-                val duration = player.mediaProperties.value?.durationMillis
-                if (duration != null) {
-                    println("[demo][script] seekTo(duration - 2s) — expecting MediaEnded soon")
-                    player.seekTo(duration - 2_000)
-                } else {
-                    println("[demo][script] duration unknown (live source) — skipping EOF leg")
+                val path = "$screenshotDir/frame-${index++}.png"
+                val result = runCatching { screenshots.takeScreenshot(path) }
+                println("[demo] screenshot #$index -> $path: ${result.exceptionOrNull() ?: "ok"}")
+            }
+        }
+    }
+
+    val playerState by player.state.collectAsState()
+    val positionMillis by player.currentPositionMillis.collectAsState()
+    val properties by player.mediaProperties.collectAsState()
+
+    Box(modifier) {
+        MpvMediampPlayerSurface(player, Modifier.fillMaxSize())
+        DemoOverlay(
+            title = "mediamp-mpv production path (D3D11/Metal/GLX)",
+            statusLine = loadError
+                ?: "mediaStatus: ${playerState.mediaStatus}   state: $playerState   uri: $videoUri",
+            statusOk = loadError == null && playerState.isPlaying,
+            // Button icon derives from the intent axis, never from buffering.
+            paused = !playerState.playWhenReady,
+            isLoading = playerState.isLoadingOrBuffering,
+            positionSeconds = positionMillis / 1000.0,
+            durationSeconds = (properties?.durationMillis ?: 0L) / 1000.0,
+            // Never dead in any loaded state; replays at Ended.
+            onTogglePause = { player.togglePlayWhenReady() },
+            onSeek = { player.seekTo((it * 1000).toLong()) },
+            onRestart = {
+                scope.launch {
+                    player.stopPlayback()
+                    delay(3000)
+                    try {
+                        player.setMediaData(
+                            UriMediaData(videoUri, emptyMap(), MediaExtraFiles.EMPTY),
+                            playWhenReady = true,
+                        )
+                    } catch (e: PlaybackException) {
+                        loadError = e.toString()
+                    }
                 }
-            }
-        }
-
-        // Smoke-test hook: -Dmpvdemo.screenshot.dir=<dir> dumps a frame readback every
-        // 2s (native surface-ring PNG path), so playback can be pixel-verified.
-        val screenshotDir = remember { System.getProperty("mpvdemo.screenshot.dir") }
-        if (screenshotDir != null) {
-            LaunchedEffect(player) {
-                val screenshots = player.features[org.openani.mediamp.features.Screenshots.Key] ?: return@LaunchedEffect
-                var index = 0
-                while (true) {
-                    kotlinx.coroutines.delay(2_000)
-                    val path = "$screenshotDir/frame-${index++}.png"
-                    val result = runCatching { screenshots.takeScreenshot(path) }
-                    println("[demo] screenshot #$index -> $path: ${result.exceptionOrNull() ?: "ok"}")
+            },
+            onStop = {
+                scope.launch {
+                    player.stopPlayback()
                 }
-            }
-        }
-
-        val playerState by player.state.collectAsState()
-        val positionMillis by player.currentPositionMillis.collectAsState()
-        val properties by player.mediaProperties.collectAsState()
-
-        MaterialTheme(colorScheme = darkColorScheme()) {
-            Box(Modifier.fillMaxSize().background(Color.Black)) {
-                MpvMediampPlayerSurface(player, Modifier.fillMaxSize())
-                DemoOverlay(
-                    title = "mediamp-mpv production path (D3D11/Metal/GLX)",
-                    statusLine = loadError
-                        ?: "mediaStatus: ${playerState.mediaStatus}   state: $playerState   uri: $videoUri",
-                    statusOk = loadError == null && playerState.isPlaying,
-                    // Button icon derives from the intent axis, never from buffering.
-                    paused = !playerState.playWhenReady,
-                    isLoading = playerState.isLoadingOrBuffering,
-                    positionSeconds = positionMillis / 1000.0,
-                    durationSeconds = (properties?.durationMillis ?: 0L) / 1000.0,
-                    // Never dead in any loaded state; replays at Ended.
-                    onTogglePause = { player.togglePlayWhenReady() },
-                    onSeek = { player.seekTo((it * 1000).toLong()) },
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
-        }
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
     }
 }

--- a/mediamp-mpv/mpv-d3d11-rendering.md
+++ b/mediamp-mpv/mpv-d3d11-rendering.md
@@ -17,6 +17,16 @@
 > - 附带修复:`mpvRuntimeAllElements` 聚合 variant 缺 capability, 导致项目内
 >   `implementation(projects.mediampMpv)` 被解析到该 variant(buildSrc 已修)。
 > 当前工作流见 [dependency.md](dependency.md) "Windows 渲染与开发工作流"。
+>
+> **后续(2026-08):** §5 删掉的旧同步 GL 路径没有回归, 但 Windows 又多了一条**独立的**
+> OpenGL 兼容路径: 当宿主把 Compose 切到 Skiko 的 OpenGL 后端时(`SKIKO_RENDER_API=OPENGL`,
+> Skia 没有 D3D12 设备, 本文的共享纹理方案不成立), mediamp 改走 CPU 读回方案
+> (`src/cpp/render_opengl_win.cpp` + `wgl_offscreen_context.cpp`): 独立渲染线程在
+> 一个与 Skiko **零共享**的离屏 WGL 上下文里渲染到私有 FBO, 每帧 `glReadPixels` 读回,
+> 消费端在 Compose 绘制时上传进 Skia surface。每帧多一次 GPU→CPU→GPU 往返是有意为之——
+> 这是兼容 fallback, 以可用性换零拷贝(不依赖 `wglShareLists`/像素格式匹配, 曾在
+> 共享纹理方案的 Windows 移植中被驱动拒绝)。不是被删掉的那个 `glFinish` 阻塞 UI
+> 线程的老实现: 渲染线程模型、帧状态协议与其他平台一致。D3D11 仍是 Windows 默认路径。
 
 ---
 

--- a/mediamp-mpv/src/cpp/gl_functions_win.cpp
+++ b/mediamp-mpv/src/cpp/gl_functions_win.cpp
@@ -105,6 +105,81 @@ GLenum check_framebuffer_status(GLenum target) {
     return api.check_status ? api.check_status(target) : 0;
 }
 
+namespace {
+
+struct buffer_functions final {
+    PFNGLGENBUFFERSPROC gen = nullptr;
+    PFNGLDELETEBUFFERSPROC destroy = nullptr;
+    PFNGLBINDBUFFERPROC bind = nullptr;
+    PFNGLBUFFERDATAPROC data = nullptr;
+    PFNGLMAPBUFFERPROC map = nullptr;
+    PFNGLUNMAPBUFFERPROC unmap = nullptr;
+    bool complete = false;
+};
+
+const buffer_functions &buffer_api() {
+    static buffer_functions functions;
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+    if (functions.complete) return functions;
+
+    functions.gen = reinterpret_cast<PFNGLGENBUFFERSPROC>(
+        resolve_gl_symbol("glGenBuffers", "glGenBuffersARB"));
+    functions.destroy = reinterpret_cast<PFNGLDELETEBUFFERSPROC>(
+        resolve_gl_symbol("glDeleteBuffers", "glDeleteBuffersARB"));
+    functions.bind = reinterpret_cast<PFNGLBINDBUFFERPROC>(
+        resolve_gl_symbol("glBindBuffer", "glBindBufferARB"));
+    functions.data = reinterpret_cast<PFNGLBUFFERDATAPROC>(
+        resolve_gl_symbol("glBufferData", "glBufferDataARB"));
+    functions.map = reinterpret_cast<PFNGLMAPBUFFERPROC>(
+        resolve_gl_symbol("glMapBuffer", "glMapBufferARB"));
+    functions.unmap = reinterpret_cast<PFNGLUNMAPBUFFERPROC>(
+        resolve_gl_symbol("glUnmapBuffer", "glUnmapBufferARB"));
+    functions.complete = functions.gen && functions.destroy && functions.bind &&
+        functions.data && functions.map && functions.unmap;
+    return functions;
+}
+
+} // namespace
+
+bool buffer_objects_available() {
+    return buffer_api().complete;
+}
+
+void gen_buffers(GLsizei n, GLuint *buffers) {
+    const auto &api = buffer_api();
+    if (api.gen) {
+        api.gen(n, buffers);
+    } else if (buffers) {
+        for (GLsizei i = 0; i < n; ++i) buffers[i] = 0;
+    }
+}
+
+void delete_buffers(GLsizei n, const GLuint *buffers) {
+    const auto &api = buffer_api();
+    if (api.destroy) api.destroy(n, buffers);
+}
+
+void bind_buffer(GLenum target, GLuint buffer) {
+    const auto &api = buffer_api();
+    if (api.bind) api.bind(target, buffer);
+}
+
+void buffer_data(GLenum target, GLsizeiptr size, const void *data, GLenum usage) {
+    const auto &api = buffer_api();
+    if (api.data) api.data(target, size, data, usage);
+}
+
+void *map_buffer(GLenum target, GLenum access) {
+    const auto &api = buffer_api();
+    return api.map ? api.map(target, access) : nullptr;
+}
+
+GLboolean unmap_buffer(GLenum target) {
+    const auto &api = buffer_api();
+    return api.unmap ? api.unmap(target) : GL_FALSE;
+}
+
 } // namespace gl
 } // namespace mediampv
 

--- a/mediamp-mpv/src/cpp/gl_functions_win.cpp
+++ b/mediamp-mpv/src/cpp/gl_functions_win.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#ifdef _WIN32
+
+#include "gl_functions_win.h"
+
+#include <cstdint>
+#include <mutex>
+
+#include "log.h"
+
+namespace mediampv {
+namespace gl {
+
+namespace {
+
+void *resolve_gl_symbol(const char *name) {
+    if (PROC proc = wglGetProcAddress(name)) {
+        // Some drivers report "unsupported" with these sentinels instead of null.
+        const auto value = reinterpret_cast<intptr_t>(proc);
+        if (value != 1 && value != 2 && value != 3 && value != -1) {
+            return reinterpret_cast<void *>(proc);
+        }
+    }
+    static HMODULE const gl_module = LoadLibraryW(L"opengl32.dll");
+    return gl_module ? reinterpret_cast<void *>(GetProcAddress(gl_module, name)) : nullptr;
+}
+
+/** Core/ARB name first, then the pre-3.0 EXT spelling for compatibility contexts. */
+void *resolve_gl_symbol(const char *name, const char *ext_name) {
+    if (void *symbol = resolve_gl_symbol(name)) return symbol;
+    return resolve_gl_symbol(ext_name);
+}
+
+struct framebuffer_functions final {
+    PFNGLGENFRAMEBUFFERSPROC gen = nullptr;
+    PFNGLDELETEFRAMEBUFFERSPROC destroy = nullptr;
+    PFNGLBINDFRAMEBUFFERPROC bind = nullptr;
+    PFNGLFRAMEBUFFERTEXTURE2DPROC attach_texture = nullptr;
+    PFNGLCHECKFRAMEBUFFERSTATUSPROC check_status = nullptr;
+    bool complete = false;
+};
+
+const framebuffer_functions &framebuffer_api() {
+    static framebuffer_functions functions;
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+    if (functions.complete) return functions;
+
+    // Retried until it succeeds: a call could in principle happen before any context
+    // is current, and wglGetProcAddress resolves nothing then.
+    functions.gen = reinterpret_cast<PFNGLGENFRAMEBUFFERSPROC>(
+        resolve_gl_symbol("glGenFramebuffers", "glGenFramebuffersEXT"));
+    functions.destroy = reinterpret_cast<PFNGLDELETEFRAMEBUFFERSPROC>(
+        resolve_gl_symbol("glDeleteFramebuffers", "glDeleteFramebuffersEXT"));
+    functions.bind = reinterpret_cast<PFNGLBINDFRAMEBUFFERPROC>(
+        resolve_gl_symbol("glBindFramebuffer", "glBindFramebufferEXT"));
+    functions.attach_texture = reinterpret_cast<PFNGLFRAMEBUFFERTEXTURE2DPROC>(
+        resolve_gl_symbol("glFramebufferTexture2D", "glFramebufferTexture2DEXT"));
+    functions.check_status = reinterpret_cast<PFNGLCHECKFRAMEBUFFERSTATUSPROC>(
+        resolve_gl_symbol("glCheckFramebufferStatus", "glCheckFramebufferStatusEXT"));
+    functions.complete = functions.gen && functions.destroy && functions.bind &&
+        functions.attach_texture && functions.check_status;
+    if (!functions.complete && wglGetCurrentContext() != nullptr) {
+        LOGE("this OpenGL driver exposes no framebuffer objects; mpv cannot render offscreen");
+    }
+    return functions;
+}
+
+} // namespace
+
+void gen_framebuffers(GLsizei n, GLuint *framebuffers) {
+    const auto &api = framebuffer_api();
+    if (api.gen) {
+        api.gen(n, framebuffers);
+    } else if (framebuffers) {
+        for (GLsizei i = 0; i < n; ++i) framebuffers[i] = 0;
+    }
+}
+
+void delete_framebuffers(GLsizei n, const GLuint *framebuffers) {
+    const auto &api = framebuffer_api();
+    if (api.destroy) api.destroy(n, framebuffers);
+}
+
+void bind_framebuffer(GLenum target, GLuint framebuffer) {
+    const auto &api = framebuffer_api();
+    if (api.bind) api.bind(target, framebuffer);
+}
+
+void framebuffer_texture_2d(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level) {
+    const auto &api = framebuffer_api();
+    if (api.attach_texture) api.attach_texture(target, attachment, textarget, texture, level);
+}
+
+GLenum check_framebuffer_status(GLenum target) {
+    const auto &api = framebuffer_api();
+    return api.check_status ? api.check_status(target) : 0;
+}
+
+} // namespace gl
+} // namespace mediampv
+
+#endif // _WIN32

--- a/mediamp-mpv/src/cpp/include/gl_functions_win.h
+++ b/mediamp-mpv/src/cpp/include/gl_functions_win.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#ifndef MEDIAMP_GL_FUNCTIONS_WIN_H
+#define MEDIAMP_GL_FUNCTIONS_WIN_H
+
+#ifdef _WIN32
+
+// opengl32.dll exports only the OpenGL 1.1 core, so glext.h contributes types and enums
+// while the post-1.1 entry points below are resolved at runtime through
+// wglGetProcAddress.
+#include <windows.h>
+#include <GL/gl.h>
+#include <GL/glext.h>
+
+// Enums newer than OpenGL 1.1 that the fallback render path uses. glext.h defines all
+// of them; the guards only protect against an outdated copy in a MinGW sysroot.
+#ifndef GL_CLAMP_TO_EDGE
+#define GL_CLAMP_TO_EDGE 0x812F
+#endif
+#ifndef GL_FRAMEBUFFER
+#define GL_FRAMEBUFFER 0x8D40
+#endif
+#ifndef GL_COLOR_ATTACHMENT0
+#define GL_COLOR_ATTACHMENT0 0x8CE0
+#endif
+#ifndef GL_FRAMEBUFFER_COMPLETE
+#define GL_FRAMEBUFFER_COMPLETE 0x8CD5
+#endif
+#ifndef GL_RGBA8
+#define GL_RGBA8 0x8058
+#endif
+
+namespace mediampv {
+namespace gl {
+
+/**
+ * Framebuffer-object entry points resolved through wglGetProcAddress — core/ARB name
+ * first, then the pre-3.0 EXT spelling for old compatibility contexts. Resolution
+ * happens on first use and is cached process-wide; it requires a GL context to be
+ * current, which the render thread guarantees (the offscreen WGL context is made
+ * current before any of these run). A call on a driver without framebuffer objects is
+ * a no-op that leaves out-parameters zeroed, which every call site treats as failure.
+ */
+void gen_framebuffers(GLsizei n, GLuint *framebuffers);
+void delete_framebuffers(GLsizei n, const GLuint *framebuffers);
+void bind_framebuffer(GLenum target, GLuint framebuffer);
+void framebuffer_texture_2d(
+    GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+GLenum check_framebuffer_status(GLenum target);
+
+} // namespace gl
+} // namespace mediampv
+
+#endif // _WIN32
+
+#endif // MEDIAMP_GL_FUNCTIONS_WIN_H

--- a/mediamp-mpv/src/cpp/include/gl_functions_win.h
+++ b/mediamp-mpv/src/cpp/include/gl_functions_win.h
@@ -35,6 +35,15 @@
 #ifndef GL_RGBA8
 #define GL_RGBA8 0x8058
 #endif
+#ifndef GL_PIXEL_PACK_BUFFER
+#define GL_PIXEL_PACK_BUFFER 0x88EB
+#endif
+#ifndef GL_STREAM_READ
+#define GL_STREAM_READ 0x88E1
+#endif
+#ifndef GL_READ_ONLY
+#define GL_READ_ONLY 0x88B8
+#endif
 
 namespace mediampv {
 namespace gl {
@@ -53,6 +62,19 @@ void bind_framebuffer(GLenum target, GLuint framebuffer);
 void framebuffer_texture_2d(
     GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
 GLenum check_framebuffer_status(GLenum target);
+
+/**
+ * Buffer-object entry points for the asynchronous PBO readback, resolved the same
+ * way. buffer_objects_available() reports whether the whole set resolved; when it is
+ * false the render path falls back to synchronous glReadPixels.
+ */
+bool buffer_objects_available();
+void gen_buffers(GLsizei n, GLuint *buffers);
+void delete_buffers(GLsizei n, const GLuint *buffers);
+void bind_buffer(GLenum target, GLuint buffer);
+void buffer_data(GLenum target, GLsizeiptr size, const void *data, GLenum usage);
+void *map_buffer(GLenum target, GLenum access);
+GLboolean unmap_buffer(GLenum target);
 
 } // namespace gl
 } // namespace mediampv

--- a/mediamp-mpv/src/cpp/include/mpv_handle_t.h
+++ b/mediamp-mpv/src/cpp/include/mpv_handle_t.h
@@ -116,9 +116,12 @@ public:
     // which one is decided in Kotlin from Skiko's configured render API.
     bool create_render_context_win_gl();
     bool destroy_render_context_win_gl();
-    // Same request/reply protocol as the D3D11 set_surface_config, but there is no
+    // Same request protocol as the D3D11 set_surface_config, but there is no
     // consumer device: width/height <= 0 deactivates the surface (frames are then
-    // drained without rendering). Asynchronous.
+    // drained without rendering). Resizes are asynchronous; deactivation waits
+    // (bounded by a 1s timeout) until the render thread has dropped its FBO and
+    // parked, so the consumer can destroy its Skia GPU objects without racing this
+    // path's GL.
     bool set_surface_config_win_gl(int width, int height);
     // Packed frame state, same layout as the D3D11 path: generation(16) |
     // latest_index(4, 0xF = none; always 0 when a frame exists) | width(14) |

--- a/mediamp-mpv/src/cpp/include/mpv_handle_t.h
+++ b/mediamp-mpv/src/cpp/include/mpv_handle_t.h
@@ -290,8 +290,17 @@ private:
     // The helpers below run on the render thread; *_locked ones assume the state
     // mutex is held.
     bool apply_config_win_gl_locked();
+    bool allocate_target_win_gl_locked(int width, int height);
+    void destroy_target_win_gl_locked();
     void publish_state_win_gl_locked();
+    void publish_collected_frame_win_gl_locked(int width, int height);
+    // Renders mpv into the FBO and starts the readback: asynchronously into the next
+    // PBO when available, else synchronously into scratch.
     bool render_frame_win_gl(int width, int height);
+    // Moves the oldest completed readback into scratch; false when none is ready.
+    // include_pbos=false only collects a synchronous-path frame (used right after a
+    // render, where mapping the just-queued PBO would defeat the asynchrony).
+    bool collect_ready_frame_win_gl(int *out_width, int *out_height, bool include_pbos);
     void drain_one_frame_win_gl();
 #endif
 

--- a/mediamp-mpv/src/cpp/include/mpv_handle_t.h
+++ b/mediamp-mpv/src/cpp/include/mpv_handle_t.h
@@ -103,6 +103,36 @@ public:
     // Copies the latest rendered frame as ARGB_8888 ints (0xAARRGGBB, row-major,
     // top-down) with alpha forced opaque. Returns false when no frame is available.
     bool read_surface_pixels(std::vector<uint32_t> &out_pixels, int &out_width, int &out_height);
+
+    // OpenGL fallback render path (render_opengl_win.cpp), used instead of the D3D11
+    // path above when Compose renders with Skiko's OpenGL backend
+    // (SKIKO_RENDER_API=OPENGL) — Skia then has no D3D12 device for the shared-texture
+    // ring to open its buffers on. A dedicated render thread drives mpv through the
+    // libmpv OpenGL render API on a private offscreen WGL context (no sharing with
+    // Skiko) into one FBO, and reads every frame back to CPU memory; the consumer
+    // copies the latest frame into a Skia bitmap during draw. One GPU->CPU->GPU round
+    // trip per frame by design: this is the compatibility path, robustness over
+    // zero-copy. Per player exactly one of the two Windows paths is ever created;
+    // which one is decided in Kotlin from Skiko's configured render API.
+    bool create_render_context_win_gl();
+    bool destroy_render_context_win_gl();
+    // Same request/reply protocol as the D3D11 set_surface_config, but there is no
+    // consumer device: width/height <= 0 deactivates the surface (frames are then
+    // drained without rendering). Asynchronous.
+    bool set_surface_config_win_gl(int width, int height);
+    // Packed frame state, same layout as the D3D11 path: generation(16) |
+    // latest_index(4, 0xF = none; always 0 when a frame exists) | width(14) |
+    // height(14) | serial(16).
+    uint64_t get_frame_state_win_gl();
+    bool has_win_gl_surface();
+    bool save_surface_png_win_gl(const char *path);
+    bool read_surface_pixels_win_gl(std::vector<uint32_t> &out_pixels, int &out_width, int &out_height);
+    // Copies the latest frame as tightly packed RGBA8 rows (top-down) into dest,
+    // provided the frame is exactly width x height (dest must hold width*height*4
+    // bytes). Returns the packed frame state the copy corresponds to, or 0 when no
+    // matching frame is available. Called from the consumer (UI) thread; the copy is
+    // serialized against the render thread's buffer swap, never against rendering.
+    uint64_t copy_latest_frame_win_gl(void *dest, int width, int height);
 #endif
 
 #ifdef __APPLE__
@@ -240,6 +270,26 @@ private:
     // Staging-texture readback of the latest frame; shared by save_surface_png and
     // read_surface_pixels. Assumes render_mutex_ is held.
     bool read_frame_argb_locked(std::vector<uint32_t> &out_pixels, int &out_width, int &out_height);
+
+    // OpenGL fallback state (render_opengl_win.cpp). Behind a pointer so the D3D11
+    // members above keep their names and this header stays free of GL types; the
+    // struct is defined next to its implementation. Null until
+    // create_render_context_win_gl() and after cleanup_render_resources_win_gl().
+    struct win_gl_state;
+    win_gl_state *win_gl_ = nullptr;
+    static void on_render_update_win_gl(void *context);
+    void signal_render_update_win_gl();
+    void render_thread_loop_win_gl();
+    void cleanup_render_resources_win_gl();
+    // Frees win_gl_ itself (destructor only; the struct is incomplete in this header,
+    // so a plain `delete win_gl_` outside render_opengl_win.cpp would not destruct it).
+    void free_win_gl_state();
+    // The helpers below run on the render thread; *_locked ones assume the state
+    // mutex is held.
+    bool apply_config_win_gl_locked();
+    void publish_state_win_gl_locked();
+    bool render_frame_win_gl(int width, int height);
+    void drain_one_frame_win_gl();
 #endif
 
 #ifdef __APPLE__

--- a/mediamp-mpv/src/cpp/include/png_writer_win.h
+++ b/mediamp-mpv/src/cpp/include/png_writer_win.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#ifndef MEDIAMP_PNG_WRITER_WIN_H
+#define MEDIAMP_PNG_WRITER_WIN_H
+
+#ifdef _WIN32
+
+#include <cstdint>
+#include <vector>
+
+namespace mediampv {
+
+/**
+ * Encodes ARGB_8888 pixels (0xAARRGGBB ints, row-major, top-down — i.e. 32bppBGRA
+ * bytes in little-endian memory) as a PNG file through WIC. Initializes COM on the
+ * calling thread if needed. Shared by the D3D11 and OpenGL-fallback render paths'
+ * save_surface_png, which cannot use mpv's own screenshot pipeline (it cannot convert
+ * hwdec frames without zimg).
+ */
+bool write_argb_png_wic(const char *path, int width, int height,
+                        const std::vector<uint32_t> &pixels);
+
+} // namespace mediampv
+
+#endif // _WIN32
+
+#endif // MEDIAMP_PNG_WRITER_WIN_H

--- a/mediamp-mpv/src/cpp/include/wgl_offscreen_context.h
+++ b/mediamp-mpv/src/cpp/include/wgl_offscreen_context.h
@@ -13,7 +13,10 @@
 
 #include <windows.h>
 
+#include <condition_variable>
+#include <mutex>
 #include <string>
+#include <thread>
 
 namespace mediampv {
 
@@ -29,16 +32,28 @@ namespace mediampv {
  * current. Rendering only ever targets FBOs; the window's framebuffer is never drawn
  * to and never presented.
  *
+ * The window lives on its own message-pump thread, blocked in GetMessageW — NOT on the
+ * render thread. A top-level window whose thread does not retrieve messages deadlocks
+ * the process: window activation/focus bookkeeping (e.g. when the application's main
+ * window closes) makes other in-process threads SendMessage to every top-level window,
+ * and a cross-thread sent message is only delivered while the owning thread is inside
+ * message retrieval. The render thread spends its life in condition waits, mpv
+ * rendering and JNI upcalls, so it must not own a window; the pump thread services it
+ * at all times. Window and GDI operations (creation, pixel format, destruction) all
+ * happen on the pump thread; the render thread only creates, uses and deletes the WGL
+ * context (HDCs and HGLRCs are not thread-affine — a context is simply current on one
+ * thread at a time).
+ *
  * Thread affinity: create() must run on the thread that will use the context (the
  * render thread). It leaves the context current on success. destroy() must run on that
- * same thread — DestroyWindow only works on the creating thread, and wglDeleteContext
- * requires the context to be current nowhere.
+ * same thread.
  */
 class wgl_offscreen_context final {
 public:
     /**
-     * Creates the hidden window, picks a hardware-accelerated (ICD) pixel format,
-     * and creates the context — preferring a 3.3 core profile through
+     * Starts the window thread (which creates the hidden window and picks a
+     * hardware-accelerated (ICD) pixel format), then creates the context on the
+     * calling thread — preferring a 3.3 core profile through
      * wglCreateContextAttribsARB with a legacy wglCreateContext fallback. On success
      * the context is current on the calling thread. Returns null with *error set on
      * failure.
@@ -54,7 +69,10 @@ public:
 
     ~wgl_offscreen_context();
 
-    /** Releases the context from the calling thread and destroys it with its window. */
+    /**
+     * Releases and deletes the context from the calling thread, then closes the
+     * window (on its pump thread, via WM_CLOSE) and joins the window thread.
+     */
     void destroy();
 
     /**
@@ -64,23 +82,28 @@ public:
      */
     void *get_proc_address(const char *name) const;
 
-    /**
-     * Discards queued window messages. The hidden window is top-level, so it receives
-     * posted system broadcasts, and its thread never runs a message pump — the render
-     * loop calls this on every wake-up so the queue cannot grow without bound.
-     */
-    void drain_window_messages();
-
     wgl_offscreen_context(const wgl_offscreen_context &) = delete;
     wgl_offscreen_context &operator=(const wgl_offscreen_context &) = delete;
 
 private:
-    wgl_offscreen_context(HWND window, HDC device_context, HGLRC context)
-        : window_(window), device_context_(device_context), context_(context) {}
+    wgl_offscreen_context() = default;
+    void window_thread_loop();
+    void shutdown_window_thread();
 
+    // Written by the window thread during startup (before the ready handshake),
+    // read-only afterwards.
     HWND window_ = nullptr;
     HDC device_context_ = nullptr;
-    HGLRC context_ = nullptr;
+    std::string window_error_;
+
+    HGLRC context_ = nullptr; // owned by the render thread
+    std::thread window_thread_;
+
+    // Startup handshake: create() waits until the window thread has either published
+    // window_/device_context_ (with the pixel format set) or failed.
+    std::mutex startup_mutex_;
+    std::condition_variable startup_cv_;
+    bool startup_done_ = false;
 };
 
 } // namespace mediampv

--- a/mediamp-mpv/src/cpp/include/wgl_offscreen_context.h
+++ b/mediamp-mpv/src/cpp/include/wgl_offscreen_context.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#ifndef MEDIAMP_WGL_OFFSCREEN_CONTEXT_H
+#define MEDIAMP_WGL_OFFSCREEN_CONTEXT_H
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#include <string>
+
+namespace mediampv {
+
+/**
+ * A private OpenGL context for the Windows OpenGL fallback producer
+ * (render_opengl_win.cpp). Deliberately independent: it shares nothing with Skiko's
+ * context — no wglShareLists, no pixel-format matching — because frames leave this
+ * context through a CPU readback, never as GL objects. That independence is the whole
+ * point of the fallback: it cannot break when the driver refuses cross-context sharing.
+ *
+ * The drawable is a hidden 1x1 CS_OWNDC window: WGL has no universally available
+ * pbuffer/surfaceless equivalent and a context needs a DC to be created and made
+ * current. Rendering only ever targets FBOs; the window's framebuffer is never drawn
+ * to and never presented.
+ *
+ * Thread affinity: create() must run on the thread that will use the context (the
+ * render thread). It leaves the context current on success. destroy() must run on that
+ * same thread — DestroyWindow only works on the creating thread, and wglDeleteContext
+ * requires the context to be current nowhere.
+ */
+class wgl_offscreen_context final {
+public:
+    /**
+     * Creates the hidden window, picks a hardware-accelerated (ICD) pixel format,
+     * and creates the context — preferring a 3.3 core profile through
+     * wglCreateContextAttribsARB with a legacy wglCreateContext fallback. On success
+     * the context is current on the calling thread. Returns null with *error set on
+     * failure.
+     *
+     * ChoosePixelFormat is only trusted when the format it returns is accelerated:
+     * it matches a PIXELFORMATDESCRIPTOR, which cannot express most of what
+     * distinguishes real formats, and it readily returns the Microsoft generic
+     * (software, GL 1.1) format — on which wglCreateContext still succeeds but mpv
+     * cannot run. When that happens the format list is scanned for the first
+     * accelerated RGBA window format instead.
+     */
+    static wgl_offscreen_context *create(std::string *error);
+
+    ~wgl_offscreen_context();
+
+    /** Releases the context from the calling thread and destroys it with its window. */
+    void destroy();
+
+    /**
+     * Resolves a GL entry point for mpv: wglGetProcAddress first (filtering the
+     * non-null "unsupported" sentinels some drivers return), then opengl32.dll for
+     * the OpenGL 1.1 core that wglGetProcAddress deliberately does not resolve.
+     */
+    void *get_proc_address(const char *name) const;
+
+    /**
+     * Discards queued window messages. The hidden window is top-level, so it receives
+     * posted system broadcasts, and its thread never runs a message pump — the render
+     * loop calls this on every wake-up so the queue cannot grow without bound.
+     */
+    void drain_window_messages();
+
+    wgl_offscreen_context(const wgl_offscreen_context &) = delete;
+    wgl_offscreen_context &operator=(const wgl_offscreen_context &) = delete;
+
+private:
+    wgl_offscreen_context(HWND window, HDC device_context, HGLRC context)
+        : window_(window), device_context_(device_context), context_(context) {}
+
+    HWND window_ = nullptr;
+    HDC device_context_ = nullptr;
+    HGLRC context_ = nullptr;
+};
+
+} // namespace mediampv
+
+#endif // _WIN32
+
+#endif // MEDIAMP_WGL_OFFSCREEN_CONTEXT_H

--- a/mediamp-mpv/src/cpp/jni.cpp
+++ b/mediamp-mpv/src/cpp/jni.cpp
@@ -28,16 +28,22 @@ mediampv::mpv_handle_t *get_instance(jlong ptr) {
 }
 
 #if defined(_WIN32) || defined(__APPLE__) || (defined(__linux__) && !defined(__ANDROID__))
-// Shared body of nReadSurfacePixels{D3D11,Macos,OpenGL}: returns the latest frame as an ARGB
-// jintArray and writes [width, height] into dims, or null when no frame is available.
-jintArray read_surface_pixels_to_java(JNIEnv *env, jlong ptr, jintArray dims) {
+// Shared body of nReadSurfacePixels{D3D11,Macos,OpenGL,WindowsOpenGL}: returns the
+// latest frame of [reader] (the platform readback member) as an ARGB jintArray and
+// writes [width, height] into dims, or null when no frame is available.
+using read_surface_pixels_fn =
+    bool (mediampv::mpv_handle_t::*)(std::vector<uint32_t> &, int &, int &);
+
+jintArray read_surface_pixels_to_java(
+    JNIEnv *env, jlong ptr, jintArray dims,
+    read_surface_pixels_fn reader = &mediampv::mpv_handle_t::read_surface_pixels) {
     auto *instance = get_instance(ptr);
     if (!instance || !dims || env->GetArrayLength(dims) < 2) {
         return nullptr;
     }
     std::vector<uint32_t> pixels;
     int width = 0, height = 0;
-    if (!instance->read_surface_pixels(pixels, width, height) || pixels.empty()) {
+    if (!(instance->*reader)(pixels, width, height) || pixels.empty()) {
         return nullptr;
     }
     jintArray result = env->NewIntArray(static_cast<jsize>(pixels.size()));
@@ -128,6 +134,17 @@ extern "C" {
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasD3D11Surface)(JNIEnv *env, jclass clazz, jlong ptr);
 	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngD3D11)(JNIEnv *env, jclass clazz, jlong ptr, jstring path);
 	JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsD3D11)(JNIEnv *env, jclass clazz, jlong ptr, jintArray dims);
+
+	// Windows OpenGL fallback render path (render_opengl_win.cpp), used when Compose
+	// renders with Skiko's OpenGL backend instead of Direct3D.
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nCreateRenderContextWindowsOpenGL)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nDestroyRenderContextWindowsOpenGL)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSetSurfaceConfigWindowsOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jint width, jint height);
+	JNIEXPORT jlong JNICALL FN_DESKTOP(nGetFrameStateWindowsOpenGL)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasWindowsOpenGLSurface)(JNIEnv *env, jclass clazz, jlong ptr);
+	JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngWindowsOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jstring path);
+	JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsWindowsOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jintArray dims);
+	JNIEXPORT jlong JNICALL FN_DESKTOP(nCopyLatestFrameWindowsOpenGL)(JNIEnv *env, jclass clazz, jlong ptr, jlong dest_addr, jint width, jint height);
 #endif
 
 #ifdef __APPLE__
@@ -483,6 +500,59 @@ JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngD3D11)(JNIEnv * env, jclass
 
 JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsD3D11)(JNIEnv * env, jclass clazz, jlong ptr, jintArray dims) {
     return read_surface_pixels_to_java(env, ptr, dims);
+}
+
+// Windows OpenGL fallback render path (render_opengl_win.cpp).
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nCreateRenderContextWindowsOpenGL)(JNIEnv * env, jclass clazz, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance ? instance->create_render_context_win_gl() : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nDestroyRenderContextWindowsOpenGL)(JNIEnv * env, jclass clazz, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance ? instance->destroy_render_context_win_gl() : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nSetSurfaceConfigWindowsOpenGL)(JNIEnv * env, jclass clazz, jlong ptr, jint width, jint height) {
+    auto *instance = get_instance(ptr);
+    return instance ? instance->set_surface_config_win_gl(width, height) : JNI_FALSE;
+}
+
+JNIEXPORT jlong JNICALL FN_DESKTOP(nGetFrameStateWindowsOpenGL)(JNIEnv * env, jclass clazz, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance ? (jlong) instance->get_frame_state_win_gl() : 0;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nHasWindowsOpenGLSurface)(JNIEnv * env, jclass clazz, jlong ptr) {
+    auto *instance = get_instance(ptr);
+    return instance ? instance->has_win_gl_surface() : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL FN_DESKTOP(nSaveSurfacePngWindowsOpenGL)(JNIEnv * env, jclass clazz, jlong ptr, jstring path) {
+    auto *instance = get_instance(ptr);
+    if (!instance) {
+        return JNI_FALSE;
+    }
+    scoped_utf_chars path_chars(env, path);
+    if (!path_chars.valid()) {
+        return JNI_FALSE;
+    }
+    return instance->save_surface_png_win_gl(path_chars.get());
+}
+
+JNIEXPORT jintArray JNICALL FN_DESKTOP(nReadSurfacePixelsWindowsOpenGL)(JNIEnv * env, jclass clazz, jlong ptr, jintArray dims) {
+    return read_surface_pixels_to_java(
+        env, ptr, dims, &mediampv::mpv_handle_t::read_surface_pixels_win_gl);
+}
+
+JNIEXPORT jlong JNICALL FN_DESKTOP(nCopyLatestFrameWindowsOpenGL)(JNIEnv * env, jclass clazz, jlong ptr, jlong dest_addr, jint width, jint height) {
+    auto *instance = get_instance(ptr);
+    if (!instance || dest_addr == 0) {
+        return 0;
+    }
+    return (jlong) instance->copy_latest_frame_win_gl(
+        reinterpret_cast<void *>(static_cast<uintptr_t>(dest_addr)), width, height);
 }
 
 #endif

--- a/mediamp-mpv/src/cpp/mpv_handle_t.cpp
+++ b/mediamp-mpv/src/cpp/mpv_handle_t.cpp
@@ -762,6 +762,12 @@ bool mpv_handle_t::destroy(JNIEnv *env) {
     // when we delete that global ref below.
     cleanup_render_resources();
 #endif
+#ifdef _WIN32
+    // Same reasoning for the OpenGL fallback render thread; at most one of the two
+    // Windows paths ever ran, the other call is a no-op.
+    cleanup_render_resources_win_gl();
+    free_win_gl_state();
+#endif
     clear_event_listener(cleanup_env);
     clear_render_update_listener(cleanup_env);
 #ifdef __ANDROID__

--- a/mediamp-mpv/src/cpp/png_writer_win.cpp
+++ b/mediamp-mpv/src/cpp/png_writer_win.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#ifdef _WIN32
+
+#include "png_writer_win.h"
+
+#include <windows.h>
+#include <wincodec.h>
+
+#include "log.h"
+
+namespace {
+
+template<typename T>
+void safe_release(T *&object) {
+    if (object) {
+        object->Release();
+        object = nullptr;
+    }
+}
+
+struct scoped_co_init final {
+    scoped_co_init() {
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        // RPC_E_CHANGED_MODE: already initialized as STA on this thread; usable as-is.
+        initialized = SUCCEEDED(hr);
+        usable = initialized || hr == RPC_E_CHANGED_MODE;
+    }
+    ~scoped_co_init() {
+        if (initialized) CoUninitialize();
+    }
+    bool initialized = false;
+    bool usable = false;
+};
+
+} // namespace
+
+namespace mediampv {
+
+bool write_argb_png_wic(const char *path, int width, int height,
+                        const std::vector<uint32_t> &pixels) {
+    if (!path || width <= 0 || height <= 0 ||
+        pixels.size() < static_cast<size_t>(width) * height) {
+        return false;
+    }
+    scoped_co_init com;
+    if (!com.usable) {
+        LOGE("CoInitializeEx failed");
+        return false;
+    }
+    bool ok = false;
+    IWICImagingFactory *factory = nullptr;
+    IWICStream *stream = nullptr;
+    IWICBitmapEncoder *encoder = nullptr;
+    IWICBitmapFrameEncode *frame = nullptr;
+    do {
+        if (FAILED(CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                                    __uuidof(IWICImagingFactory),
+                                    reinterpret_cast<void **>(&factory)))) break;
+        if (FAILED(factory->CreateStream(&stream))) break;
+        int wide_length = MultiByteToWideChar(CP_UTF8, 0, path, -1, nullptr, 0);
+        std::vector<wchar_t> wide_path((size_t) (wide_length > 0 ? wide_length : 1));
+        MultiByteToWideChar(CP_UTF8, 0, path, -1, wide_path.data(), wide_length);
+        if (FAILED(stream->InitializeFromFilename(wide_path.data(), GENERIC_WRITE))) break;
+        if (FAILED(factory->CreateEncoder(GUID_ContainerFormatPng, nullptr, &encoder))) break;
+        if (FAILED(encoder->Initialize(stream, WICBitmapEncoderNoCache))) break;
+        if (FAILED(encoder->CreateNewFrame(&frame, nullptr))) break;
+        if (FAILED(frame->Initialize(nullptr))) break;
+        if (FAILED(frame->SetSize((UINT) width, (UINT) height))) break;
+        // ARGB ints are BGRA bytes in little-endian memory.
+        WICPixelFormatGUID format = GUID_WICPixelFormat32bppBGRA;
+        if (FAILED(frame->SetPixelFormat(&format))) break;
+        if (FAILED(frame->WritePixels(
+                (UINT) height, (UINT) width * 4, (UINT) (pixels.size() * 4),
+                reinterpret_cast<BYTE *>(const_cast<uint32_t *>(pixels.data()))))) break;
+        if (FAILED(frame->Commit())) break;
+        if (FAILED(encoder->Commit())) break;
+        ok = true;
+    } while (false);
+    safe_release(frame);
+    safe_release(encoder);
+    safe_release(stream);
+    safe_release(factory);
+    return ok;
+}
+
+} // namespace mediampv
+
+#endif // _WIN32

--- a/mediamp-mpv/src/cpp/render_d3d11.cpp
+++ b/mediamp-mpv/src/cpp/render_d3d11.cpp
@@ -32,7 +32,6 @@
 #include <d3d11_4.h>
 #include <d3d12.h>
 #include <dxgi1_2.h>
-#include <wincodec.h>
 
 #include <cstdint>
 #include <cstring>
@@ -45,6 +44,7 @@
 
 #include "mpv_handle_t.h"
 #include "log.h"
+#include "png_writer_win.h"
 
 namespace {
 
@@ -124,20 +124,6 @@ ID3D12Device *open_skia_d3d12_device(const void *instance_handle, int64_t skiko_
     }
     return device;  // AddRef'd by QueryInterface; caller owns.
 }
-
-struct scoped_co_init final {
-    scoped_co_init() {
-        HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-        // RPC_E_CHANGED_MODE: already initialized as STA on this thread; usable as-is.
-        initialized = SUCCEEDED(hr);
-        usable = initialized || hr == RPC_E_CHANGED_MODE;
-    }
-    ~scoped_co_init() {
-        if (initialized) CoUninitialize();
-    }
-    bool initialized = false;
-    bool usable = false;
-};
 
 }  // namespace
 
@@ -682,10 +668,10 @@ bool mpv_handle_t::read_surface_pixels(
     return read_frame_argb_locked(out_pixels, out_width, out_height);
 }
 
-// Writes the latest rendered frame as PNG via the staging-texture readback and WIC.
-// Independent of mpv's screenshot pipeline, which cannot convert hwdec (d3d11va)
-// frames without zimg. render_mutex_ is only held for the readback; the encode works
-// on our own copy.
+// Writes the latest rendered frame as PNG via the staging-texture readback and WIC
+// (png_writer_win.cpp). Independent of mpv's screenshot pipeline, which cannot convert
+// hwdec (d3d11va) frames without zimg. render_mutex_ is only held for the readback;
+// the encode works on our own copy.
 bool mpv_handle_t::save_surface_png(const char *path) {
     if (!path) return false;
     std::vector<uint32_t> pixels;
@@ -695,44 +681,7 @@ bool mpv_handle_t::save_surface_png(const char *path) {
         if (!read_frame_argb_locked(pixels, width, height)) return false;
     }
 
-    scoped_co_init com;
-    if (!com.usable) {
-        LOG(this, LOG_LEVEL_ERROR, "CoInitializeEx failed");
-        return false;
-    }
-    bool ok = false;
-    IWICImagingFactory *factory = nullptr;
-    IWICStream *stream = nullptr;
-    IWICBitmapEncoder *encoder = nullptr;
-    IWICBitmapFrameEncode *frame = nullptr;
-    do {
-        if (FAILED(CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
-                                    __uuidof(IWICImagingFactory),
-                                    reinterpret_cast<void **>(&factory)))) break;
-        if (FAILED(factory->CreateStream(&stream))) break;
-        int wide_length = MultiByteToWideChar(CP_UTF8, 0, path, -1, nullptr, 0);
-        std::vector<wchar_t> wide_path((size_t) (wide_length > 0 ? wide_length : 1));
-        MultiByteToWideChar(CP_UTF8, 0, path, -1, wide_path.data(), wide_length);
-        if (FAILED(stream->InitializeFromFilename(wide_path.data(), GENERIC_WRITE))) break;
-        if (FAILED(factory->CreateEncoder(GUID_ContainerFormatPng, nullptr, &encoder))) break;
-        if (FAILED(encoder->Initialize(stream, WICBitmapEncoderNoCache))) break;
-        if (FAILED(encoder->CreateNewFrame(&frame, nullptr))) break;
-        if (FAILED(frame->Initialize(nullptr))) break;
-        if (FAILED(frame->SetSize((UINT) width, (UINT) height))) break;
-        // ARGB ints are BGRA bytes in little-endian memory.
-        WICPixelFormatGUID format = GUID_WICPixelFormat32bppBGRA;
-        if (FAILED(frame->SetPixelFormat(&format))) break;
-        if (FAILED(frame->WritePixels(
-                (UINT) height, (UINT) width * 4, (UINT) (pixels.size() * 4),
-                reinterpret_cast<BYTE *>(pixels.data())))) break;
-        if (FAILED(frame->Commit())) break;
-        if (FAILED(encoder->Commit())) break;
-        ok = true;
-    } while (false);
-    safe_release(frame);
-    safe_release(encoder);
-    safe_release(stream);
-    safe_release(factory);
+    const bool ok = write_argb_png_wic(path, width, height, pixels);
     if (!ok) LOG(this, LOG_LEVEL_ERROR, "save_surface_png failed for %s", path);
     return ok;
 }

--- a/mediamp-mpv/src/cpp/render_opengl_win.cpp
+++ b/mediamp-mpv/src/cpp/render_opengl_win.cpp
@@ -199,7 +199,6 @@ void mpv_handle_t::free_win_gl_state() {
 void mpv_handle_t::cleanup_render_resources_win_gl() {
     auto *s = win_gl_;
     if (!s || !s->thread) return;
-    LOGI("OpenGL fallback teardown: stopping the render thread");
     {
         std::lock_guard<std::mutex> lock(s->mutex);
         s->quit = true;
@@ -208,7 +207,6 @@ void mpv_handle_t::cleanup_render_resources_win_gl() {
     if (s->thread->joinable()) s->thread->join();
     delete s->thread;
     s->thread = nullptr;
-    LOGI("OpenGL fallback teardown: render thread joined");
     // The state struct itself stays alive for the handle's lifetime (freed in the
     // destructor): consumers may still be polling get_frame_state_win_gl or
     // copy_latest_frame_win_gl concurrently with this teardown, and they check
@@ -430,7 +428,6 @@ void mpv_handle_t::render_thread_loop_win_gl() {
     // Outside the lock: freeing the render context synchronizes with an in-flight
     // update callback, and that callback takes the state mutex.
     if (s->render_context) {
-        LOGI("OpenGL fallback teardown: freeing the mpv render context");
         mpv_render_context_set_update_callback(s->render_context, nullptr, nullptr);
         mpv_render_context_free(s->render_context);
         s->render_context = nullptr;
@@ -438,7 +435,6 @@ void mpv_handle_t::render_thread_loop_win_gl() {
     s->gl->destroy();
     delete s->gl;
     s->gl = nullptr;
-    LOGI("OpenGL fallback teardown: WGL context and window destroyed");
     if (attached) jvm_->DetachCurrentThread();
 }
 

--- a/mediamp-mpv/src/cpp/render_opengl_win.cpp
+++ b/mediamp-mpv/src/cpp/render_opengl_win.cpp
@@ -130,6 +130,7 @@ void mpv_handle_t::free_win_gl_state() {
 void mpv_handle_t::cleanup_render_resources_win_gl() {
     auto *s = win_gl_;
     if (!s || !s->thread) return;
+    LOGI("OpenGL fallback teardown: stopping the render thread");
     {
         std::lock_guard<std::mutex> lock(s->mutex);
         s->quit = true;
@@ -138,6 +139,7 @@ void mpv_handle_t::cleanup_render_resources_win_gl() {
     if (s->thread->joinable()) s->thread->join();
     delete s->thread;
     s->thread = nullptr;
+    LOGI("OpenGL fallback teardown: render thread joined");
     // The state struct itself stays alive for the handle's lifetime (freed in the
     // destructor): consumers may still be polling get_frame_state_win_gl or
     // copy_latest_frame_win_gl concurrently with this teardown, and they check
@@ -237,10 +239,6 @@ void mpv_handle_t::render_thread_loop_win_gl() {
         s->cv.wait(lock, [s] { return s->quit || s->render_pending || s->config_pending; });
         if (s->quit) break;
 
-        // The hidden window's thread never pumps; keep its queue empty (posted system
-        // broadcasts reach top-level windows even when hidden).
-        s->gl->drain_window_messages();
-
         bool configured = false;
         if (s->config_pending) {
             s->config_pending = false;
@@ -295,6 +293,7 @@ void mpv_handle_t::render_thread_loop_win_gl() {
     // Outside the lock: freeing the render context synchronizes with an in-flight
     // update callback, and that callback takes the state mutex.
     if (s->render_context) {
+        LOGI("OpenGL fallback teardown: freeing the mpv render context");
         mpv_render_context_set_update_callback(s->render_context, nullptr, nullptr);
         mpv_render_context_free(s->render_context);
         s->render_context = nullptr;
@@ -302,6 +301,7 @@ void mpv_handle_t::render_thread_loop_win_gl() {
     s->gl->destroy();
     delete s->gl;
     s->gl = nullptr;
+    LOGI("OpenGL fallback teardown: WGL context and window destroyed");
     if (attached) jvm_->DetachCurrentThread();
 }
 

--- a/mediamp-mpv/src/cpp/render_opengl_win.cpp
+++ b/mediamp-mpv/src/cpp/render_opengl_win.cpp
@@ -35,6 +35,7 @@
 #include <mpv/render.h>
 #include <mpv/render_gl.h>
 
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <mutex>
@@ -83,9 +84,11 @@ struct mpv_handle_t::win_gl_state final {
     uint64_t serial = 0;
     std::atomic<uint64_t> frame_state{0xFull << 44}; // "no frame" sentinel
 
-    // Requests to the render thread; guarded by mutex.
+    // Requests to the render thread; guarded by mutex. The serial pair lets a
+    // deactivation request wait until the render thread has actually applied it.
     bool config_pending = false;
     int pending_width = 0, pending_height = 0;
+    uint64_t config_request_serial = 0, config_applied_serial = 0;
     bool render_pending = false;
     bool quit = false;
     bool initialized = false, initialize_ok = false;
@@ -149,13 +152,30 @@ void mpv_handle_t::cleanup_render_resources_win_gl() {
 bool mpv_handle_t::set_surface_config_win_gl(int width, int height) {
     auto *s = win_gl_;
     if (!s || !s->thread) return false;
+    uint64_t request;
     {
         std::lock_guard<std::mutex> lock(s->mutex);
         s->pending_width = width;
         s->pending_height = height;
         s->config_pending = true; // newest request replaces an unprocessed resize
+        request = ++s->config_request_serial;
     }
     s->cv.notify_all();
+    if (width > 0 && height > 0) return true;
+    // Deactivation is synchronous: the consumer releases its Skia GPU objects right
+    // after this call, and destroying them on Skiko's GL context while this path's
+    // producer context is still actively rendering can block in the driver's
+    // cross-context synchronization. Wait until the render thread has dropped the FBO
+    // and parked (it then only drains frames without touching GL). Bounded: the
+    // thread is at worst one frame render away, and the timeout means a wedged
+    // producer degrades to the old behavior instead of hanging the caller.
+    std::unique_lock<std::mutex> lock(s->mutex);
+    const bool applied = s->cv.wait_for(lock, std::chrono::seconds(1), [s, request] {
+        return s->quit || s->config_applied_serial >= request;
+    });
+    if (!applied) {
+        LOGW("OpenGL fallback surface deactivation was not acknowledged within 1s");
+    }
     return true;
 }
 
@@ -243,6 +263,10 @@ void mpv_handle_t::render_thread_loop_win_gl() {
         if (s->config_pending) {
             s->config_pending = false;
             configured = apply_config_win_gl_locked();
+            // Acknowledges every request posted so far (requests coalesce; the apply
+            // above used the latest values). Deactivation waits on this.
+            s->config_applied_serial = s->config_request_serial;
+            s->cv.notify_all();
         }
         const bool want_render = s->render_pending;
         s->render_pending = false;

--- a/mediamp-mpv/src/cpp/render_opengl_win.cpp
+++ b/mediamp-mpv/src/cpp/render_opengl_win.cpp
@@ -20,6 +20,13 @@
 // matching against Skiko's drawable, no cross-context object lifetime rules; exactly
 // the parts that make context sharing fragile across drivers.
 //
+// Two measures keep the round trip cheap: the render target is clamped to the video's
+// display size (rendering a 1080p video at 4K-window size would move 4x the bytes for
+// pixels Skia can scale up during the draw), and the readback streams through two
+// alternating pixel-pack buffers, so glReadPixels never synchronizes — a frame is
+// mapped out one iteration after it was queued (one frame of extra latency; an idle
+// grace period delivers the last frame after a pause or EOF).
+//
 // Threading model: the render thread exclusively owns the WGL context, the FBO and the
 // scratch buffer, and is the only thread that renders. Requests (resize, mpv's update
 // callback) are flags posted under the state mutex. Consumers read the packed frame
@@ -55,6 +62,50 @@ void *win_gl_get_proc_address(void *ctx, const char *name) {
     return context ? context->get_proc_address(name) : nullptr;
 }
 
+// mpv's display size of the current video track (dwidth/dheight: after aspect
+// correction and rotation), or 0x0 while no video is loaded. Must be called WITHOUT
+// the state mutex held: mpv may hold internal locks while invoking the update
+// callback, which takes that mutex.
+void query_video_display_size(mpv_handle *handle, int *out_width, int *out_height) {
+    int64_t width = 0, height = 0;
+    if (!handle || mpv_get_property(handle, "dwidth", MPV_FORMAT_INT64, &width) < 0) width = 0;
+    if (!handle || mpv_get_property(handle, "dheight", MPV_FORMAT_INT64, &height) < 0) height = 0;
+    // The packed frame state carries 14-bit dimensions.
+    *out_width = static_cast<int>(width < 0 ? 0 : (width > 0x3FFF ? 0x3FFF : width));
+    *out_height = static_cast<int>(height < 0 ? 0 : (height > 0x3FFF ? 0x3FFF : height));
+}
+
+// The largest aspect-correct size that fits the consumer's request without exceeding
+// the video's display size. Every readback byte scales with this area, so rendering a
+// 1080p video into a 4K-window-sized target would quadruple the GPU<->CPU traffic for
+// pixels Skia can scale up during the draw instead. Falls back to the request while
+// the video size is unknown (before the first reconfig). mpv letterboxes inside
+// whatever size it gets, and the aspect-exact target also keeps the bars out of the
+// readback entirely (the Compose draw letterboxes the image itself).
+void compute_target_size(
+    int requested_width, int requested_height, int video_width, int video_height,
+    int *out_width, int *out_height) {
+    if (requested_width <= 0 || requested_height <= 0) {
+        *out_width = 0;
+        *out_height = 0;
+        return;
+    }
+    if (video_width <= 0 || video_height <= 0) {
+        *out_width = requested_width;
+        *out_height = requested_height;
+        return;
+    }
+    double scale = 1.0;
+    const double fit_width = static_cast<double>(requested_width) / video_width;
+    const double fit_height = static_cast<double>(requested_height) / video_height;
+    if (fit_width < scale) scale = fit_width;
+    if (fit_height < scale) scale = fit_height;
+    const auto width = static_cast<int>(video_width * scale + 0.5);
+    const auto height = static_cast<int>(video_height * scale + 0.5);
+    *out_width = width > 0 ? width : 1;
+    *out_height = height > 0 ? height : 1;
+}
+
 // glGetError pops one error from a queue that anyone (including mpv's renderer) may
 // have left non-empty; drain it before a checked sequence so a stale error cannot
 // fail an unrelated operation.
@@ -73,11 +124,26 @@ struct mpv_handle_t::win_gl_state final {
     wgl_offscreen_context *gl = nullptr;
     GLuint fbo = 0, texture = 0;
 
+    // Double-buffered PBO streaming readback; render-thread-only. Frame N's
+    // glReadPixels lands asynchronously in pbos[pbo_write] while frame N-1 is mapped
+    // out of the other buffer — one frame of extra latency instead of a full GPU sync
+    // per frame. pbo_active falls back to synchronous readback into scratch when
+    // buffer objects are unavailable; sync_frame_* then marks the scratch content.
+    GLuint pbos[2] = {0, 0};
+    bool pbo_pending[2] = {false, false};
+    int pbo_width[2] = {0, 0}, pbo_height[2] = {0, 0};
+    int pbo_write = 0;
+    bool pbo_active = false;
+    bool sync_frame_ready = false;
+    int sync_frame_width = 0, sync_frame_height = 0;
+
     // Guarded by mutex, except scratch: only the render thread touches scratch, and
     // the scratch/latest swap happens under the mutex, so a consumer copying latest
     // never observes a buffer the render thread is writing into.
     std::vector<uint8_t> scratch, latest; // RGBA8, glReadPixels bottom-up row order
-    int width = 0, height = 0;            // active surface size (0 = deactivated)
+    int width = 0, height = 0;            // active render-target size (0 = none)
+    int requested_width = 0, requested_height = 0; // consumer request (composable size)
+    int video_width = 0, video_height = 0;         // cached mpv dwidth/dheight
     int latest_width = 0, latest_height = 0;
     bool has_frame = false;
     uint32_t generation = 0;
@@ -256,8 +322,42 @@ void mpv_handle_t::render_thread_loop_win_gl() {
 
     std::unique_lock<std::mutex> lock(s->mutex);
     while (!s->quit) {
-        s->cv.wait(lock, [s] { return s->quit || s->render_pending || s->config_pending; });
+        if (s->pbo_pending[0] || s->pbo_pending[1]) {
+            // A readback is still in flight. Give the DMA transfer the time until the
+            // next frame arrives; if none does (pause, EOF), deliver the frame anyway
+            // after a short grace so the last rendered frame never gets stuck in the
+            // PBO. Mapping then cannot stall anything: the thread is idle.
+            s->cv.wait_for(lock, std::chrono::milliseconds(50), [s] {
+                return s->quit || s->render_pending || s->config_pending;
+            });
+            if (!s->quit && !s->render_pending && !s->config_pending) {
+                lock.unlock();
+                int ready_width = 0, ready_height = 0;
+                const bool ready = collect_ready_frame_win_gl(&ready_width, &ready_height, true);
+                lock.lock();
+                if (ready) {
+                    publish_collected_frame_win_gl_locked(ready_width, ready_height);
+                    lock.unlock();
+                    notify_render_update();
+                    lock.lock();
+                }
+                continue;
+            }
+        } else {
+            s->cv.wait(lock, [s] { return s->quit || s->render_pending || s->config_pending; });
+        }
         if (s->quit) break;
+
+        // Refresh the cached video display size before acting on the wake-up: both
+        // the config target and the per-frame drift check depend on it, and mpv must
+        // not be queried while the state mutex is held (its update callback takes
+        // this mutex, possibly under mpv-internal locks).
+        lock.unlock();
+        int video_width = 0, video_height = 0;
+        query_video_display_size(handle_, &video_width, &video_height);
+        lock.lock();
+        s->video_width = video_width;
+        s->video_height = video_height;
 
         bool configured = false;
         if (s->config_pending) {
@@ -285,32 +385,45 @@ void mpv_handle_t::render_thread_loop_win_gl() {
         // A fresh config renders even without a new mpv frame so a paused video is
         // re-rendered at the new size.
         if (!has_new_frame && !configured) continue;
+        // The video size can change under an unchanged surface request (track
+        // switch, rotation); keep the target clamped to it.
+        {
+            int target_width = 0, target_height = 0;
+            compute_target_size(
+                s->requested_width, s->requested_height,
+                s->video_width, s->video_height, &target_width, &target_height);
+            if (target_width > 0 && (target_width != s->width || target_height != s->height)) {
+                if (!allocate_target_win_gl_locked(target_width, target_height)) continue;
+                configured = true;
+            }
+        }
         const int width = s->width, height = s->height;
         lock.unlock();
+        int ready_width = 0, ready_height = 0;
+        // Collect BEFORE queuing the next readback: the pending PBO was filled during
+        // the previous iteration, so its DMA has had a full frame time — the map does
+        // not stall. Collecting after would map the buffer glReadPixels just wrote,
+        // which is the synchronous behavior the PBOs exist to avoid.
+        bool ready = collect_ready_frame_win_gl(&ready_width, &ready_height, true);
         const bool rendered = render_frame_win_gl(width, height);
+        if (!ready && rendered) {
+            // Zero-latency delivery for the synchronous fallback; a no-op in PBO mode
+            // (the frame just queued stays pending until the next iteration).
+            ready = collect_ready_frame_win_gl(&ready_width, &ready_height, false);
+        }
         lock.lock();
         // The surface cannot have been reconfigured meanwhile: only this thread
         // applies config changes.
-        if (rendered) {
-            std::swap(s->scratch, s->latest);
-            s->latest_width = width;
-            s->latest_height = height;
-            s->has_frame = true;
-            ++s->serial;
-            publish_state_win_gl_locked();
+        if (ready) {
+            publish_collected_frame_win_gl_locked(ready_width, ready_height);
             lock.unlock();
             notify_render_update(); // release-store has completed before this JNI callback
             lock.lock();
         }
     }
     // Teardown in the owner thread while the WGL context is current.
-    if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
-    if (s->texture) glDeleteTextures(1, &s->texture);
-    s->fbo = 0;
-    s->texture = 0;
-    s->width = s->height = 0;
-    s->has_frame = false;
-    s->latest_width = s->latest_height = 0;
+    destroy_target_win_gl_locked();
+    s->requested_width = s->requested_height = 0;
     ++s->generation;
     publish_state_win_gl_locked();
     lock.unlock();
@@ -331,15 +444,11 @@ void mpv_handle_t::render_thread_loop_win_gl() {
 
 bool mpv_handle_t::apply_config_win_gl_locked() {
     auto *s = win_gl_;
-    const int width = s->pending_width, height = s->pending_height;
-    if (width <= 0 || height <= 0) {
-        if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
-        if (s->texture) glDeleteTextures(1, &s->texture);
-        s->fbo = 0;
-        s->texture = 0;
-        s->width = s->height = 0;
-        s->has_frame = false;
-        s->latest_width = s->latest_height = 0;
+    s->requested_width = s->pending_width;
+    s->requested_height = s->pending_height;
+    if (s->requested_width <= 0 || s->requested_height <= 0) {
+        s->requested_width = s->requested_height = 0;
+        destroy_target_win_gl_locked();
         // An inactive surface holds no frame; actually return the buffer memory
         // (clear() would keep the capacity).
         std::vector<uint8_t>().swap(s->scratch);
@@ -348,11 +457,35 @@ bool mpv_handle_t::apply_config_win_gl_locked() {
         publish_state_win_gl_locked();
         return false;
     }
-    if (s->fbo && width == s->width && height == s->height) return false;
+    int target_width = 0, target_height = 0;
+    compute_target_size(
+        s->requested_width, s->requested_height,
+        s->video_width, s->video_height, &target_width, &target_height);
+    if (s->fbo && target_width == s->width && target_height == s->height) return false;
+    return allocate_target_win_gl_locked(target_width, target_height);
+}
+
+// Frees the FBO, its texture, and the readback PBOs; resets the published frame.
+void mpv_handle_t::destroy_target_win_gl_locked() {
+    auto *s = win_gl_;
     if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
     if (s->texture) glDeleteTextures(1, &s->texture);
     s->fbo = 0;
     s->texture = 0;
+    if (s->pbos[0] || s->pbos[1]) gl::delete_buffers(2, s->pbos);
+    s->pbos[0] = s->pbos[1] = 0;
+    s->pbo_pending[0] = s->pbo_pending[1] = false;
+    s->pbo_write = 0;
+    s->pbo_active = false;
+    s->sync_frame_ready = false;
+    s->width = s->height = 0;
+    s->has_frame = false;
+    s->latest_width = s->latest_height = 0;
+}
+
+bool mpv_handle_t::allocate_target_win_gl_locked(int width, int height) {
+    auto *s = win_gl_;
+    destroy_target_win_gl_locked();
 
     drain_gl_errors();
     glGenTextures(1, &s->texture);
@@ -370,16 +503,32 @@ bool mpv_handle_t::apply_config_win_gl_locked() {
     gl::bind_framebuffer(GL_FRAMEBUFFER, 0);
     if (status != GL_FRAMEBUFFER_COMPLETE || glGetError() != GL_NO_ERROR) {
         LOGE("OpenGL fallback FBO incomplete (%dx%d): 0x%x", width, height, status);
-        if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
-        if (s->texture) glDeleteTextures(1, &s->texture);
-        s->fbo = 0;
-        s->texture = 0;
-        s->width = s->height = 0;
-        s->has_frame = false;
-        s->latest_width = s->latest_height = 0;
+        destroy_target_win_gl_locked();
         ++s->generation;
         publish_state_win_gl_locked();
         return false;
+    }
+
+    // Streaming readback buffers. Optional: without them the render path falls back
+    // to a synchronous glReadPixels.
+    if (gl::buffer_objects_available()) {
+        const auto size = static_cast<GLsizeiptr>(static_cast<size_t>(width) * height * 4);
+        gl::gen_buffers(2, s->pbos);
+        bool ok = s->pbos[0] != 0 && s->pbos[1] != 0;
+        for (int i = 0; ok && i < 2; ++i) {
+            gl::bind_buffer(GL_PIXEL_PACK_BUFFER, s->pbos[i]);
+            gl::buffer_data(GL_PIXEL_PACK_BUFFER, size, nullptr, GL_STREAM_READ);
+        }
+        gl::bind_buffer(GL_PIXEL_PACK_BUFFER, 0);
+        ok = ok && glGetError() == GL_NO_ERROR;
+        if (!ok) {
+            LOGW("PBO allocation failed; falling back to synchronous readback");
+            if (s->pbos[0] || s->pbos[1]) gl::delete_buffers(2, s->pbos);
+            s->pbos[0] = s->pbos[1] = 0;
+        }
+        s->pbo_active = ok;
+    } else {
+        s->pbo_active = false;
     }
 
     s->width = width;
@@ -389,7 +538,10 @@ bool mpv_handle_t::apply_config_win_gl_locked() {
     s->has_frame = false;
     ++s->generation;
     publish_state_win_gl_locked();
-    LOGI("OpenGL fallback target allocated %dx%d generation=%u", width, height, s->generation);
+    LOGI("OpenGL fallback target allocated %dx%d (requested %dx%d, video %dx%d, %s) generation=%u",
+         width, height, s->requested_width, s->requested_height,
+         s->video_width, s->video_height,
+         s->pbo_active ? "async PBO readback" : "sync readback", s->generation);
     return true;
 }
 
@@ -402,6 +554,17 @@ void mpv_handle_t::publish_state_win_gl_locked() {
         (static_cast<uint64_t>(s->latest_width & 0x3FFF) << 30) |
         (static_cast<uint64_t>(s->latest_height & 0x3FFF) << 16) |
         (s->serial & 0xFFFFu), std::memory_order_release);
+}
+
+// scratch holds a collected frame of the given size; make it the published latest.
+void mpv_handle_t::publish_collected_frame_win_gl_locked(int width, int height) {
+    auto *s = win_gl_;
+    std::swap(s->scratch, s->latest);
+    s->latest_width = width;
+    s->latest_height = height;
+    s->has_frame = true;
+    ++s->serial;
+    publish_state_win_gl_locked();
 }
 
 bool mpv_handle_t::render_frame_win_gl(int width, int height) {
@@ -426,14 +589,64 @@ bool mpv_handle_t::render_frame_win_gl(int width, int height) {
     glClearColor(0.f, 0.f, 0.f, 1.f);
     glClear(GL_COLOR_BUFFER_BIT);
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-    // Only the render thread touches scratch; the swap into latest happens under the
-    // state mutex after this returns. glReadPixels is the synchronization point with
-    // the GPU (no glFinish needed).
-    s->scratch.resize(static_cast<size_t>(width) * height * 4);
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, s->scratch.data());
+    if (s->pbo_active) {
+        // Asynchronous: the driver DMAs the pixels into the buffer while we return;
+        // the frame is mapped out one iteration later (collect_ready_frame).
+        gl::bind_buffer(GL_PIXEL_PACK_BUFFER, s->pbos[s->pbo_write]);
+        glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+        gl::bind_buffer(GL_PIXEL_PACK_BUFFER, 0);
+        s->pbo_pending[s->pbo_write] = true;
+        s->pbo_width[s->pbo_write] = width;
+        s->pbo_height[s->pbo_write] = height;
+        s->pbo_write ^= 1;
+    } else {
+        // Only the render thread touches scratch; the swap into latest happens under
+        // the state mutex after this returns. glReadPixels is the synchronization
+        // point with the GPU.
+        s->scratch.resize(static_cast<size_t>(width) * height * 4);
+        glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, s->scratch.data());
+        s->sync_frame_ready = true;
+        s->sync_frame_width = width;
+        s->sync_frame_height = height;
+    }
     gl::bind_framebuffer(GL_FRAMEBUFFER, 0);
     return result >= 0 && glGetError() == GL_NO_ERROR;
+}
+
+bool mpv_handle_t::collect_ready_frame_win_gl(int *out_width, int *out_height, bool include_pbos) {
+    auto *s = win_gl_;
+    if (s->sync_frame_ready) {
+        s->sync_frame_ready = false;
+        *out_width = s->sync_frame_width;
+        *out_height = s->sync_frame_height;
+        return true;
+    }
+    if (!include_pbos) return false;
+    // Oldest pending first: after render_frame flipped pbo_write, the buffer it
+    // points at is the one queued a frame ago (or longer).
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        const int index = (s->pbo_write + attempt) % 2;
+        if (!s->pbo_pending[index]) continue;
+        s->pbo_pending[index] = false;
+        const int width = s->pbo_width[index], height = s->pbo_height[index];
+        const size_t size = static_cast<size_t>(width) * height * 4;
+        gl::bind_buffer(GL_PIXEL_PACK_BUFFER, s->pbos[index]);
+        void *mapped = gl::map_buffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+        if (!mapped) {
+            gl::bind_buffer(GL_PIXEL_PACK_BUFFER, 0);
+            drain_gl_errors();
+            continue;
+        }
+        s->scratch.resize(size);
+        std::memcpy(s->scratch.data(), mapped, size);
+        gl::unmap_buffer(GL_PIXEL_PACK_BUFFER);
+        gl::bind_buffer(GL_PIXEL_PACK_BUFFER, 0);
+        *out_width = width;
+        *out_height = height;
+        return true;
+    }
+    return false;
 }
 
 void mpv_handle_t::drain_one_frame_win_gl() {

--- a/mediamp-mpv/src/cpp/render_opengl_win.cpp
+++ b/mediamp-mpv/src/cpp/render_opengl_win.cpp
@@ -1,0 +1,482 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+// Windows OpenGL fallback render path, used when Compose renders with Skiko's OpenGL
+// backend (SKIKO_RENDER_API=OPENGL) instead of the Direct3D default — Skia then has no
+// D3D12 device, so the D3D11 shared-texture path (render_d3d11.cpp) cannot exist.
+//
+// This is deliberately the simplest correct path, not the fastest one: a dedicated
+// render thread drives mpv through the libmpv OpenGL render API on a private offscreen
+// WGL context that shares nothing with Skiko, renders into a single FBO, and reads
+// every frame back to CPU memory (double-buffered: the thread fills a scratch buffer
+// while unlocked, then swaps it in under the state mutex). The consumer copies the
+// latest frame into a Skia bitmap during a Compose draw and uploads it there. One
+// GPU->CPU->GPU round trip per frame by design — no wglShareLists, no pixel-format
+// matching against Skiko's drawable, no cross-context object lifetime rules; exactly
+// the parts that make context sharing fragile across drivers.
+//
+// Threading model: the render thread exclusively owns the WGL context, the FBO and the
+// scratch buffer, and is the only thread that renders. Requests (resize, mpv's update
+// callback) are flags posted under the state mutex. Consumers read the packed frame
+// state (atomic) and copy the latest CPU frame under the mutex; the mutex is never held
+// across mpv rendering or the glReadPixels, so a consumer copy can only ever wait for a
+// buffer swap, not for a frame.
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#include <mpv/client.h>
+#include <mpv/render.h>
+#include <mpv/render_gl.h>
+
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "gl_functions_win.h"
+#include "log.h"
+#include "mpv_handle_t.h"
+#include "png_writer_win.h"
+#include "wgl_offscreen_context.h"
+
+namespace {
+
+void *win_gl_get_proc_address(void *ctx, const char *name) {
+    auto *context = static_cast<mediampv::wgl_offscreen_context *>(ctx);
+    return context ? context->get_proc_address(name) : nullptr;
+}
+
+// glGetError pops one error from a queue that anyone (including mpv's renderer) may
+// have left non-empty; drain it before a checked sequence so a stale error cannot
+// fail an unrelated operation.
+void drain_gl_errors() {
+    while (glGetError() != GL_NO_ERROR) {
+    }
+}
+
+} // namespace
+
+namespace mediampv {
+
+struct mpv_handle_t::win_gl_state final {
+    // Owned by the render thread between initialization and thread exit.
+    mpv_render_context *render_context = nullptr;
+    wgl_offscreen_context *gl = nullptr;
+    GLuint fbo = 0, texture = 0;
+
+    // Guarded by mutex, except scratch: only the render thread touches scratch, and
+    // the scratch/latest swap happens under the mutex, so a consumer copying latest
+    // never observes a buffer the render thread is writing into.
+    std::vector<uint8_t> scratch, latest; // RGBA8, glReadPixels bottom-up row order
+    int width = 0, height = 0;            // active surface size (0 = deactivated)
+    int latest_width = 0, latest_height = 0;
+    bool has_frame = false;
+    uint32_t generation = 0;
+    uint64_t serial = 0;
+    std::atomic<uint64_t> frame_state{0xFull << 44}; // "no frame" sentinel
+
+    // Requests to the render thread; guarded by mutex.
+    bool config_pending = false;
+    int pending_width = 0, pending_height = 0;
+    bool render_pending = false;
+    bool quit = false;
+    bool initialized = false, initialize_ok = false;
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::thread *thread = nullptr;
+};
+
+bool mpv_handle_t::create_render_context_win_gl() {
+    if (!handle_) {
+        LOGE("create_render_context_win_gl: mpv handle is null");
+        return false;
+    }
+    if (win_gl_ && win_gl_->thread) return true;
+    if (!win_gl_) win_gl_ = new win_gl_state();
+    auto *s = win_gl_;
+    {
+        std::lock_guard<std::mutex> lock(s->mutex);
+        s->quit = false;
+        s->initialized = false;
+        s->initialize_ok = false;
+    }
+    s->thread = new std::thread([this] { render_thread_loop_win_gl(); });
+    std::unique_lock<std::mutex> lock(s->mutex);
+    s->cv.wait(lock, [s] { return s->initialized; });
+    const bool initialized = s->initialize_ok;
+    lock.unlock();
+    if (!initialized) cleanup_render_resources_win_gl();
+    return initialized;
+}
+
+bool mpv_handle_t::destroy_render_context_win_gl() {
+    cleanup_render_resources_win_gl();
+    return true;
+}
+
+void mpv_handle_t::free_win_gl_state() {
+    delete win_gl_;
+    win_gl_ = nullptr;
+}
+
+void mpv_handle_t::cleanup_render_resources_win_gl() {
+    auto *s = win_gl_;
+    if (!s || !s->thread) return;
+    {
+        std::lock_guard<std::mutex> lock(s->mutex);
+        s->quit = true;
+    }
+    s->cv.notify_all();
+    if (s->thread->joinable()) s->thread->join();
+    delete s->thread;
+    s->thread = nullptr;
+    // The state struct itself stays alive for the handle's lifetime (freed in the
+    // destructor): consumers may still be polling get_frame_state_win_gl or
+    // copy_latest_frame_win_gl concurrently with this teardown, and they check
+    // has_frame/thread under the mutex.
+}
+
+bool mpv_handle_t::set_surface_config_win_gl(int width, int height) {
+    auto *s = win_gl_;
+    if (!s || !s->thread) return false;
+    {
+        std::lock_guard<std::mutex> lock(s->mutex);
+        s->pending_width = width;
+        s->pending_height = height;
+        s->config_pending = true; // newest request replaces an unprocessed resize
+    }
+    s->cv.notify_all();
+    return true;
+}
+
+uint64_t mpv_handle_t::get_frame_state_win_gl() {
+    auto *s = win_gl_;
+    return s ? s->frame_state.load(std::memory_order_acquire) : (0xFull << 44);
+}
+
+bool mpv_handle_t::has_win_gl_surface() {
+    auto *s = win_gl_;
+    if (!s) return false;
+    std::lock_guard<std::mutex> lock(s->mutex);
+    return s->width > 0;
+}
+
+void mpv_handle_t::on_render_update_win_gl(void *context) {
+    auto *instance = static_cast<mpv_handle_t *>(context);
+    if (instance) instance->signal_render_update_win_gl();
+}
+
+void mpv_handle_t::signal_render_update_win_gl() {
+    auto *s = win_gl_;
+    if (!s) return;
+    {
+        std::lock_guard<std::mutex> lock(s->mutex);
+        s->render_pending = true;
+    }
+    s->cv.notify_all();
+}
+
+void mpv_handle_t::render_thread_loop_win_gl() {
+    auto *s = win_gl_;
+    // Pre-attach so the per-frame notify_render_update() is a cheap GetEnv, not an
+    // attach/detach pair.
+    JNIEnv *thread_env = nullptr;
+    const bool attached = jvm_ &&
+        jvm_->AttachCurrentThread(reinterpret_cast<void **>(&thread_env), nullptr) == JNI_OK;
+
+    std::string error;
+    s->gl = wgl_offscreen_context::create(&error);
+    if (!s->gl) LOGE("cannot create the offscreen WGL fallback context: %s", error.c_str());
+    bool initialized = s->gl != nullptr;
+    if (initialized) {
+        mpv_opengl_init_params gl_init_params{
+            .get_proc_address = win_gl_get_proc_address,
+            .get_proc_address_ctx = s->gl,
+        };
+        mpv_render_param params[] = {
+            {MPV_RENDER_PARAM_API_TYPE, const_cast<char *>(MPV_RENDER_API_TYPE_OPENGL)},
+            {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
+            {MPV_RENDER_PARAM_INVALID, nullptr},
+        };
+        const int result = mpv_render_context_create(&s->render_context, handle_, params);
+        if (result < 0) {
+            s->render_context = nullptr;
+            LOGE("mpv_render_context_create(OpenGL fallback) failed: %s", mpv_error_string(result));
+            initialized = false;
+        } else {
+            mpv_render_context_set_update_callback(
+                s->render_context, &mpv_handle_t::on_render_update_win_gl, this);
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(s->mutex);
+        s->initialize_ok = initialized;
+        s->initialized = true;
+    }
+    s->cv.notify_all();
+    if (!initialized) {
+        if (s->gl) {
+            s->gl->destroy();
+            delete s->gl;
+            s->gl = nullptr;
+        }
+        if (attached) jvm_->DetachCurrentThread();
+        return;
+    }
+
+    std::unique_lock<std::mutex> lock(s->mutex);
+    while (!s->quit) {
+        s->cv.wait(lock, [s] { return s->quit || s->render_pending || s->config_pending; });
+        if (s->quit) break;
+
+        // The hidden window's thread never pumps; keep its queue empty (posted system
+        // broadcasts reach top-level windows even when hidden).
+        s->gl->drain_window_messages();
+
+        bool configured = false;
+        if (s->config_pending) {
+            s->config_pending = false;
+            configured = apply_config_win_gl_locked();
+        }
+        const bool want_render = s->render_pending;
+        s->render_pending = false;
+        if (s->fbo == 0) {
+            if (want_render) {
+                lock.unlock();
+                drain_one_frame_win_gl();
+                lock.lock();
+            }
+            continue;
+        }
+        bool has_new_frame = false;
+        if (want_render) {
+            has_new_frame = (mpv_render_context_update(s->render_context) & MPV_RENDER_UPDATE_FRAME) != 0;
+        }
+        // A fresh config renders even without a new mpv frame so a paused video is
+        // re-rendered at the new size.
+        if (!has_new_frame && !configured) continue;
+        const int width = s->width, height = s->height;
+        lock.unlock();
+        const bool rendered = render_frame_win_gl(width, height);
+        lock.lock();
+        // The surface cannot have been reconfigured meanwhile: only this thread
+        // applies config changes.
+        if (rendered) {
+            std::swap(s->scratch, s->latest);
+            s->latest_width = width;
+            s->latest_height = height;
+            s->has_frame = true;
+            ++s->serial;
+            publish_state_win_gl_locked();
+            lock.unlock();
+            notify_render_update(); // release-store has completed before this JNI callback
+            lock.lock();
+        }
+    }
+    // Teardown in the owner thread while the WGL context is current.
+    if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
+    if (s->texture) glDeleteTextures(1, &s->texture);
+    s->fbo = 0;
+    s->texture = 0;
+    s->width = s->height = 0;
+    s->has_frame = false;
+    s->latest_width = s->latest_height = 0;
+    ++s->generation;
+    publish_state_win_gl_locked();
+    lock.unlock();
+    // Outside the lock: freeing the render context synchronizes with an in-flight
+    // update callback, and that callback takes the state mutex.
+    if (s->render_context) {
+        mpv_render_context_set_update_callback(s->render_context, nullptr, nullptr);
+        mpv_render_context_free(s->render_context);
+        s->render_context = nullptr;
+    }
+    s->gl->destroy();
+    delete s->gl;
+    s->gl = nullptr;
+    if (attached) jvm_->DetachCurrentThread();
+}
+
+bool mpv_handle_t::apply_config_win_gl_locked() {
+    auto *s = win_gl_;
+    const int width = s->pending_width, height = s->pending_height;
+    if (width <= 0 || height <= 0) {
+        if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
+        if (s->texture) glDeleteTextures(1, &s->texture);
+        s->fbo = 0;
+        s->texture = 0;
+        s->width = s->height = 0;
+        s->has_frame = false;
+        s->latest_width = s->latest_height = 0;
+        // An inactive surface holds no frame; actually return the buffer memory
+        // (clear() would keep the capacity).
+        std::vector<uint8_t>().swap(s->scratch);
+        std::vector<uint8_t>().swap(s->latest);
+        ++s->generation;
+        publish_state_win_gl_locked();
+        return false;
+    }
+    if (s->fbo && width == s->width && height == s->height) return false;
+    if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
+    if (s->texture) glDeleteTextures(1, &s->texture);
+    s->fbo = 0;
+    s->texture = 0;
+
+    drain_gl_errors();
+    glGenTextures(1, &s->texture);
+    glBindTexture(GL_TEXTURE_2D, s->texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    gl::gen_framebuffers(1, &s->fbo);
+    gl::bind_framebuffer(GL_FRAMEBUFFER, s->fbo);
+    gl::framebuffer_texture_2d(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, s->texture, 0);
+    const GLenum status = gl::check_framebuffer_status(GL_FRAMEBUFFER);
+    gl::bind_framebuffer(GL_FRAMEBUFFER, 0);
+    if (status != GL_FRAMEBUFFER_COMPLETE || glGetError() != GL_NO_ERROR) {
+        LOGE("OpenGL fallback FBO incomplete (%dx%d): 0x%x", width, height, status);
+        if (s->fbo) gl::delete_framebuffers(1, &s->fbo);
+        if (s->texture) glDeleteTextures(1, &s->texture);
+        s->fbo = 0;
+        s->texture = 0;
+        s->width = s->height = 0;
+        s->has_frame = false;
+        s->latest_width = s->latest_height = 0;
+        ++s->generation;
+        publish_state_win_gl_locked();
+        return false;
+    }
+
+    s->width = width;
+    s->height = height;
+    // No frame exists at the new size yet; consumers keep drawing their cached image
+    // (the previous size, letterboxed) until the render below publishes one.
+    s->has_frame = false;
+    ++s->generation;
+    publish_state_win_gl_locked();
+    LOGI("OpenGL fallback target allocated %dx%d generation=%u", width, height, s->generation);
+    return true;
+}
+
+void mpv_handle_t::publish_state_win_gl_locked() {
+    auto *s = win_gl_;
+    const uint64_t index = s->has_frame ? 0ull : 0xFull;
+    s->frame_state.store(
+        (static_cast<uint64_t>(s->generation & 0xFFFFu) << 48) |
+        (index << 44) |
+        (static_cast<uint64_t>(s->latest_width & 0x3FFF) << 30) |
+        (static_cast<uint64_t>(s->latest_height & 0x3FFF) << 16) |
+        (s->serial & 0xFFFFu), std::memory_order_release);
+}
+
+bool mpv_handle_t::render_frame_win_gl(int width, int height) {
+    auto *s = win_gl_;
+    if (!s->render_context || !s->fbo) return false;
+    mpv_opengl_fbo fbo{static_cast<int>(s->fbo), width, height, 0};
+    // Same orientation contract as the GLX path: flip_y=1, and the readback flips row
+    // order back to top-down (glReadPixels returns bottom-up rows).
+    int flip_y = 1;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
+        {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+        {MPV_RENDER_PARAM_INVALID, nullptr},
+    };
+    const int result = mpv_render_context_render(s->render_context, params);
+    // Failures below must be ours, not a stale error mpv's renderer left queued.
+    drain_gl_errors();
+    gl::bind_framebuffer(GL_FRAMEBUFFER, s->fbo);
+    // mpv does not promise useful alpha for opaque video; the consumer treats the
+    // frame as opaque, but normalize anyway so the CPU copies and debug PNGs are too.
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    // Only the render thread touches scratch; the swap into latest happens under the
+    // state mutex after this returns. glReadPixels is the synchronization point with
+    // the GPU (no glFinish needed).
+    s->scratch.resize(static_cast<size_t>(width) * height * 4);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, s->scratch.data());
+    gl::bind_framebuffer(GL_FRAMEBUFFER, 0);
+    return result >= 0 && glGetError() == GL_NO_ERROR;
+}
+
+void mpv_handle_t::drain_one_frame_win_gl() {
+    auto *s = win_gl_;
+    if (!s->render_context) return;
+    mpv_render_context_update(s->render_context);
+    int skip = 1;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_SKIP_RENDERING, &skip},
+        {MPV_RENDER_PARAM_INVALID, nullptr},
+    };
+    mpv_render_context_render(s->render_context, params);
+}
+
+uint64_t mpv_handle_t::copy_latest_frame_win_gl(void *dest, int width, int height) {
+    auto *s = win_gl_;
+    if (!s || !dest || width <= 0 || height <= 0) return 0;
+    std::lock_guard<std::mutex> lock(s->mutex);
+    if (!s->has_frame || s->latest_width != width || s->latest_height != height) return 0;
+    const size_t stride = static_cast<size_t>(width) * 4;
+    if (s->latest.size() < stride * static_cast<size_t>(height)) return 0;
+    auto *out = static_cast<uint8_t *>(dest);
+    for (int y = 0; y < height; ++y) {
+        std::memcpy(
+            out + static_cast<size_t>(y) * stride,
+            s->latest.data() + static_cast<size_t>(height - 1 - y) * stride,
+            stride);
+    }
+    return s->frame_state.load(std::memory_order_relaxed);
+}
+
+bool mpv_handle_t::read_surface_pixels_win_gl(
+    std::vector<uint32_t> &out_pixels, int &out_width, int &out_height) {
+    auto *s = win_gl_;
+    if (!s) return false;
+    std::lock_guard<std::mutex> lock(s->mutex);
+    if (!s->has_frame) return false;
+    const int width = s->latest_width, height = s->latest_height;
+    const size_t pixel_count = static_cast<size_t>(width) * height;
+    if (width <= 0 || height <= 0 || s->latest.size() < pixel_count * 4) return false;
+    out_pixels.resize(pixel_count);
+    for (int y = 0; y < height; ++y) {
+        const size_t source_row = static_cast<size_t>(height - 1 - y) * width;
+        const size_t target_row = static_cast<size_t>(y) * width;
+        for (int x = 0; x < width; ++x) {
+            const size_t source = (source_row + x) * 4;
+            out_pixels[target_row + x] = 0xFF000000u |
+                (static_cast<uint32_t>(s->latest[source]) << 16) |
+                (static_cast<uint32_t>(s->latest[source + 1]) << 8) |
+                static_cast<uint32_t>(s->latest[source + 2]);
+        }
+    }
+    out_width = width;
+    out_height = height;
+    return true;
+}
+
+bool mpv_handle_t::save_surface_png_win_gl(const char *path) {
+    if (!path) return false;
+    std::vector<uint32_t> pixels;
+    int width = 0, height = 0;
+    if (!read_surface_pixels_win_gl(pixels, width, height)) return false;
+    const bool ok = write_argb_png_wic(path, width, height, pixels);
+    if (!ok) LOGE("save_surface_png(OpenGL fallback) failed for %s", path);
+    return ok;
+}
+
+} // namespace mediampv
+
+#endif // _WIN32

--- a/mediamp-mpv/src/cpp/wgl_offscreen_context.cpp
+++ b/mediamp-mpv/src/cpp/wgl_offscreen_context.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+#ifdef _WIN32
+
+#include "wgl_offscreen_context.h"
+
+#include <GL/gl.h> // glGetString, for logging what the driver actually gave us
+
+#include <cstdint>
+#include <mutex>
+
+#include "log.h"
+
+// WGL_ARB_create_context. Defined locally instead of pulling in <GL/wglext.h>: the
+// values are frozen registry constants and the header is not part of the Windows SDK,
+// only of the MinGW GL headers.
+#ifndef WGL_CONTEXT_MAJOR_VERSION_ARB
+#define WGL_CONTEXT_MAJOR_VERSION_ARB 0x2091
+#endif
+#ifndef WGL_CONTEXT_MINOR_VERSION_ARB
+#define WGL_CONTEXT_MINOR_VERSION_ARB 0x2092
+#endif
+#ifndef WGL_CONTEXT_PROFILE_MASK_ARB
+#define WGL_CONTEXT_PROFILE_MASK_ARB 0x9126
+#endif
+#ifndef WGL_CONTEXT_CORE_PROFILE_BIT_ARB
+#define WGL_CONTEXT_CORE_PROFILE_BIT_ARB 0x00000001
+#endif
+
+namespace {
+
+using create_context_attribs_fn = HGLRC(WINAPI *)(HDC, HGLRC, const int *);
+
+constexpr wchar_t kWindowClassName[] = L"mediampv_gl_fallback_producer";
+
+// OpenGL 3.3 core, matching the GLX producer context. mpv's GL renderer works with both
+// profiles; the legacy-context fallback below covers drivers without the extension.
+constexpr int kContextAttributes[] = {
+    WGL_CONTEXT_MAJOR_VERSION_ARB, 3,
+    WGL_CONTEXT_MINOR_VERSION_ARB, 3,
+    WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+    0,
+};
+
+bool ensure_window_class(std::string *error) {
+    static bool registered = false;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        WNDCLASSEXW window_class{};
+        window_class.cbSize = sizeof(window_class);
+        // CS_OWNDC: the window keeps one private device context for its whole life,
+        // which is what a long-lived GL drawable needs (a cached DC could be recycled
+        // by GDI between wglMakeCurrent calls).
+        window_class.style = CS_OWNDC;
+        window_class.lpfnWndProc = DefWindowProcW;
+        window_class.hInstance = GetModuleHandleW(nullptr);
+        window_class.lpszClassName = kWindowClassName;
+        registered = RegisterClassExW(&window_class) != 0 ||
+            GetLastError() == ERROR_CLASS_ALREADY_EXISTS;
+    });
+    if (!registered && error) *error = "RegisterClassExW for the GL fallback window failed";
+    return registered;
+}
+
+/**
+ * Whether [format] on [device_context] belongs to the hardware ICD rather than the
+ * Microsoft generic implementation. The generic implementation is OpenGL 1.1 software:
+ * wglCreateContext on it succeeds but resolves no post-1.1 entry points, which mpv
+ * needs. PFD_GENERIC_FORMAT alone is the software rasterizer; together with
+ * PFD_GENERIC_ACCELERATED it is a (long obsolete) MCD driver — neither qualifies.
+ */
+bool is_accelerated_pixel_format(HDC device_context, int format) {
+    PIXELFORMATDESCRIPTOR descriptor{};
+    descriptor.nSize = sizeof(descriptor);
+    descriptor.nVersion = 1;
+    if (format <= 0 ||
+        DescribePixelFormat(device_context, format, sizeof(descriptor), &descriptor) == 0) {
+        return false;
+    }
+    return (descriptor.dwFlags & PFD_GENERIC_FORMAT) == 0 &&
+        (descriptor.dwFlags & PFD_SUPPORT_OPENGL) != 0;
+}
+
+/** First hardware-accelerated RGBA window format offered for [device_context], or 0. */
+int scan_for_accelerated_pixel_format(HDC device_context) {
+    PIXELFORMATDESCRIPTOR descriptor{};
+    descriptor.nSize = sizeof(descriptor);
+    descriptor.nVersion = 1;
+    const int format_count = DescribePixelFormat(device_context, 1, sizeof(descriptor), &descriptor);
+    for (int format = 1; format <= format_count; ++format) {
+        if (DescribePixelFormat(device_context, format, sizeof(descriptor), &descriptor) == 0)
+            continue;
+        const DWORD required = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
+        if ((descriptor.dwFlags & required) != required) continue;
+        if (descriptor.dwFlags & PFD_GENERIC_FORMAT) continue;
+        if (descriptor.iPixelType != PFD_TYPE_RGBA) continue;
+        if (descriptor.cColorBits < 24) continue;
+        return format;
+    }
+    return 0;
+}
+
+bool set_producer_pixel_format(HDC device_context, std::string *error) {
+    PIXELFORMATDESCRIPTOR descriptor{};
+    descriptor.nSize = sizeof(descriptor);
+    descriptor.nVersion = 1;
+    descriptor.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
+    descriptor.iPixelType = PFD_TYPE_RGBA;
+    descriptor.cColorBits = 24;
+    descriptor.cAlphaBits = 8;
+    descriptor.iLayerType = PFD_MAIN_PLANE;
+
+    int format = 0;
+    const char *source = "ChoosePixelFormat";
+    const int chosen = ChoosePixelFormat(device_context, &descriptor);
+    if (is_accelerated_pixel_format(device_context, chosen)) {
+        format = chosen;
+    } else {
+        if (chosen != 0) {
+            LOGW("ChoosePixelFormat returned the non-accelerated format %d; scanning instead", chosen);
+        }
+        format = scan_for_accelerated_pixel_format(device_context);
+        source = "scan";
+    }
+    if (format == 0) {
+        if (error) {
+            *error = "no hardware-accelerated OpenGL pixel format is available "
+                     "(the Microsoft generic implementation is GL 1.1, which mpv cannot use)";
+        }
+        return false;
+    }
+    if (!SetPixelFormat(device_context, format, &descriptor)) {
+        if (error) *error = "SetPixelFormat for the GL fallback drawable failed";
+        LOGE("SetPixelFormat(%d) failed: GetLastError=%lu", format, GetLastError());
+        return false;
+    }
+    LOGI("WGL fallback drawable uses pixel format %d via %s", format, source);
+    return true;
+}
+
+/**
+ * Creates the context and leaves it current. A legacy context comes first: it is also
+ * the bootstrap that makes wglGetProcAddress work at all (WGL entry points resolve only
+ * while some context is current). If WGL_ARB_create_context is available, a 3.3 core
+ * context replaces it; otherwise the legacy context is kept — on an accelerated format
+ * it is the driver's full compatibility context, which mpv accepts too.
+ */
+HGLRC create_and_bind_context(HDC device_context, std::string *error) {
+    HGLRC legacy = wglCreateContext(device_context);
+    if (!legacy) {
+        if (error) *error = "wglCreateContext for the GL fallback context failed";
+        LOGE("wglCreateContext failed: GetLastError=%lu", GetLastError());
+        return nullptr;
+    }
+    if (!wglMakeCurrent(device_context, legacy)) {
+        if (error) *error = "wglMakeCurrent for the GL fallback context failed";
+        LOGE("wglMakeCurrent failed: GetLastError=%lu", GetLastError());
+        wglDeleteContext(legacy);
+        return nullptr;
+    }
+
+    const auto create_context_attribs = reinterpret_cast<create_context_attribs_fn>(
+        wglGetProcAddress("wglCreateContextAttribsARB"));
+    if (!create_context_attribs) {
+        LOGW("wglCreateContextAttribsARB is unavailable; keeping the legacy context");
+        return legacy;
+    }
+    HGLRC core = create_context_attribs(device_context, nullptr, kContextAttributes);
+    if (!core) {
+        LOGW("wglCreateContextAttribsARB(3.3 core) failed (GetLastError=%lu); "
+             "keeping the legacy context", GetLastError());
+        return legacy;
+    }
+    if (!wglMakeCurrent(device_context, core)) {
+        LOGW("wglMakeCurrent for the 3.3 core context failed (GetLastError=%lu); "
+             "keeping the legacy context", GetLastError());
+        wglDeleteContext(core);
+        if (!wglMakeCurrent(device_context, legacy)) {
+            if (error) *error = "wglMakeCurrent could not restore the legacy GL fallback context";
+            wglDeleteContext(legacy);
+            return nullptr;
+        }
+        return legacy;
+    }
+    wglDeleteContext(legacy);
+    return core;
+}
+
+} // namespace
+
+namespace mediampv {
+
+wgl_offscreen_context *wgl_offscreen_context::create(std::string *error) {
+    if (!ensure_window_class(error)) return nullptr;
+
+    HWND window = CreateWindowExW(
+        0, kWindowClassName, L"", WS_POPUP, 0, 0, 1, 1,
+        nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+    if (!window) {
+        if (error) *error = "CreateWindowExW for the GL fallback drawable failed";
+        LOGE("CreateWindowExW failed: GetLastError=%lu", GetLastError());
+        return nullptr;
+    }
+    // CS_OWNDC hands out the window's private DC; it stays valid until the window is
+    // destroyed and must not be released separately.
+    HDC device_context = GetDC(window);
+    if (!device_context) {
+        DestroyWindow(window);
+        if (error) *error = "GetDC for the GL fallback drawable failed";
+        return nullptr;
+    }
+
+    HGLRC context = nullptr;
+    if (set_producer_pixel_format(device_context, error)) {
+        context = create_and_bind_context(device_context, error);
+    }
+    if (!context) {
+        DestroyWindow(window);
+        return nullptr;
+    }
+
+    LOGI("WGL fallback context ready: %s / %s / GL %s",
+         reinterpret_cast<const char *>(glGetString(GL_VENDOR)),
+         reinterpret_cast<const char *>(glGetString(GL_RENDERER)),
+         reinterpret_cast<const char *>(glGetString(GL_VERSION)));
+    return new wgl_offscreen_context(window, device_context, context);
+}
+
+wgl_offscreen_context::~wgl_offscreen_context() {
+    destroy();
+}
+
+void wgl_offscreen_context::destroy() {
+    if (!context_ && !window_) return;
+    if (wglGetCurrentContext() == context_) {
+        wglMakeCurrent(nullptr, nullptr);
+    }
+    if (context_) wglDeleteContext(context_);
+    if (window_) DestroyWindow(window_);
+    context_ = nullptr;
+    device_context_ = nullptr;
+    window_ = nullptr;
+}
+
+void wgl_offscreen_context::drain_window_messages() {
+    if (!window_) return;
+    MSG message;
+    while (PeekMessageW(&message, window_, 0, 0, PM_REMOVE)) {
+        TranslateMessage(&message);
+        DispatchMessageW(&message);
+    }
+}
+
+void *wgl_offscreen_context::get_proc_address(const char *name) const {
+    if (!name || !*name) return nullptr;
+    if (PROC proc = wglGetProcAddress(name)) {
+        // Some drivers report "unsupported" as one of these sentinel values instead of
+        // null, so a plain null check would hand mpv an unusable pointer.
+        const auto value = reinterpret_cast<intptr_t>(proc);
+        if (value != 1 && value != 2 && value != 3 && value != -1) {
+            return reinterpret_cast<void *>(proc);
+        }
+    }
+    static HMODULE const gl_module = LoadLibraryW(L"opengl32.dll");
+    return gl_module ? reinterpret_cast<void *>(GetProcAddress(gl_module, name)) : nullptr;
+}
+
+} // namespace mediampv
+
+#endif // _WIN32

--- a/mediamp-mpv/src/cpp/wgl_offscreen_context.cpp
+++ b/mediamp-mpv/src/cpp/wgl_offscreen_context.cpp
@@ -247,11 +247,15 @@ void wgl_offscreen_context::window_thread_loop() {
     startup_cv_.notify_all();
     if (!window) return;
 
+    // This line doubles as a build marker: its presence in a log confirms the running
+    // mediampv.dll has the dedicated window pump thread.
+    LOGI("WGL fallback window pump thread running");
     MSG message;
     while (GetMessageW(&message, nullptr, 0, 0) > 0) {
         TranslateMessage(&message);
         DispatchMessageW(&message);
     }
+    LOGI("WGL fallback window pump thread exited");
 }
 
 wgl_offscreen_context *wgl_offscreen_context::create(std::string *error) {

--- a/mediamp-mpv/src/cpp/wgl_offscreen_context.cpp
+++ b/mediamp-mpv/src/cpp/wgl_offscreen_context.cpp
@@ -13,7 +13,6 @@
 #include <GL/gl.h> // glGetString, for logging what the driver actually gave us
 
 #include <cstdint>
-#include <mutex>
 
 #include "log.h"
 
@@ -48,6 +47,16 @@ constexpr int kContextAttributes[] = {
     0,
 };
 
+LRESULT CALLBACK producer_window_proc(HWND window, UINT message, WPARAM w_param, LPARAM l_param) {
+    // WM_CLOSE -> DefWindowProc -> DestroyWindow; ending the message loop on
+    // WM_DESTROY lets destroy() shut the window thread down with one PostMessage.
+    if (message == WM_DESTROY) {
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProcW(window, message, w_param, l_param);
+}
+
 bool ensure_window_class(std::string *error) {
     static bool registered = false;
     static std::once_flag once;
@@ -58,7 +67,7 @@ bool ensure_window_class(std::string *error) {
         // which is what a long-lived GL drawable needs (a cached DC could be recycled
         // by GDI between wglMakeCurrent calls).
         window_class.style = CS_OWNDC;
-        window_class.lpfnWndProc = DefWindowProcW;
+        window_class.lpfnWndProc = producer_window_proc;
         window_class.hInstance = GetModuleHandleW(nullptr);
         window_class.lpszClassName = kWindowClassName;
         registered = RegisterClassExW(&window_class) != 0 ||
@@ -196,32 +205,75 @@ HGLRC create_and_bind_context(HDC device_context, std::string *error) {
 
 namespace mediampv {
 
+// Runs on the dedicated window thread: creates the hidden window, sets its pixel
+// format, publishes the handles, then pumps messages until WM_DESTROY. GetMessageW
+// keeps the thread inside message retrieval at all times, so cross-thread sent
+// messages (activation/focus bookkeeping when other process windows close) are always
+// delivered promptly instead of deadlocking their sender.
+void wgl_offscreen_context::window_thread_loop() {
+    std::string error;
+    HWND window = nullptr;
+    HDC device_context = nullptr;
+    if (ensure_window_class(&error)) {
+        window = CreateWindowExW(
+            0, kWindowClassName, L"", WS_POPUP, 0, 0, 1, 1,
+            nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+        if (!window) {
+            error = "CreateWindowExW for the GL fallback drawable failed";
+            LOGE("CreateWindowExW failed: GetLastError=%lu", GetLastError());
+        }
+    }
+    if (window) {
+        // CS_OWNDC hands out the window's private DC; it stays valid until the window
+        // is destroyed and must not be released separately.
+        device_context = GetDC(window);
+        if (!device_context) {
+            error = "GetDC for the GL fallback drawable failed";
+        } else if (!set_producer_pixel_format(device_context, &error)) {
+            device_context = nullptr;
+        }
+        if (!device_context) {
+            DestroyWindow(window);
+            window = nullptr;
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(startup_mutex_);
+        window_ = window;
+        device_context_ = device_context;
+        window_error_ = error;
+        startup_done_ = true;
+    }
+    startup_cv_.notify_all();
+    if (!window) return;
+
+    MSG message;
+    while (GetMessageW(&message, nullptr, 0, 0) > 0) {
+        TranslateMessage(&message);
+        DispatchMessageW(&message);
+    }
+}
+
 wgl_offscreen_context *wgl_offscreen_context::create(std::string *error) {
-    if (!ensure_window_class(error)) return nullptr;
-
-    HWND window = CreateWindowExW(
-        0, kWindowClassName, L"", WS_POPUP, 0, 0, 1, 1,
-        nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
-    if (!window) {
-        if (error) *error = "CreateWindowExW for the GL fallback drawable failed";
-        LOGE("CreateWindowExW failed: GetLastError=%lu", GetLastError());
-        return nullptr;
+    auto *context = new wgl_offscreen_context();
+    context->window_thread_ = std::thread([context] { context->window_thread_loop(); });
+    {
+        std::unique_lock<std::mutex> lock(context->startup_mutex_);
+        context->startup_cv_.wait(lock, [context] { return context->startup_done_; });
     }
-    // CS_OWNDC hands out the window's private DC; it stays valid until the window is
-    // destroyed and must not be released separately.
-    HDC device_context = GetDC(window);
-    if (!device_context) {
-        DestroyWindow(window);
-        if (error) *error = "GetDC for the GL fallback drawable failed";
+    if (!context->window_) {
+        if (error) *error = context->window_error_;
+        if (context->window_thread_.joinable()) context->window_thread_.join();
+        delete context;
         return nullptr;
     }
 
-    HGLRC context = nullptr;
-    if (set_producer_pixel_format(device_context, error)) {
-        context = create_and_bind_context(device_context, error);
-    }
-    if (!context) {
-        DestroyWindow(window);
+    // The GL context itself belongs to the calling (render) thread. HDCs are not
+    // thread-affine, so using the window's DC from here is fine.
+    context->context_ = create_and_bind_context(context->device_context_, error);
+    if (!context->context_) {
+        context->shutdown_window_thread();
+        delete context;
         return nullptr;
     }
 
@@ -229,32 +281,37 @@ wgl_offscreen_context *wgl_offscreen_context::create(std::string *error) {
          reinterpret_cast<const char *>(glGetString(GL_VENDOR)),
          reinterpret_cast<const char *>(glGetString(GL_RENDERER)),
          reinterpret_cast<const char *>(glGetString(GL_VERSION)));
-    return new wgl_offscreen_context(window, device_context, context);
+    return context;
 }
 
 wgl_offscreen_context::~wgl_offscreen_context() {
     destroy();
 }
 
-void wgl_offscreen_context::destroy() {
-    if (!context_ && !window_) return;
-    if (wglGetCurrentContext() == context_) {
-        wglMakeCurrent(nullptr, nullptr);
+void wgl_offscreen_context::shutdown_window_thread() {
+    if (window_) {
+        // WM_CLOSE -> DefWindowProc -> DestroyWindow (on the window thread, as
+        // required) -> WM_DESTROY -> PostQuitMessage ends the pump loop.
+        PostMessageW(window_, WM_CLOSE, 0, 0);
     }
-    if (context_) wglDeleteContext(context_);
-    if (window_) DestroyWindow(window_);
-    context_ = nullptr;
-    device_context_ = nullptr;
+    if (window_thread_.joinable()) window_thread_.join();
     window_ = nullptr;
+    device_context_ = nullptr;
 }
 
-void wgl_offscreen_context::drain_window_messages() {
-    if (!window_) return;
-    MSG message;
-    while (PeekMessageW(&message, window_, 0, 0, PM_REMOVE)) {
-        TranslateMessage(&message);
-        DispatchMessageW(&message);
+void wgl_offscreen_context::destroy() {
+    if (!context_ && !window_) {
+        if (window_thread_.joinable()) window_thread_.join();
+        return;
     }
+    if (context_) {
+        if (wglGetCurrentContext() == context_) {
+            wglMakeCurrent(nullptr, nullptr);
+        }
+        wglDeleteContext(context_);
+        context_ = nullptr;
+    }
+    shutdown_window_thread();
 }
 
 void *wgl_offscreen_context::get_proc_address(const char *name) const {

--- a/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
@@ -119,8 +119,10 @@ external fun nDestroyRenderContextWindowsOpenGL(ptr: Long): Boolean
 
 /**
  * Asks the render thread to (re)allocate its render target at [width] x [height].
- * Non-positive size deactivates the surface. Asynchronous — the swap happens between
- * frames.
+ * Non-positive size deactivates the surface. Resizes are asynchronous — the swap
+ * happens between frames; deactivation is synchronous (bounded by a 1s timeout): it
+ * returns once the render thread has dropped its FBO and parked, so the consumer may
+ * safely destroy Skia GPU objects without racing the producer's GL.
  */
 @InternalMediampApi
 external fun nSetSurfaceConfigWindowsOpenGL(ptr: Long, width: Int, height: Int): Boolean

--- a/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
@@ -103,6 +103,56 @@ external fun nHasD3D11Surface(ptr: Long): Boolean
 @InternalMediampApi
 external fun nSaveSurfacePngD3D11(ptr: Long, path: String): Boolean
 
+// Windows OpenGL fallback render path (render_opengl_win.cpp): used when Compose
+// renders with Skiko's OpenGL backend (SKIKO_RENDER_API=OPENGL) instead of the
+// Direct3D default. A native render thread drives mpv through the libmpv OpenGL render
+// API on a private offscreen WGL context (shared with nothing) and reads every frame
+// back to CPU memory; the consumer copies the latest frame into a Skia bitmap during
+// draw. There are no consumer-side textures, so this path has no getBufferTexture/
+// ackRetiredBuffers surface.
+
+@InternalMediampApi
+external fun nCreateRenderContextWindowsOpenGL(ptr: Long): Boolean
+
+@InternalMediampApi
+external fun nDestroyRenderContextWindowsOpenGL(ptr: Long): Boolean
+
+/**
+ * Asks the render thread to (re)allocate its render target at [width] x [height].
+ * Non-positive size deactivates the surface. Asynchronous — the swap happens between
+ * frames.
+ */
+@InternalMediampApi
+external fun nSetSurfaceConfigWindowsOpenGL(ptr: Long, width: Int, height: Int): Boolean
+
+/**
+ * Packed frame state: generation(16) | latestIndex(4, 0xF = none) | width(14) |
+ * height(14) | serial(16). Any change means a new frame or a new render target.
+ */
+@InternalMediampApi
+external fun nGetFrameStateWindowsOpenGL(ptr: Long): Long
+
+@InternalMediampApi
+external fun nHasWindowsOpenGLSurface(ptr: Long): Boolean
+
+/** Saves the latest rendered frame (CPU copy) as PNG via WIC. */
+@InternalMediampApi
+external fun nSaveSurfacePngWindowsOpenGL(ptr: Long, path: String): Boolean
+
+/** Windows OpenGL fallback equivalent of [nReadSurfacePixelsD3D11]. */
+@InternalMediampApi
+external fun nReadSurfacePixelsWindowsOpenGL(ptr: Long, dims: IntArray): IntArray?
+
+/**
+ * Copies the latest frame as tightly packed RGBA_8888 rows (top-down) into the native
+ * memory at [destAddr] (which must hold [width] * [height] * 4 bytes, e.g. a Skia
+ * bitmap's pixel storage), provided the latest frame is exactly [width] x [height].
+ * Returns the packed frame state the copy corresponds to, or 0 when no matching frame
+ * is available.
+ */
+@InternalMediampApi
+external fun nCopyLatestFrameWindowsOpenGL(ptr: Long, destAddr: Long, width: Int, height: Int): Long
+
 // OpenGL render path (Linux/GLX): a native render thread
 // render into shared GL_TEXTURE_2D objects. The `consumerEnvironmentPtr` is an opaque
 // native description of Skiko's live GLX environment, not a producer FBO or a texture

--- a/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MPVHandle.desktop.kt
@@ -118,11 +118,14 @@ external fun nCreateRenderContextWindowsOpenGL(ptr: Long): Boolean
 external fun nDestroyRenderContextWindowsOpenGL(ptr: Long): Boolean
 
 /**
- * Asks the render thread to (re)allocate its render target at [width] x [height].
- * Non-positive size deactivates the surface. Resizes are asynchronous — the swap
- * happens between frames; deactivation is synchronous (bounded by a 1s timeout): it
- * returns once the render thread has dropped its FBO and parked, so the consumer may
- * safely destroy Skia GPU objects without racing the producer's GL.
+ * Asks the render thread to (re)allocate its render target for a [width] x [height]
+ * consumer area. The native side clamps the actual target to the video's display size
+ * (aspect-fit): every readback byte scales with the target area, and Skia upscales
+ * during the draw anyway. Non-positive size deactivates the surface. Resizes are
+ * asynchronous — the swap happens between frames; deactivation is synchronous
+ * (bounded by a 1s timeout): it returns once the render thread has dropped its FBO
+ * and parked, so the consumer may safely destroy its objects without racing the
+ * producer.
  */
 @InternalMediampApi
 external fun nSetSurfaceConfigWindowsOpenGL(ptr: Long, width: Int, height: Int): Boolean

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvFramePreview.desktop.kt
@@ -30,8 +30,8 @@ import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.features.FramePreview
 import org.openani.mediamp.features.PreviewFrame
 import org.openani.mediamp.mpv.internal.MpvPreviewDecoder
-import org.openani.mediamp.mpv.internal.MpvSurfaceRingBackend
-import org.openani.mediamp.mpv.internal.currentSurfaceRingBackend
+import org.openani.mediamp.mpv.internal.MpvSurfaceBackend
+import org.openani.mediamp.mpv.internal.currentSurfaceBackend
 import org.openani.mediamp.source.MediaData
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
@@ -46,7 +46,7 @@ internal actual fun createMpvFramePreview(
 ): FramePreview? {
     // Without a surface-ring backend frames cannot be read back, so the
     // feature is absent rather than present-but-always-null.
-    val ringBackend = currentSurfaceRingBackend() ?: return null
+    val ringBackend = currentSurfaceBackend() ?: return null
     return MpvFramePreview(player, context, ringBackend, parentCoroutineContext)
 }
 
@@ -62,7 +62,7 @@ internal actual fun createMpvFramePreview(
 internal class MpvFramePreview(
     private val mainPlayer: JvmMpvMediampPlayer,
     private val context: Any,
-    private val ringBackend: MpvSurfaceRingBackend,
+    private val ringBackend: MpvSurfaceBackend,
     parentCoroutineContext: CoroutineContext,
 ) : FramePreview, AutoCloseable {
     private val scope = CoroutineScope(

--- a/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/MpvMediampPlayer.desktop.kt
@@ -18,9 +18,9 @@ import org.jetbrains.skiko.SkiaLayer
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.internal.MpvRenderContextHost
 import org.openani.mediamp.mpv.internal.MpvRenderContextLifecycle
-import org.openani.mediamp.mpv.internal.MpvSurfaceRing
-import org.openani.mediamp.mpv.internal.MpvSurfaceRingBackend
-import org.openani.mediamp.mpv.internal.currentSurfaceRingBackend
+import org.openani.mediamp.mpv.internal.MpvSurfaceBackend
+import org.openani.mediamp.mpv.internal.MpvSurfaceConsumer
+import org.openani.mediamp.mpv.internal.currentSurfaceBackend
 import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
 import kotlin.coroutines.CoroutineContext
 
@@ -36,9 +36,11 @@ actual class MpvMediampPlayer(
     mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : JvmMpvMediampPlayer(context, parentCoroutineContext, mainDispatcher) {
 
-    // Native surface-ring render path; the consumer state machine is shared (MpvSurfaceRing).
-    private val ringBackend: MpvSurfaceRingBackend? = currentSurfaceRingBackend()
-    private val surfaceRing: MpvSurfaceRing? = ringBackend?.let { MpvSurfaceRing(handle.ptr, it) }
+    // Native render path; the consumer state machine is chosen by the backend
+    // (MpvSurfaceRing for the shared-texture rings, MpvReadbackSurface for the Windows
+    // OpenGL fallback).
+    private val ringBackend: MpvSurfaceBackend? = currentSurfaceBackend()
+    private val surfaceRing: MpvSurfaceConsumer? = ringBackend?.createSurfaceConsumer(handle.ptr)
 
     /**
      * Producer-context lifecycle chosen by the backend: eager where the backend owns its
@@ -76,29 +78,29 @@ actual class MpvMediampPlayer(
     override fun ensureRenderContextForLoad(): Boolean =
         renderContextLifecycle?.ensureReadyForLoad() ?: true
 
-    /** See [MpvSurfaceRingBackend.createSkiaInterop]. */
+    /** See [MpvSurfaceBackend.createSkiaInterop]. */
     internal fun createSkiaInterop(layer: SkiaLayer): SkiaRenderDeviceInterop? =
         ringBackend?.createSkiaInterop(layer)
 
-    /** See [MpvSurfaceRing.requestSurface]. */
+    /** See [MpvSurfaceConsumer.requestSurface]. */
     internal fun requestSurface(width: Int, height: Int, devicePtr: Long): Boolean =
         surfaceRing?.requestSurface(width, height, devicePtr) ?: false
 
-    /** See [MpvSurfaceRing.refreshDeviceIfChanged]. */
+    /** See [MpvSurfaceConsumer.refreshDeviceIfChanged]. */
     internal fun refreshDeviceIfChanged(devicePtr: Long) {
         surfaceRing?.refreshDeviceIfChanged(devicePtr)
     }
 
-    /** See [MpvSurfaceRing.currentFrameImage]. Do NOT close the returned image. */
+    /** See [MpvSurfaceConsumer.currentFrameImage]. Do NOT close the returned image. */
     internal fun currentFrameImage(directContext: DirectContext): Image? =
         surfaceRing?.currentFrameImage(directContext)
 
-    /** See [MpvSurfaceRing.release]. */
+    /** See [MpvSurfaceConsumer.release]. */
     internal fun releaseSurface() {
         surfaceRing?.release()
     }
 
-    /** See [MpvSurfaceRingBackend.readSurfacePixels]. */
+    /** See [MpvSurfaceBackend.readSurfacePixels]. */
     internal fun readSurfacePixels(dims: IntArray): IntArray? =
         ringBackend?.readSurfacePixels(handle.ptr, dims)
 

--- a/mediamp-mpv/src/desktopMain/kotlin/compose/MpvMediampPlayerSurface.desktop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/compose/MpvMediampPlayerSurface.desktop.kt
@@ -36,7 +36,7 @@ import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.MPVLog
 import org.openani.mediamp.mpv.MpvMediampPlayer
 import org.openani.mediamp.mpv.internal.MpvSurfaceDrawResolver
-import org.openani.mediamp.mpv.internal.currentSurfaceRingBackend
+import org.openani.mediamp.mpv.internal.currentSurfaceBackend
 import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
 import org.openani.mediamp.mpv.utils.findSkiaLayer
 import kotlin.time.Duration.Companion.milliseconds
@@ -46,7 +46,7 @@ actual fun MpvMediampPlayerSurface(
     player: MpvMediampPlayer,
     modifier: Modifier,
 ) {
-    if (currentSurfaceRingBackend() != null) {
+    if (currentSurfaceBackend() != null) {
         MpvMediampPlayerSurfaceRing(player, modifier)
     } else {
         Box(modifier)
@@ -54,14 +54,17 @@ actual fun MpvMediampPlayerSurface(
 }
 
 /**
- * Shared surface-ring render path (macOS Metal, Windows D3D11, Linux OpenGL/GLX):
+ * Shared native render path (macOS Metal, Windows D3D11 or OpenGL fallback, Linux
+ * OpenGL/GLX):
  *
  * A native render thread drives mpv into a triple-buffered ring of GPU textures that
  * are simultaneously visible to Skia's own render device — IOSurfaces wrapped as
  * MTLTextures on macOS (hwdec=videotoolbox, OpenGL over an offscreen CGL context), NT
  * shared handles opened as ID3D12Resources on Windows (hwdec=d3d11va, libmpv D3D11
  * render API). The video becomes a regular draw call in the Compose scene graph, zero
- * extra CPU copies end to end, and this thread never renders or blocks.
+ * extra CPU copies end to end, and this thread never renders or blocks. The Windows
+ * OpenGL fallback (Compose on `SKIKO_RENDER_API=OPENGL`) publishes CPU frames instead,
+ * which the consumer uploads during draw — same protocol, one extra copy by design.
  *
  * All platform differences live behind [MpvSurfaceDrawResolver] and the player's
  * render-context lifecycle; this composable contains no host checks.

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
@@ -33,7 +33,7 @@ private const val FRAME_PREVIEW_LOAD_TARGET_PREFIX = "mediamp://frame_preview/"
 @OptIn(ExperimentalMediampApi::class)
 internal class MpvPreviewDecoder(
     context: Any,
-    private val ringBackend: MpvSurfaceRingBackend,
+    private val ringBackend: MpvSurfaceBackend,
     provisioning: MpvRenderContextProvisioning,
 ) : AutoCloseable {
     val handle = MPVHandle(context)
@@ -131,11 +131,11 @@ internal class MpvPreviewDecoder(
     fun setRenderUpdateListener(listener: RenderUpdateListener?): Boolean =
         handle.setRenderUpdateListener(listener)
 
-    /** See [MpvSurfaceRingBackend.setSurfaceConfig]; the preview ring is always headless. */
+    /** See [MpvSurfaceBackend.setSurfaceConfig]; the preview ring is always headless. */
     fun requestSurface(width: Int, height: Int): Boolean =
         ringBackend.setSurfaceConfig(handle.ptr, width, height, 0L)
 
-    /** See [MpvSurfaceRingBackend.readSurfacePixels]. */
+    /** See [MpvSurfaceBackend.readSurfacePixels]. */
     fun readSurfacePixels(dims: IntArray): IntArray? =
         ringBackend.readSurfacePixels(handle.ptr, dims)
 

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvReadbackSurface.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvReadbackSurface.kt
@@ -138,6 +138,13 @@ internal class MpvReadbackSurface(
     private fun ensureBlitSurface(width: Int, height: Int, directContext: DirectContext): Surface? {
         blitSurface?.let {
             if (surfaceContext === directContext && it.width == width && it.height == height) return it
+            // The caller already handled a context change, so this surface lives on
+            // [directContext]; resolve its pending work before destruction (see
+            // dropConsumerResources).
+            runCatching {
+                directContext.flush()
+                directContext.submit(false)
+            }
             it.close()
             blitSurface = null
         }
@@ -160,6 +167,18 @@ internal class MpvReadbackSurface(
     }
 
     private fun dropConsumerResources() {
+        // Resolve any recorded-but-unsubmitted work targeting the blit surface (the
+        // last writePixels/snapshot may not have gone through a Skiko frame-end flush
+        // when disposal runs mid-frame) so the surface destructor below has nothing
+        // left to flush or wait on.
+        if (blitSurface != null || cachedFrame != null) {
+            surfaceContext?.let { context ->
+                runCatching {
+                    context.flush()
+                    context.submit(false)
+                }
+            }
+        }
         cachedFrame?.close()
         cachedFrame = null
         cachedState = 0L
@@ -180,9 +199,13 @@ internal class MpvReadbackSurface(
     }
 
     override fun release() {
-        dropConsumerResources()
-        // The render thread may drop its target and go back to draining frames.
+        // Quiesce the producer FIRST — deactivation is synchronous on this backend.
+        // Destroying the Skia GPU objects below while the producer's WGL context is
+        // still actively rendering can block the destructor in the GL driver's
+        // cross-context synchronization (observed as an EDT hang at window close,
+        // while the same closes succeed when the producer is idle).
         backend.setSurfaceConfig(handlePtr, 0, 0, 0L)
+        dropConsumerResources()
         requestedWidth = 0
         requestedHeight = 0
         configured = false

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvReadbackSurface.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvReadbackSurface.kt
@@ -15,31 +15,35 @@ import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.Pixmap
-import org.jetbrains.skia.Surface
 import org.openani.mediamp.mpv.MPVLog
 
 /**
  * Consumer side of the Windows OpenGL fallback: the native render thread publishes CPU
- * frames (RGBA_8888, top-down on copy); this class copies the latest one straight into
- * a Skia bitmap's native pixel storage (no JNI arrays, no Java-heap staging), uploads
- * it into a GPU surface on Skia's current DirectContext, and caches the snapshot. The
- * expensive part (copy + upload) only runs when the native frame state advanced;
- * overlay-driven Compose redraws just re-draw the cached image. During a resize the
- * previous frame is returned until a frame at the new size exists, so resizes never
- * flash black. All methods are called from the Compose/Skiko UI thread only.
+ * frames; this class copies the latest one into a fresh immutable Skia bitmap's native
+ * pixel storage (no JNI arrays, no Java-heap staging) and wraps it zero-copy as a
+ * raster [Image]. Drawing that image on the Compose canvas uploads it into Skia's
+ * bitmap-texture cache once per unique frame; overlay-driven redraws without a new
+ * frame re-draw the cached image and hit the same cached texture.
+ *
+ * Deliberately owns NO GPU objects. Raster images and bitmaps have CPU-only
+ * destructors, so they can be closed regardless of which (if any) GL context is
+ * current — the dispose path at window close runs without a current context, where
+ * destroying a GPU surface blocks or crashes in the driver (observed: an EDT hang in
+ * the surface destructor while the producer rendered, and a null-dispatch
+ * ACCESS_VIOLATION from a DirectContext flush). The per-frame GPU upload cost is the
+ * same as an explicit blit-surface design; only the upload's bookkeeping moved into
+ * Skia's own cache, which handles context loss itself.
+ *
+ * All methods are called from the Compose/Skiko UI thread only.
  */
 internal class MpvReadbackSurface(
     private val handlePtr: Long,
     private val backend: WindowsOpenGLSurfaceBackend,
 ) : MpvSurfaceConsumer {
+    // The bitmap of the current frame stays referenced (and unclosed) while its image
+    // is cached: the image shares the immutable bitmap's pixels instead of copying.
     private var bitmap: Bitmap? = null
     private var bitmapPixels: Pixmap? = null
-    private var bitmapWidth = 0
-    private var bitmapHeight = 0
-
-    private var blitSurface: Surface? = null
-    private var surfaceContext: DirectContext? = null
-
     private var cachedFrame: Image? = null
     private var cachedState = 0L
 
@@ -57,8 +61,9 @@ internal class MpvReadbackSurface(
     }
 
     override fun refreshDeviceIfChanged(devicePtr: Long) {
-        // Frames arrive as CPU pixels; no consumer render device is involved. A
-        // replaced Skiko DirectContext is detected per draw in currentFrameImage.
+        // Frames arrive as CPU pixels and leave as raster images; no consumer render
+        // device is involved, and Skia's texture cache survives redrawer changes on
+        // its own.
     }
 
     override fun invalidateForRenderEnvironmentChange() {
@@ -67,7 +72,7 @@ internal class MpvReadbackSurface(
 
     override fun currentFrameImage(directContext: DirectContext): Image? {
         val state = backend.getFrameState(handlePtr)
-        if (state == cachedState && surfaceContext === directContext) {
+        if (state == cachedState) {
             cachedFrame?.let { return it }
         }
         val index = ((state ushr 44) and 0xF).toInt()
@@ -75,122 +80,54 @@ internal class MpvReadbackSurface(
         val height = ((state ushr 16) and 0x3FFF).toInt()
         if (index == 0xF || width <= 0 || height <= 0) return cachedFrame
 
-        if (surfaceContext !== directContext) {
-            // Skiko replaced its redrawer: GPU objects of the old DirectContext are
-            // dead and must not be drawn or closed into the new one late — drop them
-            // now, before anything is created on the new context.
-            cachedFrame?.close()
-            cachedFrame = null
-            cachedState = 0L
-            blitSurface?.close()
-            blitSurface = null
-            surfaceContext = null
-        }
-
-        val destAddr = ensureBitmap(width, height) ?: return cachedFrame
-        // Copy first: it can still fail benignly (the render thread swapped in a frame
-        // of another size between the state read above and now), and then the cached
-        // image must stay untouched.
-        val copiedState = backend.copyLatestFrame(handlePtr, destAddr, width, height)
-        if (copiedState == 0L) return cachedFrame
-        val blit = ensureBlitSurface(width, height, directContext) ?: return cachedFrame
-
-        // Closing the previous snapshot before writing lets Skia reuse the surface's
-        // texture instead of copy-on-writing it; the image was drawn in an already
-        // flushed Compose frame.
-        cachedFrame?.close()
-        cachedFrame = null
-        blit.writePixels(bitmap!!, 0, 0)
-        cachedFrame = blit.makeImageSnapshot()
-        cachedState = copiedState
-        return cachedFrame
-    }
-
-    /** The bitmap's native pixel address for [width] x [height], or null on failure. */
-    private fun ensureBitmap(width: Int, height: Int): Long? {
-        if (bitmap != null && bitmapWidth == width && bitmapHeight == height) {
-            return bitmapPixels?.addr
-        }
-        bitmapPixels?.close()
-        bitmapPixels = null
-        bitmap?.close()
-        bitmap = null
-        val allocated = Bitmap()
-        // The native copy forces sane alpha, but the video is opaque either way.
-        if (!allocated.allocPixels(ImageInfo(width, height, ColorType.RGBA_8888, ColorAlphaType.OPAQUE))) {
-            allocated.close()
+        // A fresh bitmap per frame: the previous one is pinned by the previous image
+        // (shared pixels) until both are replaced below.
+        val newBitmap = Bitmap()
+        if (!newBitmap.allocPixels(ImageInfo(width, height, ColorType.RGBA_8888, ColorAlphaType.OPAQUE))) {
+            newBitmap.close()
             logOnce("bitmap allocation failed (${width}x${height})", MPVLog.ERROR)
-            return null
+            return cachedFrame
         }
-        val pixels = allocated.peekPixels()
-        if (pixels == null) {
-            allocated.close()
+        val newPixels = newBitmap.peekPixels()
+        if (newPixels == null) {
+            newBitmap.close()
             logOnce("bitmap pixels are not peekable; frames stay native-only", MPVLog.ERROR)
-            return null
+            return cachedFrame
         }
-        bitmap = allocated
-        bitmapPixels = pixels
-        bitmapWidth = width
-        bitmapHeight = height
-        return pixels.addr
-    }
+        // The copy can fail benignly (the render thread swapped in a frame of another
+        // size between the state read above and now); the cached image stays untouched.
+        val copiedState = backend.copyLatestFrame(handlePtr, newPixels.addr, width, height)
+        if (copiedState == 0L) {
+            newPixels.close()
+            newBitmap.close()
+            return cachedFrame
+        }
+        // Immutable, so makeFromBitmap shares the pixels instead of copying, and Skia
+        // may cache the uploaded texture under the image's unique ID.
+        newBitmap.setImmutable()
+        val newFrame = Image.makeFromBitmap(newBitmap)
 
-    private fun ensureBlitSurface(width: Int, height: Int, directContext: DirectContext): Surface? {
-        blitSurface?.let {
-            if (surfaceContext === directContext && it.width == width && it.height == height) return it
-            // The caller already handled a context change, so this surface lives on
-            // [directContext]; resolve its pending work before destruction (see
-            // dropConsumerResources).
-            runCatching {
-                directContext.flush()
-                directContext.submit(false)
-            }
-            it.close()
-            blitSurface = null
-        }
-        // A GPU (render-target) surface: writePixels is the one CPU->GPU upload, and
-        // its snapshot is drawn zero-copy onto the Compose canvas. Same color type as
-        // the bitmap, so the upload is a straight copy — an N32 (BGRA) surface would
-        // make writePixels swizzle the whole frame on the CPU first.
-        blitSurface = runCatching {
-            Surface.makeRenderTarget(
-                directContext, false,
-                ImageInfo(width, height, ColorType.RGBA_8888, ColorAlphaType.PREMUL),
-            )
-        }.onFailure { logOnce("blit surface creation failed", MPVLog.ERROR, it) }.getOrNull()
-        if (blitSurface == null) {
-            logOnce("blit surface unavailable (${width}x${height})", MPVLog.ERROR)
-            return null
-        }
-        surfaceContext = directContext
-        return blitSurface
+        // CPU-only destructors — safe on any thread with any (or no) GL context
+        // current. Skia purges a cached texture of a closed image through its own
+        // message bus, never from this destructor.
+        cachedFrame?.close()
+        bitmapPixels?.close()
+        bitmap?.close()
+        cachedFrame = newFrame
+        bitmap = newBitmap
+        bitmapPixels = newPixels
+        cachedState = copiedState
+        return newFrame
     }
 
     private fun dropConsumerResources() {
-        // Resolve any recorded-but-unsubmitted work targeting the blit surface (the
-        // last writePixels/snapshot may not have gone through a Skiko frame-end flush
-        // when disposal runs mid-frame) so the surface destructor below has nothing
-        // left to flush or wait on.
-        if (blitSurface != null || cachedFrame != null) {
-            surfaceContext?.let { context ->
-                runCatching {
-                    context.flush()
-                    context.submit(false)
-                }
-            }
-        }
         cachedFrame?.close()
         cachedFrame = null
         cachedState = 0L
-        blitSurface?.close()
-        blitSurface = null
-        surfaceContext = null
         bitmapPixels?.close()
         bitmapPixels = null
         bitmap?.close()
         bitmap = null
-        bitmapWidth = 0
-        bitmapHeight = 0
     }
 
     private val loggedStates = mutableSetOf<String>()
@@ -199,11 +136,10 @@ internal class MpvReadbackSurface(
     }
 
     override fun release() {
-        // Quiesce the producer FIRST — deactivation is synchronous on this backend.
-        // Destroying the Skia GPU objects below while the producer's WGL context is
-        // still actively rendering can block the destructor in the GL driver's
-        // cross-context synchronization (observed as an EDT hang at window close,
-        // while the same closes succeed when the producer is idle).
+        // Deactivation is synchronous: after it returns, the render thread has dropped
+        // its FBO and parked, so the native side can no longer write into the bitmap
+        // being closed below (copies only ever run on this thread anyway; this also
+        // quiesces mpv's frame flow before the player is torn down).
         backend.setSurfaceConfig(handlePtr, 0, 0, 0L)
         dropConsumerResources()
         requestedWidth = 0

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvReadbackSurface.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvReadbackSurface.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.internal
+
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Pixmap
+import org.jetbrains.skia.Surface
+import org.openani.mediamp.mpv.MPVLog
+
+/**
+ * Consumer side of the Windows OpenGL fallback: the native render thread publishes CPU
+ * frames (RGBA_8888, top-down on copy); this class copies the latest one straight into
+ * a Skia bitmap's native pixel storage (no JNI arrays, no Java-heap staging), uploads
+ * it into a GPU surface on Skia's current DirectContext, and caches the snapshot. The
+ * expensive part (copy + upload) only runs when the native frame state advanced;
+ * overlay-driven Compose redraws just re-draw the cached image. During a resize the
+ * previous frame is returned until a frame at the new size exists, so resizes never
+ * flash black. All methods are called from the Compose/Skiko UI thread only.
+ */
+internal class MpvReadbackSurface(
+    private val handlePtr: Long,
+    private val backend: WindowsOpenGLSurfaceBackend,
+) : MpvSurfaceConsumer {
+    private var bitmap: Bitmap? = null
+    private var bitmapPixels: Pixmap? = null
+    private var bitmapWidth = 0
+    private var bitmapHeight = 0
+
+    private var blitSurface: Surface? = null
+    private var surfaceContext: DirectContext? = null
+
+    private var cachedFrame: Image? = null
+    private var cachedState = 0L
+
+    private var requestedWidth = 0
+    private var requestedHeight = 0
+    private var configured = false
+
+    override fun requestSurface(width: Int, height: Int, devicePtr: Long): Boolean {
+        if (configured && width == requestedWidth && height == requestedHeight) return true
+        if (!backend.setSurfaceConfig(handlePtr, width, height, 0L)) return false
+        requestedWidth = width
+        requestedHeight = height
+        configured = true
+        return true
+    }
+
+    override fun refreshDeviceIfChanged(devicePtr: Long) {
+        // Frames arrive as CPU pixels; no consumer render device is involved. A
+        // replaced Skiko DirectContext is detected per draw in currentFrameImage.
+    }
+
+    override fun invalidateForRenderEnvironmentChange() {
+        dropConsumerResources()
+    }
+
+    override fun currentFrameImage(directContext: DirectContext): Image? {
+        val state = backend.getFrameState(handlePtr)
+        if (state == cachedState && surfaceContext === directContext) {
+            cachedFrame?.let { return it }
+        }
+        val index = ((state ushr 44) and 0xF).toInt()
+        val width = ((state ushr 30) and 0x3FFF).toInt()
+        val height = ((state ushr 16) and 0x3FFF).toInt()
+        if (index == 0xF || width <= 0 || height <= 0) return cachedFrame
+
+        if (surfaceContext !== directContext) {
+            // Skiko replaced its redrawer: GPU objects of the old DirectContext are
+            // dead and must not be drawn or closed into the new one late — drop them
+            // now, before anything is created on the new context.
+            cachedFrame?.close()
+            cachedFrame = null
+            cachedState = 0L
+            blitSurface?.close()
+            blitSurface = null
+            surfaceContext = null
+        }
+
+        val destAddr = ensureBitmap(width, height) ?: return cachedFrame
+        // Copy first: it can still fail benignly (the render thread swapped in a frame
+        // of another size between the state read above and now), and then the cached
+        // image must stay untouched.
+        val copiedState = backend.copyLatestFrame(handlePtr, destAddr, width, height)
+        if (copiedState == 0L) return cachedFrame
+        val blit = ensureBlitSurface(width, height, directContext) ?: return cachedFrame
+
+        // Closing the previous snapshot before writing lets Skia reuse the surface's
+        // texture instead of copy-on-writing it; the image was drawn in an already
+        // flushed Compose frame.
+        cachedFrame?.close()
+        cachedFrame = null
+        blit.writePixels(bitmap!!, 0, 0)
+        cachedFrame = blit.makeImageSnapshot()
+        cachedState = copiedState
+        return cachedFrame
+    }
+
+    /** The bitmap's native pixel address for [width] x [height], or null on failure. */
+    private fun ensureBitmap(width: Int, height: Int): Long? {
+        if (bitmap != null && bitmapWidth == width && bitmapHeight == height) {
+            return bitmapPixels?.addr
+        }
+        bitmapPixels?.close()
+        bitmapPixels = null
+        bitmap?.close()
+        bitmap = null
+        val allocated = Bitmap()
+        // The native copy forces sane alpha, but the video is opaque either way.
+        if (!allocated.allocPixels(ImageInfo(width, height, ColorType.RGBA_8888, ColorAlphaType.OPAQUE))) {
+            allocated.close()
+            logOnce("bitmap allocation failed (${width}x${height})", MPVLog.ERROR)
+            return null
+        }
+        val pixels = allocated.peekPixels()
+        if (pixels == null) {
+            allocated.close()
+            logOnce("bitmap pixels are not peekable; frames stay native-only", MPVLog.ERROR)
+            return null
+        }
+        bitmap = allocated
+        bitmapPixels = pixels
+        bitmapWidth = width
+        bitmapHeight = height
+        return pixels.addr
+    }
+
+    private fun ensureBlitSurface(width: Int, height: Int, directContext: DirectContext): Surface? {
+        blitSurface?.let {
+            if (surfaceContext === directContext && it.width == width && it.height == height) return it
+            it.close()
+            blitSurface = null
+        }
+        // A GPU (render-target) surface: writePixels is the one CPU->GPU upload, and
+        // its snapshot is drawn zero-copy onto the Compose canvas. Same color type as
+        // the bitmap, so the upload is a straight copy — an N32 (BGRA) surface would
+        // make writePixels swizzle the whole frame on the CPU first.
+        blitSurface = runCatching {
+            Surface.makeRenderTarget(
+                directContext, false,
+                ImageInfo(width, height, ColorType.RGBA_8888, ColorAlphaType.PREMUL),
+            )
+        }.onFailure { logOnce("blit surface creation failed", MPVLog.ERROR, it) }.getOrNull()
+        if (blitSurface == null) {
+            logOnce("blit surface unavailable (${width}x${height})", MPVLog.ERROR)
+            return null
+        }
+        surfaceContext = directContext
+        return blitSurface
+    }
+
+    private fun dropConsumerResources() {
+        cachedFrame?.close()
+        cachedFrame = null
+        cachedState = 0L
+        blitSurface?.close()
+        blitSurface = null
+        surfaceContext = null
+        bitmapPixels?.close()
+        bitmapPixels = null
+        bitmap?.close()
+        bitmap = null
+        bitmapWidth = 0
+        bitmapHeight = 0
+    }
+
+    private val loggedStates = mutableSetOf<String>()
+    private fun logOnce(message: String, level: Int = MPVLog.WARN, throwable: Throwable? = null) {
+        if (loggedStates.add(message)) MPVLog.log(handlePtr, level, message, throwable)
+    }
+
+    override fun release() {
+        dropConsumerResources()
+        // The render thread may drop its target and go back to draining frames.
+        backend.setSurfaceConfig(handlePtr, 0, 0, 0L)
+        requestedWidth = 0
+        requestedHeight = 0
+        configured = false
+    }
+}

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvRenderContextLifecycle.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvRenderContextLifecycle.kt
@@ -41,11 +41,11 @@ internal fun interface MpvRenderContextProvisioning {
 
 /**
  * Per-player lifecycle of the backend's producer render context: WHEN
- * [MpvSurfaceRingBackend.createRenderContext] may run. Backends that own their producer
+ * [MpvSurfaceBackend.createRenderContext] may run. Backends that own their producer
  * device ([EagerRenderContextLifecycle]) create it at player construction; backends whose
  * producer context must join an externally owned render environment
  * (`OpenGLRenderContextLifecycle`) create it only once that environment has been attached
- * and gate `loadfile` on it. Chosen by [MpvSurfaceRingBackend], so the shared player and
+ * and gate `loadfile` on it. Chosen by [MpvSurfaceBackend], so the shared player and
  * composable contain no platform checks — and platform-specific operations (such as the
  * Linux GLX attach) exist only on the platform implementation, where other platforms
  * cannot call them by mistake.
@@ -92,12 +92,12 @@ internal interface MpvRenderContextLifecycle {
 }
 
 /**
- * Lifecycle for backends that own their producer device (macOS Metal, Windows D3D11):
- * the render context is created eagerly at player construction and needs nothing from
- * the live Skiko renderer.
+ * Lifecycle for backends that own their producer device (macOS Metal, Windows D3D11,
+ * and the Windows OpenGL fallback): the render context is created eagerly at player
+ * construction and needs nothing from the live Skiko renderer.
  */
 internal class EagerRenderContextLifecycle(
-    private val backend: MpvSurfaceRingBackend,
+    private val backend: MpvSurfaceBackend,
     private val host: MpvRenderContextHost,
 ) : MpvRenderContextLifecycle {
     override fun initialize() {

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceConsumer.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceConsumer.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.internal
+
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.Image
+
+/**
+ * Consumer side of a native render path: turns whatever the native render thread
+ * publishes into a Skia [Image] the Compose surface draws. Two implementations exist:
+ * [MpvSurfaceRing] wraps a ring of shared GPU textures (macOS Metal, Windows D3D11,
+ * Linux GLX), and [MpvReadbackSurface] uploads the CPU frames of the Windows OpenGL
+ * fallback. All methods are called from the Compose/Skiko UI thread only.
+ */
+internal interface MpvSurfaceConsumer {
+    /**
+     * Asks the native render thread to size its render target to [width] x [height]
+     * (physical pixels, normally the composable size — mpv then scales, letterboxes
+     * and renders subtitles at display resolution). Asynchronous and cheap; until the
+     * first frame lands at the new size, [currentFrameImage] keeps returning the
+     * previous frame. [devicePtr] is the consumer render device where the backend
+     * needs one (see [MpvSurfaceBackend.setSurfaceConfig]).
+     */
+    fun requestSurface(width: Int, height: Int, devicePtr: Long): Boolean
+
+    /** Re-posts the current config when Skiko recreated its redrawer on a new device. */
+    fun refreshDeviceIfChanged(devicePtr: Long)
+
+    /** Drops consumer-side Skia objects before the producer replaces its render environment. */
+    fun invalidateForRenderEnvironmentChange()
+
+    /**
+     * Returns the latest video frame as a Skia-owned texture image (safe to draw
+     * through Compose, including RenderNode recordings), or null when no frame exists
+     * yet. Do NOT close the returned image — it is owned by this consumer.
+     */
+    fun currentFrameImage(directContext: DirectContext): Image?
+
+    /** Releases all consumer resources and deactivates the native surface. */
+    fun release()
+}

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceConsumer.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceConsumer.kt
@@ -36,8 +36,9 @@ internal interface MpvSurfaceConsumer {
     fun invalidateForRenderEnvironmentChange()
 
     /**
-     * Returns the latest video frame as a Skia-owned texture image (safe to draw
-     * through Compose, including RenderNode recordings), or null when no frame exists
+     * Returns the latest video frame as a Skia image (safe to draw through Compose,
+     * including RenderNode recordings; a GPU texture for the ring backends, an
+     * immutable raster image for the readback fallback), or null when no frame exists
      * yet. Do NOT close the returned image — it is owned by this consumer.
      */
     fun currentFrameImage(directContext: DirectContext): Image?

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceDrawResolver.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceDrawResolver.kt
@@ -23,7 +23,7 @@ internal class MpvSurfaceDrawPass(
 )
 
 /**
- * Platform half of the compose draw pass, mirroring [MpvSurfaceRingBackend]: how each
+ * Platform half of the compose draw pass, mirroring [MpvSurfaceBackend]: how each
  * draw resolves readiness and Skia's current target. Environment-bound backends may
  * (re)attach their render environment inside [resolveDrawPass]; eager backends only gate
  * on the readiness established when the surface entered composition.
@@ -43,7 +43,7 @@ internal interface MpvSurfaceDrawResolver {
 
 /** Draw resolver for eagerly-created contexts: readiness was decided at composition start. */
 internal class EagerSurfaceDrawResolver(
-    backend: MpvSurfaceRingBackend,
+    backend: MpvSurfaceBackend,
     private val interop: SkiaRenderDeviceInterop,
 ) : MpvSurfaceDrawResolver {
     override val rendererName: String = backend.rendererName

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvSurfaceRing.kt
@@ -18,8 +18,10 @@ import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
 import org.jetbrains.skia.SurfaceOrigin
+import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkiaLayer
+import org.jetbrains.skiko.SkikoProperties
 import org.jetbrains.skiko.hostOs
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.mpv.MPVLog
@@ -81,30 +83,42 @@ internal class MpvConsumerRenderTarget(
 }
 
 /**
- * The native surface-ring backend for the current host: macOS renders through
- * Metal/IOSurface (render_macos.mm), Windows through D3D11/D3D12 shared textures,
- * and Linux through shared OpenGL textures (render_glx.cpp).
+ * The native surface backend for the current host: macOS renders through
+ * Metal/IOSurface (render_macos.mm), Windows through D3D11/D3D12 shared textures
+ * (render_d3d11.cpp) or the OpenGL readback fallback (render_opengl_win.cpp), and
+ * Linux through shared OpenGL textures (render_glx.cpp).
  */
-internal fun currentSurfaceRingBackend(): MpvSurfaceRingBackend? = when (hostOs) {
+internal fun currentSurfaceBackend(): MpvSurfaceBackend? = when (hostOs) {
     OS.MacOS -> MacosSurfaceRingBackend
-    OS.Windows -> D3D11SurfaceRingBackend
+    OS.Windows -> windowsSurfaceBackend()
     OS.Linux -> OpenGLSurfaceRingBackend
     else -> null
 }
 
 /**
- * Platform half of the native surface-ring render path: the JNI entry points, how a
- * ring buffer's native texture is wrapped for Skia, which reflective Skia interop reads
- * the consumer device, and which [MpvRenderContextLifecycle] governs the producer
- * context. The consumer state machine on top ([MpvSurfaceRing]) is capability-based:
- * Metal/IOSurface on macOS, D3D11/D3D12 shared textures on Windows, and shared OpenGL
- * textures on Linux/GLX.
+ * The D3D11 shared-texture path needs Skia to run on Skiko's Direct3D backend (the
+ * Windows default): its ring buffers are opened on Skia's D3D12 device. When the host
+ * configures another Skiko render API (`SKIKO_RENDER_API=OPENGL`), Skia has no such
+ * device, so the OpenGL readback fallback drives mpv instead. Decided from Skiko's
+ * *configured* API because the backend (and with it mpv's render context type) must be
+ * chosen at player construction, before any SkiaLayer exists; if Skiko later falls back
+ * to a different redrawer at runtime, the draw-time interop reports the mismatch.
  */
-internal interface MpvSurfaceRingBackend {
+private fun windowsSurfaceBackend(): MpvSurfaceBackend =
+    if (SkikoProperties.renderApi == GraphicsApi.DIRECT3D) D3D11SurfaceRingBackend
+    else WindowsOpenGLSurfaceBackend
+
+/**
+ * Platform half of a native render path: the JNI entry points, which reflective Skia
+ * interop reads the consumer device, which [MpvRenderContextLifecycle] governs the
+ * producer context, and which [MpvSurfaceConsumer] turns published frames into Skia
+ * images.
+ */
+internal interface MpvSurfaceBackend {
     fun createRenderContext(ptr: Long): Boolean
     fun destroyRenderContext(ptr: Long): Boolean
 
-    /** Renderer name for user-facing logs: what Compose draws the ring's frames with. */
+    /** Renderer name for user-facing logs: what Compose draws the published frames with. */
     val rendererName: String
 
     /** Creates the reflective interop reading the consumer render device of [layer]. */
@@ -120,14 +134,13 @@ internal interface MpvSurfaceRingBackend {
 
     /**
      * [devicePtr] is the consumer-side render device: an MTLDevice pointer on macOS or a
-     * pointer to Skiko's native DirectXDevice struct on Windows. OpenGL attaches its GLX
-     * environment separately and ignores this value. 0 requests a consumer-less ring
-     * where that platform supports one.
+     * pointer to Skiko's native DirectXDevice struct on Windows/D3D11. The OpenGL
+     * backends ignore this value (Linux attaches its GLX environment separately; the
+     * Windows fallback has no consumer device at all). 0 requests a consumer-less
+     * surface where that platform supports one.
      */
     fun setSurfaceConfig(ptr: Long, width: Int, height: Int, devicePtr: Long): Boolean
     fun getFrameState(ptr: Long): Long
-    fun getBufferTexture(ptr: Long, index: Int): Long
-    fun ackRetiredBuffers(ptr: Long): Boolean
     fun hasSurface(ptr: Long): Boolean
     fun saveSurfacePng(ptr: Long, path: String): Boolean
 
@@ -138,9 +151,28 @@ internal interface MpvSurfaceRingBackend {
      */
     fun readSurfacePixels(ptr: Long, dims: IntArray): IntArray?
 
+    /** Creates the consumer state machine matching this backend's publication model. */
+    fun createSurfaceConsumer(handlePtr: Long): MpvSurfaceConsumer
+}
+
+/**
+ * A [MpvSurfaceBackend] whose native render thread publishes a triple-buffered ring of
+ * GPU textures that are directly visible to Skia's render device: how a ring buffer's
+ * native texture is wrapped for Skia, plus the retire/ack protocol for ring swaps. The
+ * consumer state machine on top ([MpvSurfaceRing]) is capability-based: Metal/IOSurface
+ * on macOS, D3D11/D3D12 shared textures on Windows, shared OpenGL textures on
+ * Linux/GLX.
+ */
+internal interface MpvSurfaceRingBackend : MpvSurfaceBackend {
+    fun getBufferTexture(ptr: Long, index: Int): Long
+    fun ackRetiredBuffers(ptr: Long): Boolean
+
     fun makeConsumerRenderTarget(width: Int, height: Int, texturePtr: Long): MpvConsumerRenderTarget
     val wrapColorFormat: SurfaceColorFormat
     val skiaSurfaceOrigin: SurfaceOrigin get() = SurfaceOrigin.TOP_LEFT
+
+    override fun createSurfaceConsumer(handlePtr: Long): MpvSurfaceConsumer =
+        MpvSurfaceRing(handlePtr, this)
 }
 
 @OptIn(InternalMediampApi::class)
@@ -280,7 +312,7 @@ internal object OpenGLSurfaceRingBackend : MpvSurfaceRingBackend {
 internal class MpvSurfaceRing(
     private val handlePtr: Long,
     private val backend: MpvSurfaceRingBackend,
-) {
+) : MpvSurfaceConsumer {
     private val wrappedSurfaces = arrayOfNulls<Surface>(SURFACE_RING_BUFFER_COUNT)
     private val consumerTargets = arrayOfNulls<MpvConsumerRenderTarget>(SURFACE_RING_BUFFER_COUNT)
     private var blitSurface: Surface? = null
@@ -303,7 +335,7 @@ internal class MpvSurfaceRing(
      * happens between frames on the render thread; until the first frame lands in the
      * new ring, [currentFrameImage] keeps returning the previous frame.
      */
-    fun requestSurface(width: Int, height: Int, devicePtr: Long): Boolean {
+    override fun requestSurface(width: Int, height: Int, devicePtr: Long): Boolean {
         if (width == requestedWidth && height == requestedHeight &&
             devicePtr == requestedDevicePtr
         ) return true
@@ -315,7 +347,7 @@ internal class MpvSurfaceRing(
     }
 
     /** Re-posts the current config when Skiko recreated its redrawer on a new device. */
-    fun refreshDeviceIfChanged(devicePtr: Long) {
+    override fun refreshDeviceIfChanged(devicePtr: Long) {
         if (requestedWidth > 0 && devicePtr != requestedDevicePtr) {
             requestSurface(requestedWidth, requestedHeight, devicePtr)
         }
@@ -326,7 +358,7 @@ internal class MpvSurfaceRing(
      * A replaced GLX context destroys its context-local FBOs itself; their shared texture
      * names must never be reused by the new context.
      */
-    fun invalidateForRenderEnvironmentChange() {
+    override fun invalidateForRenderEnvironmentChange() {
         cachedFrame?.close()
         cachedFrame = null
         cachedState = 0L
@@ -347,7 +379,7 @@ internal class MpvSurfaceRing(
      * returned until the new ring has content, so resizes never flash black. Do NOT
      * close the returned image — it is owned by this ring.
      */
-    fun currentFrameImage(directContext: DirectContext): Image? {
+    override fun currentFrameImage(directContext: DirectContext): Image? {
         val state = backend.getFrameState(handlePtr)
         if (state == cachedState && surfaceContext === directContext) {
             cachedFrame?.let { return it }
@@ -489,7 +521,7 @@ internal class MpvSurfaceRing(
         if (loggedStates.add(message)) MPVLog.log(handlePtr, level, message, throwable)
     }
 
-    fun release() {
+    override fun release() {
         cachedFrame?.close()
         cachedFrame = null
         cachedState = 0L

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/WindowsOpenGLSurfaceBackend.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/WindowsOpenGLSurfaceBackend.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.internal
+
+import org.jetbrains.skiko.SkiaLayer
+import org.openani.mediamp.InternalMediampApi
+import org.openani.mediamp.mpv.nCopyLatestFrameWindowsOpenGL
+import org.openani.mediamp.mpv.nCreateRenderContextWindowsOpenGL
+import org.openani.mediamp.mpv.nDestroyRenderContextWindowsOpenGL
+import org.openani.mediamp.mpv.nGetFrameStateWindowsOpenGL
+import org.openani.mediamp.mpv.nHasWindowsOpenGLSurface
+import org.openani.mediamp.mpv.nReadSurfacePixelsWindowsOpenGL
+import org.openani.mediamp.mpv.nSaveSurfacePngWindowsOpenGL
+import org.openani.mediamp.mpv.nSetSurfaceConfigWindowsOpenGL
+import org.openani.mediamp.mpv.utils.SkiaRenderDeviceInterop
+import org.openani.mediamp.mpv.utils.SkiaWindowsOpenGLInterop
+
+/**
+ * Windows OpenGL fallback backend (render_opengl_win.cpp): drives mpv when Compose
+ * renders with Skiko's OpenGL backend (`SKIKO_RENDER_API=OPENGL`) instead of the
+ * Direct3D default, where the D3D11 shared-texture path has no D3D12 consumer device.
+ *
+ * The producer is a private offscreen WGL context on a dedicated render thread; it
+ * shares nothing with Skiko — frames leave it as CPU pixel copies which the consumer
+ * ([MpvReadbackSurface]) uploads into a Skia surface during draw. One GPU->CPU->GPU
+ * round trip per frame by design: this is the compatibility path, chosen for
+ * robustness over zero-copy (no wglShareLists, no pixel-format matching against
+ * Skiko's drawable). Because the producer needs nothing from the live Skiko renderer,
+ * the eager lifecycle applies, and the frame-preview decoder can create its own
+ * context freely.
+ */
+@OptIn(InternalMediampApi::class)
+internal object WindowsOpenGLSurfaceBackend : MpvSurfaceBackend {
+    override fun createRenderContext(ptr: Long) = nCreateRenderContextWindowsOpenGL(ptr)
+    override fun destroyRenderContext(ptr: Long) = nDestroyRenderContextWindowsOpenGL(ptr)
+
+    // No consumer device: frames leave the producer through a CPU copy.
+    override fun setSurfaceConfig(ptr: Long, width: Int, height: Int, devicePtr: Long) =
+        nSetSurfaceConfigWindowsOpenGL(ptr, width, height)
+
+    override fun getFrameState(ptr: Long) = nGetFrameStateWindowsOpenGL(ptr)
+    override fun hasSurface(ptr: Long) = nHasWindowsOpenGLSurface(ptr)
+    override fun saveSurfacePng(ptr: Long, path: String) = nSaveSurfacePngWindowsOpenGL(ptr, path)
+    override fun readSurfacePixels(ptr: Long, dims: IntArray) = nReadSurfacePixelsWindowsOpenGL(ptr, dims)
+
+    /** See [nCopyLatestFrameWindowsOpenGL]. */
+    fun copyLatestFrame(ptr: Long, destAddr: Long, width: Int, height: Int): Long =
+        nCopyLatestFrameWindowsOpenGL(ptr, destAddr, width, height)
+
+    override fun createSurfaceConsumer(handlePtr: Long): MpvSurfaceConsumer =
+        MpvReadbackSurface(handlePtr, this)
+
+    override val rendererName: String get() = "OpenGL/WGL readback"
+    override fun createSkiaInterop(layer: SkiaLayer): SkiaRenderDeviceInterop =
+        SkiaWindowsOpenGLInterop(layer)
+
+    override fun createRenderContextLifecycle(host: MpvRenderContextHost): MpvRenderContextLifecycle =
+        WindowsOpenGLRenderContextLifecycle(EagerRenderContextLifecycle(this, host), host)
+}
+
+/**
+ * Eager lifecycle with the fallback's decode constraint: a GL renderer has no zero-copy
+ * D3D11/DXVA2 interop in this build, so decode on the GPU through D3D11 and copy the
+ * frames back to system memory for mpv's GL upload; mpv's safe auto list covers codecs
+ * d3d11va cannot handle. Deliberately not plain `auto`, which prefers direct-mapping
+ * modes whose interop does not exist here.
+ */
+internal class WindowsOpenGLRenderContextLifecycle(
+    private val eager: EagerRenderContextLifecycle,
+    private val host: MpvRenderContextHost,
+) : MpvRenderContextLifecycle by eager {
+    override fun initialize() {
+        check(host.handle.setPropertyString("hwdec", "d3d11va-copy,auto-safe"))
+        eager.initialize()
+    }
+}

--- a/mediamp-mpv/src/desktopMain/kotlin/utils/SkiaWindowsOpenGLInterop.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/utils/SkiaWindowsOpenGLInterop.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv.utils
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skiko.SkiaLayer
+
+/**
+ * Reflective access to Skiko 0.9.37.4's Windows OpenGL redrawer
+ * ([WindowsOpenGLRedrawer]), which Compose uses when the render API is OPENGL instead
+ * of the Direct3D 12 default.
+ *
+ * The OpenGL fallback producer is fully independent of Skiko (its frames arrive as CPU
+ * copies), so unlike the other interops this one carries no real render device: only
+ * Skia's DirectContext (the consumer upload target) and the redrawer's private
+ * `context` Long, which serves purely as an identity token for detecting redrawer
+ * recreation — its native meaning is never interpreted.
+ *
+ * The redrawer (and with it the DirectContext) can be recreated by Skiko at runtime,
+ * so nothing is cached across calls — every access re-reads the live redrawer from the
+ * layer.
+ */
+internal class SkiaWindowsOpenGLInterop(private val layer: SkiaLayer) : SkiaRenderDeviceInterop {
+    private val getRedrawerMethod: Method = SkiaLayer::class.java.getMethod("getRedrawer\$skiko")
+
+    private class RedrawerAccess(redrawerClass: Class<*>) {
+        val contextHandlerField: Field = redrawerClass.getDeclaredField("contextHandler")
+            .apply { isAccessible = true }
+        val contextField: Field = redrawerClass.getDeclaredField("context")
+            .apply { isAccessible = true }
+        val directContextField: Field = Class.forName("org.jetbrains.skiko.context.ContextHandler")
+            .getDeclaredField("context")
+            .apply { isAccessible = true }
+
+        init {
+            check(contextHandlerField.type.name == "org.jetbrains.skiko.context.OpenGLContextHandler") {
+                "Unexpected WindowsOpenGLRedrawer.contextHandler type ${contextHandlerField.type.name}; " +
+                    "Skiko 0.9.37.4 OpenGL interop layout changed."
+            }
+            check(contextField.type == java.lang.Long.TYPE) {
+                "Unexpected WindowsOpenGLRedrawer.context type ${contextField.type}; expected long."
+            }
+            check(DirectContext::class.java.isAssignableFrom(directContextField.type)) {
+                "Unexpected ContextHandler.context type ${directContextField.type}; expected DirectContext."
+            }
+        }
+    }
+
+    private var cachedAccess: RedrawerAccess? = null
+    private var cachedAccessClass: Class<*>? = null
+
+    private fun currentRedrawer(): Any {
+        val redrawer = getRedrawerMethod.invoke(layer) ?: error(
+            "SkiaLayer has no redrawer yet. Attach the player after the Compose window is visible."
+        )
+        check(redrawer.javaClass.name == WINDOWS_OPENGL_REDRAWER) {
+            "Unsupported Skiko redrawer ${redrawer.javaClass.name}. The mpv OpenGL fallback " +
+                "on Windows requires Skiko's WindowsOpenGLRedrawer, which Compose only uses when " +
+                "SKIKO_RENDER_API/skiko.renderApi is OPENGL. Unset it to use the Direct3D render " +
+                "path instead (mediamp then drives mpv through D3D11)."
+        }
+        return redrawer
+    }
+
+    private fun accessFor(redrawer: Any): RedrawerAccess {
+        val clazz = redrawer.javaClass
+        cachedAccess?.let { if (cachedAccessClass == clazz) return it }
+        return RedrawerAccess(clazz).also {
+            cachedAccess = it
+            cachedAccessClass = clazz
+        }
+    }
+
+    /** The redrawer's own context token — an identity, not a usable device pointer. */
+    override val renderDevicePtr: Long
+        get() {
+            val redrawer = currentRedrawer()
+            return accessFor(redrawer).contextField.getLong(redrawer)
+        }
+
+    /** Skia's live GrDirectContext; null before its first render. */
+    override val directContext: DirectContext?
+        get() {
+            val redrawer = currentRedrawer()
+            val access = accessFor(redrawer)
+            return access.directContextField.get(access.contextHandlerField.get(redrawer)) as DirectContext?
+        }
+
+    companion object {
+        private const val WINDOWS_OPENGL_REDRAWER = "org.jetbrains.skiko.redrawer.WindowsOpenGLRedrawer"
+    }
+}

--- a/mediamp-mpv/src/desktopTest/kotlin/SkikoWindowsOpenGLReflectionLayoutTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/SkikoWindowsOpenGLReflectionLayoutTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.mpv
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SkikoWindowsOpenGLReflectionLayoutTest {
+    @Test
+    fun `Skiko Windows OpenGL reflection layout matches the production interop`() {
+        val result = probeSkikoWindowsOpenGLReflectionLayout()
+        System.err.println("[WindowsOpenGLValidation] Skiko reflection preflight: ${result.message}")
+        assertTrue(result.compatible, "Skiko 0.9.37.4 reflection layout changed: ${result.message}")
+    }
+}
+
+private data class WindowsReflectionLayoutResult(val compatible: Boolean, val message: String)
+
+/**
+ * Checks the private Skiko layout SkiaWindowsOpenGLInterop reflects, without
+ * initializing SkiaLayer or creating a WGL context — so it runs on every host OS.
+ */
+private fun probeSkikoWindowsOpenGLReflectionLayout(): WindowsReflectionLayoutResult {
+    val classLoader = SkikoWindowsOpenGLReflectionLayoutTest::class.java.classLoader
+    val layer = runCatching { Class.forName("org.jetbrains.skiko.SkiaLayer", false, classLoader) }
+        .getOrElse { return WindowsReflectionLayoutResult(false, "SkiaLayer is not on the classpath: $it") }
+    val redrawer = runCatching {
+        Class.forName("org.jetbrains.skiko.redrawer.WindowsOpenGLRedrawer", false, classLoader)
+    }.getOrElse { return WindowsReflectionLayoutResult(false, "WindowsOpenGLRedrawer is not on the classpath: $it") }
+    val redrawerGetter = layer.methods.firstOrNull { it.name == "getRedrawer\$skiko" && it.parameterCount == 0 }
+        ?: return WindowsReflectionLayoutResult(false, "SkiaLayer.getRedrawer\$skiko() is missing")
+    val contextHandler = generateSequence(redrawer) { it.superclass }
+        .flatMap { it.declaredFields.asSequence() }
+        .firstOrNull { it.name == "contextHandler" }
+        ?: return WindowsReflectionLayoutResult(false, "WindowsOpenGLRedrawer.contextHandler is missing")
+    val redrawerContext = generateSequence(redrawer) { it.superclass }
+        .flatMap { it.declaredFields.asSequence() }
+        .firstOrNull { it.name == "context" && it.type == java.lang.Long.TYPE }
+        ?: return WindowsReflectionLayoutResult(false, "WindowsOpenGLRedrawer.context (long) is missing")
+    val context = generateSequence(contextHandler.type) { it.superclass }
+        .flatMap { it.declaredFields.asSequence() }
+        .firstOrNull { it.name == "context" }
+        ?: return WindowsReflectionLayoutResult(false, "${contextHandler.type.name}.context is missing")
+
+    return WindowsReflectionLayoutResult(
+        compatible = true,
+        message = "${redrawer.name}; ${redrawerGetter.name}; ${contextHandler.type.name}.${context.name}; " +
+            "${redrawer.simpleName}.${redrawerContext.name}",
+    )
+}

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -351,8 +351,11 @@ abstract class JvmMpvMediampPlayer(
             }
 
             is Platform.Windows -> {
-                // The desktop render path drives the libmpv D3D11 render API on its own
-                // ID3D11Device (render_d3d11.cpp); gpu-context is not used with vo=libmpv.
+                // The desktop render path drives either the libmpv D3D11 render API on
+                // its own ID3D11Device (render_d3d11.cpp) or, when Compose renders with
+                // Skiko's OpenGL backend, the OpenGL render API on a private offscreen
+                // WGL context with CPU readback (render_opengl_win.cpp). gpu-context is
+                // not used with vo=libmpv either way.
                 handle.option("ao", "wasapi")
                 handle.option("vo", "libmpv")
             }

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -655,8 +655,11 @@ abstract class JvmMpvMediampPlayer(
         mediaMetadata.clear()
         // Released is already committed and the session detached; do the heavy native
         // teardown off the machine thread (spec §4): mpv destruction joins the native event
-        // thread, which used to hang the UI thread (v1 defect M8).
-        thread(name = "mediamp-mpv-teardown") {
+        // thread, which used to hang the UI thread (v1 defect M8). Daemon so that a wedged
+        // native join can never keep a naturally-exiting JVM alive: while the app runs the
+        // thread completes normally, and once the JVM is exiting anyway the OS reclaims
+        // whatever a killed teardown would have released.
+        thread(name = "mediamp-mpv-teardown", isDaemon = true) {
             runCatching { handle.command("stop") }
             runCatching { handle.destroy() }
             runCatching { handle.close() }


### PR DESCRIPTION
## Why

Compose renders Windows with Direct3D 12 by default, and mediamp drives mpv through the libmpv D3D11 render API to match. A host that switches Skiko to its OpenGL backend (`SKIKO_RENDER_API=OPENGL` / `-Dskiko.renderApi=OPENGL`) leaves Skia without a D3D12 device, so the shared-texture ring cannot exist and video stays black.

PR #59 ported the Linux shared-texture design to WGL (producer context in Skiko's share group). On the test machine, both `wglCreateContextAttribsARB` and the `wglShareLists` fallback refused the shared context. This PR is a fresh start from `main` with the opposite philosophy: **a compatibility fallback that shares nothing, so the parts drivers rejected simply do not exist.** 可用性优先，不追求零拷贝。

## What

A dedicated render thread drives mpv through the libmpv OpenGL render API on a **private offscreen WGL context** — hidden 1×1 `CS_OWNDC` window, first hardware-accelerated (ICD) pixel format, 3.3 core via `wglCreateContextAttribsARB` with a legacy `wglCreateContext` fallback — into a single FBO, and reads every frame back to CPU memory (`glReadPixels`, double-buffered swap under the state mutex). The consumer copies the latest frame straight into a Skia bitmap's native pixels during a Compose draw (`nCopyLatestFrameWindowsOpenGL` → `Bitmap.peekPixels().addr`, no JNI arrays), uploads it with `Surface.writePixels`, and caches the snapshot. Redraws that arrive without a new frame reuse the cached image.

One GPU→CPU→GPU round trip per frame is the design, not an accident:

- no `wglShareLists`, no pixel-format matching against Skiko's drawable, no cross-context object lifetimes — exactly the machinery that failed in #59;
- the producer needs *nothing* from the live Skiko renderer, so the **eager lifecycle applies unchanged**: no deferred `loadfile` gating (`surface-independent-open` stays intact), and the frame-preview decoder works without provisioning;
- `render_glx.cpp` and `render_d3d11.cpp` are untouched (D3D11 stays the default path; the only D3D11-file change is using the extracted WIC PNG helper).

At 1080p the readback+upload is ~8 MB × 2 per frame — trivially fine; 4K is heavier but acceptable for a fallback.

### Selection

Chosen at player construction from `SkikoProperties.renderApi` (public Skiko API, reads `skiko.renderApi`/`SKIKO_RENDER_API`): `DIRECT3D` → D3D11 shared-texture path, anything else → this fallback. Unset defaults to `DIRECT3D`, so existing setups are unaffected. If Skiko falls back to a different redrawer at runtime, the draw-time interop reports the mismatch with an actionable message.

### Structure

| | |
|---|---|
| `wgl_offscreen_context.{h,cpp}` | Hidden window + ICD pixel-format scan + context creation. `ChoosePixelFormat` is only trusted when its result is accelerated (it happily returns the Microsoft GL 1.1 software format — the #59 failure mode); otherwise the format list is scanned. Logs `GL_VENDOR/GL_RENDERER/GL_VERSION` for diagnosis. Drains its message queue on every render-loop wake-up (top-level windows receive posted system broadcasts even when hidden). |
| `render_opengl_win.cpp` | The render thread + state machine, same request/publish protocol as the other platforms (packed frame state `generation|index|w|h|serial`), minus the retire/ack machinery — CPU buffers need no consumer-side wraps. Screenshot/pixel readback read the CPU frame directly, no render-thread marshalling. |
| `gl_functions_win.h/cpp` | FBO entry points via `wglGetProcAddress` (ARB then EXT spelling) — `opengl32.dll` only exports GL 1.1. |
| `png_writer_win.{h,cpp}` | WIC PNG encode extracted from `render_d3d11.cpp`; both Windows paths share it. |
| Kotlin | `MpvSurfaceBackend` (core) split out of `MpvSurfaceRingBackend` (texture-ring extras); consumer state machine behind new `MpvSurfaceConsumer` — `MpvSurfaceRing` for the three ring backends (behavior unchanged), new `MpvReadbackSurface` for the fallback. `SkiaWindowsOpenGLInterop` reflects only Skia's `DirectContext` and a redrawer-identity token (layout preflighted by `SkikoWindowsOpenGLReflectionLayoutTest`). |

### Behaviour notes

- hwdec is `d3d11va-copy,auto-safe`: decode stays on GPU through D3D11, frames copy back for mpv's GL upload. A GL renderer has no zero-copy D3D interop in this build, and plain `auto` prefers direct-mapping modes whose interop doesn't exist here.
- The consumer bitmap and its GPU blit surface are both `RGBA_8888`, so `writePixels` is a straight copy (an N32/BGRA surface would swizzle the whole frame on the CPU first).
- Orientation follows the GLX convention exactly (`flip_y=1`, row flip on readback) — deliberately not "optimized", it is the empirically proven combination.
- libmpv needs **no build changes**: the Windows build already has `-Dgl=enabled -Dgl-win32=enabled`. Only the JNI dll gains `-lopengl32 -lgdi32`.
- Fixed in passing: `delete` of the state struct through an incomplete type would have skipped the destructor (caught by the mingw cross-check below).

## Verification

- Kotlin desktop/jvm compile; **all 38 desktop tests pass** on macOS (including the Metal-path player smoke tests — the backend/consumer refactor did not disturb existing paths).
- **Every `.cpp` compiles under `x86_64-w64-mingw32-g++ -std=c++17`** against the patch-applied mpv headers and real Windows headers (`-Wall -Wextra` clean for the new files) — a stronger check than #59's macOS `-fsyntax-only`, but still not a run on real Windows. That is what this PR needs from review.

## Testing on Windows

```powershell
./gradlew :mediamp-mpv:mpvAssembleWindowsX64          # unchanged libmpv/FFmpeg → cached artifacts fine; only mediampv.dll recompiles
./gradlew :mediamp-mpv-demo:runOpenGL "-Pvideo=C:\path\to.mp4"   # forces skiko.renderApi=OPENGL → fallback path
./gradlew :mediamp-mpv-demo:runD3D11  "-Pvideo=C:\path\to.mp4"   # regression-check the default path
```

Expected log lines on the fallback path:

1. `WGL fallback drawable uses pixel format N via ChoosePixelFormat|scan`
2. `WGL fallback context ready: <vendor> / <renderer> / GL <version>` — if `<renderer>` says `GDI Generic`, the ICD scan failed and everything after is expected to fail; please report the full line.
3. `OpenGL fallback target allocated WxH generation=N`
4. `rendering WxH via OpenGL/WGL readback surface`

Worth exercising: window resize during playback (paused and playing), pause/seek, the timeline preview thumbnails (second mpv instance on the same path), screenshot, and HDR content (tone-mapping goes through the same target-prim/trc options as the other paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
