### PR TITLE
fix: give SeekableInput await contexts a session-lifetime job

### DIFF
--- a/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
@@ -383,9 +383,11 @@ public class ExoPlayerMediampPlayer @UiThread public constructor(
         val epoch = ++openEpoch
         openingPhase = true
         var sessionInput: SeekableInput? = null
+        var sessionInputAwaitJob: Job? = null
         try {
             val prepared = buildMediaSource(data)
             sessionInput = prepared.sessionInput
+            sessionInputAwaitJob = prepared.sessionInputAwaitJob
             val source = mediaSourceInterceptor?.invoke(prepared.mediaSource, data) ?: prepared.mediaSource
 
             // Ready point (spec §3): the first onTracksChanged with non-empty tracks, which
@@ -424,8 +426,16 @@ public class ExoPlayerMediampPlayer @UiThread public constructor(
             // requested start position against the now-known duration (STATE_ENDED only arrives
             // asynchronously later).
             val durationMillis = exoPlayer.duration
+            val awaitJob = sessionInputAwaitJob
             return OpenResult(
-                sessionResources = sessionInput?.let { input -> AutoCloseable { input.close() } },
+                sessionResources = sessionInput?.let { input ->
+                    AutoCloseable {
+                        // Cancel before closing: unblocks a loader read still waiting in
+                        // the await context.
+                        awaitJob?.cancel()
+                        input.close()
+                    }
+                },
                 initialSnapshot = TransportSnapshot(
                     nativePlayWhenReady = exoPlayer.playWhenReady,
                     isStalled = nativeState == Media3Player.STATE_BUFFERING,
@@ -444,6 +454,7 @@ public class ExoPlayerMediampPlayer @UiThread public constructor(
                 exoPlayer.stop()
                 exoPlayer.clearMediaItems()
             }
+            sessionInputAwaitJob?.cancel()
             sessionInput?.let { input ->
                 backgroundScope.launch(NonCancellable + Dispatchers.IO) {
                     runCatching { input.close() }
@@ -500,6 +511,8 @@ public class ExoPlayerMediampPlayer @UiThread public constructor(
         val mediaSource: MediaSource,
         /** A [SeekableInput] opened for this session, to be closed with it; `null` if none. */
         val sessionInput: SeekableInput?,
+        /** Await-context job of [sessionInput]'s blocking reads, cancelled with the session. */
+        val sessionInputAwaitJob: Job? = null,
     )
 
     /**
@@ -566,13 +579,30 @@ public class ExoPlayerMediampPlayer @UiThread public constructor(
                 }.setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
                 PreparedSource(factory.createMediaSource(MediaItem.fromUri(data.uri)), sessionInput = null)
             } else {
-                val input = withContext(Dispatchers.IO) {
-                    data.createInput(currentCoroutineContext())
+                // The input's reads run on ExoPlayer loader threads for the whole session,
+                // and a read that must wait for data (e.g. a torrent input awaiting an
+                // undownloaded piece) blocks inside the await context passed here. This open
+                // coroutine's job (and the withContext job below) completes right after the
+                // open, so neither may be that context: every later wait would fail
+                // instantly with "Parent job is Completed". Hand the input a
+                // session-lifetime job instead.
+                val awaitJob = SupervisorJob(backgroundScope.coroutineContext[Job.Key])
+                val input = try {
+                    withContext(Dispatchers.IO) {
+                        data.createInput(Dispatchers.IO + awaitJob)
+                    }
+                } catch (t: Throwable) {
+                    awaitJob.cancel()
+                    throw t
                 }
                 val factory = ProgressiveMediaSource.Factory {
                     SeekableInputDataSource(data, input)
                 }.setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
-                PreparedSource(factory.createMediaSource(MediaItem.fromUri(data.uri)), sessionInput = input)
+                PreparedSource(
+                    factory.createMediaSource(MediaItem.fromUri(data.uri)),
+                    sessionInput = input,
+                    sessionInputAwaitJob = awaitJob,
+                )
             }
         }
     }

--- a/mediamp-internal-utils/build.gradle.kts
+++ b/mediamp-internal-utils/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
     }
     sourceSets {
         commonMain.dependencies {
+            api(libs.kotlinx.coroutines.core)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/mediamp-internal-utils/src/commonMain/kotlin/Dispatchers.kt
+++ b/mediamp-internal-utils/src/commonMain/kotlin/Dispatchers.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.internal
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Same as `Dispatchers.IO`. On the JVM `IO` is a member of [Dispatchers], but on native
+ * targets it is the extension property `kotlinx.coroutines.IO`, which needs its own import —
+ * one that IDEs drop as "unused" whenever the native targets are excluded from analysis,
+ * silently breaking the next iOS build. Reference this shared alias instead of importing
+ * `kotlinx.coroutines.IO` per file.
+ */
+expect val Dispatchers.IO_: CoroutineDispatcher

--- a/mediamp-internal-utils/src/iosMain/kotlin/Dispatchers.ios.kt
+++ b/mediamp-internal-utils/src/iosMain/kotlin/Dispatchers.ios.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.internal
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO as _IO
+
+actual val Dispatchers.IO_: CoroutineDispatcher
+    get() = _IO

--- a/mediamp-internal-utils/src/jvmMain/kotlin/Dispatchers.jvm.kt
+++ b/mediamp-internal-utils/src/jvmMain/kotlin/Dispatchers.jvm.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.internal
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+actual val Dispatchers.IO_: CoroutineDispatcher
+    get() = IO

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
@@ -11,6 +11,7 @@ package org.openani.mediamp.mpv.internal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import org.openani.mediamp.ExperimentalMediampApi
+import org.openani.mediamp.internal.IO_
 import org.openani.mediamp.io.SeekableInput
 import org.openani.mediamp.mpv.MPVHandle
 import org.openani.mediamp.mpv.RenderUpdateListener
@@ -122,7 +123,7 @@ internal class MpvPreviewDecoder(
             }
 
             is SeekableInputMediaData -> {
-                val input = data.createInput(Dispatchers.IO + inputAwaitJob)
+                val input = data.createInput(Dispatchers.IO_ + inputAwaitJob)
                 val registered = try {
                     handle.registerSeekableInput(input, FRAME_PREVIEW_LOAD_TARGET_PREFIX + data.uri)
                 } catch (t: Throwable) {

--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
@@ -8,7 +8,8 @@
 
 package org.openani.mediamp.mpv.internal
 
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.openani.mediamp.ExperimentalMediampApi
 import org.openani.mediamp.io.SeekableInput
 import org.openani.mediamp.mpv.MPVHandle
@@ -41,6 +42,15 @@ internal class MpvPreviewDecoder(
     /** Input opened for stream_cb media; owned and closed by this decoder. */
     private var openInput: SeekableInput? = null
     private var loadTarget: String? = null
+
+    /**
+     * Await context job for [openInput]'s blocking reads (e.g. a torrent input awaiting an
+     * undownloaded piece). Decoder-lifetime — the coroutine calling [loadPaused] completes
+     * long before preview reads stop, so its job must not be the await context. Cancelled
+     * first in [close]: a blocked read holds the native stream lock that `handle.destroy()`
+     * needs to join mpv's threads.
+     */
+    private val inputAwaitJob = SupervisorJob()
 
     init {
         try {
@@ -112,7 +122,7 @@ internal class MpvPreviewDecoder(
             }
 
             is SeekableInputMediaData -> {
-                val input = data.createInput(currentCoroutineContext())
+                val input = data.createInput(Dispatchers.IO + inputAwaitJob)
                 val registered = try {
                     handle.registerSeekableInput(input, FRAME_PREVIEW_LOAD_TARGET_PREFIX + data.uri)
                 } catch (t: Throwable) {
@@ -140,6 +150,9 @@ internal class MpvPreviewDecoder(
         ringBackend.readSurfacePixels(handle.ptr, dims)
 
     override fun close() {
+        // Unblock a read still waiting for data before handle.destroy() joins mpv's
+        // threads (a blocked read holds the native stream lock).
+        inputAwaitJob.cancel()
         try {
             handle.setRenderUpdateListener(null)
             ringBackend.setSurfaceConfig(handle.ptr, 0, 0, 0L)

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvMediampPlayerSmokeTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvMediampPlayerSmokeTest.kt
@@ -10,8 +10,8 @@ package org.openani.mediamp.mpv
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -31,6 +31,7 @@ import org.openani.mediamp.source.SeekableInputMediaData
 import org.openani.mediamp.source.UriMediaData
 import java.io.File
 import java.io.RandomAccessFile
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 import kotlin.coroutines.CoroutineContext
@@ -174,28 +175,42 @@ class MpvMediampPlayerSmokeTest {
     }
 
     /**
-     * Runs [block] with a player confined to a dedicated serial dispatcher (standing in for
+     * Runs [block] with a player confined to a dedicated single thread (standing in for
      * the UI thread — the block itself runs on it, so command-thread rules hold) and a
      * headless render surface.
+     *
+     * The dispatcher must own exactly one physical thread — `limitedParallelism(1)` only
+     * serializes and may migrate between pool workers, while the machine checks command
+     * threads by physical identity: a continuation resumed on a different worker (e.g. a
+     * join completed from the IO release dispatcher) flips close() onto its asynchronous
+     * trampoline, or trips checkMainThread, depending on scheduler luck (Windows CI flake).
      */
     private fun runPlayerTest(block: suspend CoroutineScope.(MpvMediampPlayer) -> Unit) {
-        val mainDispatcher = Dispatchers.Default.limitedParallelism(1)
-        runBlocking(mainDispatcher) {
-            val player = MpvMediampPlayer(
-                Any(), coroutineContext,
-                mainDispatcher = mainDispatcher,
-            )
-            val renderer = startHeadlessRenderer(player)
-            try {
-                block(player)
-            } finally {
-                renderer.close()
+        val mainDispatcher = Executors.newSingleThreadExecutor { r ->
+            Thread(r, "mpv-test-main").apply { isDaemon = true }
+        }.asCoroutineDispatcher()
+        try {
+            runBlocking(mainDispatcher) {
+                val player = MpvMediampPlayer(
+                    Any(), coroutineContext,
+                    mainDispatcher = mainDispatcher,
+                )
+                val renderer = startHeadlessRenderer(player)
+                try {
+                    block(player)
+                } finally {
+                    renderer.close()
+                    player.close()
+                }
+                // close() is terminal (spec: -> Released) and idempotent. Await rather than
+                // assert synchronously: called off the machine thread, close() trampolines
+                // doClose and Released commits asynchronously.
+                withTimeout(10_000) { player.state.first { it.mediaStatus == MediaStatus.Released } }
                 player.close()
+                assertEquals(MediaStatus.Released, player.state.value.mediaStatus)
             }
-            // close() is terminal (spec: -> Released) and idempotent.
-            assertEquals(MediaStatus.Released, player.state.value.mediaStatus)
-            player.close()
-            assertEquals(MediaStatus.Released, player.state.value.mediaStatus)
+        } finally {
+            mainDispatcher.close()
         }
     }
 

--- a/mediamp-mpv/src/desktopTest/kotlin/MpvMediampPlayerSmokeTest.kt
+++ b/mediamp-mpv/src/desktopTest/kotlin/MpvMediampPlayerSmokeTest.kt
@@ -11,6 +11,7 @@ package org.openani.mediamp.mpv
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -31,6 +32,7 @@ import org.openani.mediamp.source.UriMediaData
 import java.io.File
 import java.io.RandomAccessFile
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -453,6 +455,66 @@ class MpvMediampPlayerSmokeTest {
 
             player.stopPlayback()
             assertEquals(MediaStatus.Idle, player.state.value.mediaStatus)
+        }
+    }
+
+    /**
+     * Regression test for spurious EOF on still-downloading torrent sources
+     * (open-ani/animeko): the await context handed to [SeekableInputMediaData.createInput]
+     * used to be the open coroutine's own context, whose job completes right after the
+     * open. A read that later blocked for data — TorrentInput does
+     * `runBlocking(awaitContext) { piece.awaitFinished() }` on the mpv demux thread — then
+     * died instantly with "Parent job is Completed"; the JNI layer cleared the exception
+     * and returned -1, which mpv's stream layer treats as EOF: playback "finished" on the
+     * first seek into undownloaded data.
+     */
+    @OptIn(ExperimentalMediampApi::class)
+    @Test
+    fun `createInput await context outlives the open and is cancelled with the session`() {
+        if (!prepareOrSkip()) return
+        val video = generateTestVideo() ?: run { skip("ffmpeg unavailable or test video generation failed"); return }
+
+        runPlayerTest { player ->
+            var awaitContext: CoroutineContext? = null
+            val data = object : SeekableInputMediaData {
+                override val uri: String get() = "test://await-context/${video.name}"
+                override val extraFiles: MediaExtraFiles get() = MediaExtraFiles.EMPTY
+                override val options: List<String> get() = emptyList()
+                override fun fileLength(): Long = video.length()
+                override suspend fun createInput(coroutineContext: CoroutineContext): SeekableInput {
+                    awaitContext = coroutineContext
+                    return RandomAccessFileSeekableInput(RandomAccessFile(video, "r"))
+                }
+
+                override fun close() {}
+            }
+            player.setMediaData(data)
+            assertEquals(MediaStatus.Ready, player.state.value.mediaStatus)
+
+            val context = assertNotNull(awaitContext)
+            val awaitJob = assertNotNull(context[Job], "createInput must receive a context carrying a Job")
+            assertTrue(awaitJob.isActive, "the await context must stay active after the open completes")
+
+            // The exact shape of a blocked torrent read, on a foreign thread like mpv's
+            // demux thread. Must run, not die with "Parent job is Completed".
+            var probeError: Throwable? = null
+            thread(name = "fake-demux-read") {
+                try {
+                    runBlocking(context) { delay(10) }
+                } catch (t: Throwable) {
+                    probeError = t
+                }
+            }.join()
+            assertNull(probeError, "a blocking wait on the await context must work mid-session, got: $probeError")
+
+            // Ending the session must cancel the job so reads still blocked in the await
+            // context unwind before the native stream is closed (release is async on the
+            // machine's cleanup scope, hence the timeout-join rather than an immediate
+            // assertion).
+            player.stopPlayback()
+            assertEquals(MediaStatus.Idle, player.state.value.mediaStatus)
+            withTimeout(5_000) { awaitJob.join() }
+            assertTrue(awaitJob.isCancelled, "the await job must be cancelled when the session is released")
         }
     }
 

--- a/mediamp-mpv/src/iosMain/kotlin/MpvMediampPlayer.ios.kt
+++ b/mediamp-mpv/src/iosMain/kotlin/MpvMediampPlayer.ios.kt
@@ -33,6 +33,7 @@ import org.openani.mediamp.features.PlayerFeatures
 import org.openani.mediamp.features.Screenshots
 import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.features.buildPlayerFeatures
+import org.openani.mediamp.internal.IO_
 import org.openani.mediamp.metadata.MediaProperties
 import org.openani.mediamp.mpv.internal.MPV_END_FILE_REASON_EOF
 import org.openani.mediamp.mpv.internal.MPV_END_FILE_REASON_ERROR
@@ -419,7 +420,7 @@ actual class MpvMediampPlayer(
                 // session-lifetime job instead.
                 val awaitJob = SupervisorJob(inputAwaitParent)
                 val input = try {
-                    data.createInput(Dispatchers.IO + awaitJob)
+                    data.createInput(Dispatchers.IO_ + awaitJob)
                 } catch (t: Throwable) {
                     awaitJob.cancel()
                     throw t

--- a/mediamp-mpv/src/iosMain/kotlin/MpvMediampPlayer.ios.kt
+++ b/mediamp-mpv/src/iosMain/kotlin/MpvMediampPlayer.ios.kt
@@ -13,7 +13,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.openani.mediamp.AbstractMediampPlayer
 import org.openani.mediamp.ExperimentalMediampApi
@@ -128,6 +129,14 @@ actual class MpvMediampPlayer(
      */
     @Volatile
     private var nativeTeardownStarted = false
+
+    /**
+     * Parent of the per-session await jobs passed to [SeekableInputMediaData.createInput]
+     * in [openImpl]. Cancelled first thing in [closeImpl]: a read still blocked in an await
+     * context holds the native stream lock, which the stream close inside `handle.destroy()`
+     * needs — the read must be unblocked before native teardown can join mpv's threads.
+     */
+    private val inputAwaitParent = SupervisorJob(parentCoroutineContext[Job])
 
     private val audioLevelController = MpvAudioLevelController(handle)
     private val buffering = MpvBuffering(state)
@@ -401,10 +410,24 @@ actual class MpvMediampPlayer(
 
             is SeekableInputMediaData -> {
                 val target = buildSeekableInputLoadTarget(data)
-                val input = data.createInput(currentCoroutineContext())
+                // The input's reads run on mpv demux threads for the whole session, and a
+                // read that must wait for data (e.g. a torrent input awaiting an
+                // undownloaded piece) blocks inside the await context passed here. This
+                // open coroutine's own job completes right after the open, so it must not
+                // be that context: every later wait would fail instantly with "Parent job
+                // is Completed" and surface as a spurious EOF. Hand the input a
+                // session-lifetime job instead.
+                val awaitJob = SupervisorJob(inputAwaitParent)
+                val input = try {
+                    data.createInput(Dispatchers.IO + awaitJob)
+                } catch (t: Throwable) {
+                    awaitJob.cancel()
+                    throw t
+                }
                 val registered = try {
                     handle.registerSeekableInput(input, target)
                 } catch (t: Throwable) {
+                    awaitJob.cancel()
                     input.close()
                     throw t
                 }
@@ -412,6 +435,9 @@ actual class MpvMediampPlayer(
                 // started native teardown the registry is torn down wholesale and the
                 // handle must not be touched anymore.
                 sessionResources = AutoCloseable {
+                    // Cancel before unregistering: a blocked read holds the native stream
+                    // lock that the stream close behind unregistration waits for.
+                    awaitJob.cancel()
                     if (!nativeTeardownStarted) {
                         runCatching { handle.unregisterSeekableInput(registered) }
                     }
@@ -532,6 +558,9 @@ actual class MpvMediampPlayer(
     @OptIn(DelicateCoroutinesApi::class)
     override fun closeImpl() {
         nativeTeardownStarted = true
+        // Unblock reads still parked in a session await context before native teardown
+        // joins mpv's demux threads (a blocked read holds the native stream lock).
+        inputAwaitParent.cancel()
         sessionAdapter = null
         mediaMetadata.clear()
         // Released is already committed and the session detached; do the heavy native

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -35,6 +35,7 @@ import org.openani.mediamp.features.Screenshots
 import org.openani.mediamp.features.VideoAspectRatio
 import org.openani.mediamp.features.buildPlayerFeatures
 import org.openani.mediamp.internal.Arch
+import org.openani.mediamp.internal.IO_
 import org.openani.mediamp.internal.Platform
 import org.openani.mediamp.internal.currentPlatform
 import org.openani.mediamp.metadata.MediaProperties
@@ -542,7 +543,7 @@ abstract class JvmMpvMediampPlayer(
                 // session-lifetime job instead.
                 val awaitJob = SupervisorJob(inputAwaitParent)
                 val input = try {
-                    data.createInput(Dispatchers.IO + awaitJob)
+                    data.createInput(Dispatchers.IO_ + awaitJob)
                 } catch (t: Throwable) {
                     awaitJob.cancel()
                     throw t

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -11,7 +11,8 @@ package org.openani.mediamp.mpv
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -118,6 +119,14 @@ abstract class JvmMpvMediampPlayer(
      */
     @Volatile
     private var nativeTeardownStarted = false
+
+    /**
+     * Parent of the per-session await jobs passed to [SeekableInputMediaData.createInput]
+     * in [openImpl]. Cancelled first thing in [closeImpl]: a read still blocked in an await
+     * context holds the native stream lock, which the stream close inside `handle.destroy()`
+     * needs — the read must be unblocked before native teardown can join mpv's threads.
+     */
+    private val inputAwaitParent = SupervisorJob(parentCoroutineContext[Job])
 
     /** Bumped by [renderContextBecameReady]; [awaitRenderContextForLoad] waits on it. */
     private val renderContextReadySignal = MutableStateFlow(0L)
@@ -524,10 +533,24 @@ abstract class JvmMpvMediampPlayer(
 
             is SeekableInputMediaData -> {
                 val target = buildSeekableInputLoadTarget(data)
-                val input = data.createInput(currentCoroutineContext())
+                // The input's reads run on mpv demux threads for the whole session, and a
+                // read that must wait for data (e.g. a torrent input awaiting an
+                // undownloaded piece) blocks inside the await context passed here. This
+                // open coroutine's own job completes right after the open, so it must not
+                // be that context: every later wait would fail instantly with "Parent job
+                // is Completed" and surface as a spurious EOF. Hand the input a
+                // session-lifetime job instead.
+                val awaitJob = SupervisorJob(inputAwaitParent)
+                val input = try {
+                    data.createInput(Dispatchers.IO + awaitJob)
+                } catch (t: Throwable) {
+                    awaitJob.cancel()
+                    throw t
+                }
                 val registered = try {
                     handle.registerSeekableInput(input, target)
                 } catch (t: Throwable) {
+                    awaitJob.cancel()
                     input.close()
                     throw t
                 }
@@ -535,6 +558,9 @@ abstract class JvmMpvMediampPlayer(
                 // started native teardown the registry is torn down wholesale and the
                 // handle must not be touched anymore.
                 sessionResources = AutoCloseable {
+                    // Cancel before unregistering: a blocked read holds the native stream
+                    // lock that the stream close behind unregistration waits for.
+                    awaitJob.cancel()
                     if (!nativeTeardownStarted) {
                         runCatching { handle.unregisterSeekableInput(registered) }
                     }
@@ -655,6 +681,9 @@ abstract class JvmMpvMediampPlayer(
 
     override fun closeImpl() {
         nativeTeardownStarted = true
+        // Unblock reads still parked in a session await context before the teardown thread
+        // joins mpv's demux threads (a blocked read holds the native stream lock).
+        inputAwaitParent.cancel()
         sessionAdapter = null
         (framePreview as? AutoCloseable)?.close()
         mediaMetadata.clear()


### PR DESCRIPTION
## Problem

Playing a still-downloading torrent source: already-downloaded parts play fine, but seeking into undownloaded data (or playback catching up with the download edge) immediately ends playback as if the file hit EOF, with:

```
Exception in thread "Thread-43206" kotlinx.coroutines.JobCancellationException: Parent job is Completed; job=StandaloneCoroutine{Completed}
    at kotlinx.coroutines.BlockingCoroutine.<init>(Builders.kt:33)
    ...
    at me.him188.ani.app.torrent.io.TorrentInput.fillBuffer(TorrentInput.jvm.kt:120)
    at org.openani.mediamp.io.BufferedSeekableInput.read(BufferedSeekableInput.kt:167)
```

## Root cause

The mpv (JVM/iOS), preview-decoder and ExoPlayer backends passed `currentCoroutineContext()` to `SeekableInputMediaData.createInput`. That context carries the **open coroutine's job** (`mainScope.launch { runOpen(...) }` in `AbstractMediampPlayer`), which completes right after the open. The input, however, is read on native demux / loader threads for the whole session, and a read that must wait for data — animeko's `TorrentInput` does `runBlocking(awaitContext) { piece.awaitFinished() }` on the mpv demux thread — blocks inside that context:

1. Reads of finished pieces never enter `runBlocking` → downloaded parts play fine.
2. A read needing to wait constructs `runBlocking` on the dead parent → instant `JobCancellationException` (the `Exception in thread` print is JNI `ExceptionDescribe`, not an uncaught handler).
3. The piece-priority callback (`onWait`) never runs either, so the torrent engine is never told to prioritize the seek target.
4. `clear_jni_exception` clears the exception; `seekable_stream_read` returns `-1`.
5. mpv's `stream_read_unbuffered` treats `res <= 0` as EOF → `END_FILE(EOF)` → the session reports Ended → "playback finished".

## Fix

Apply the pattern the VLC backend adopted in d70d3a9 to all remaining call sites: hand `createInput` a **per-session `SupervisorJob`** (parented to a player-lifetime job) **+ an IO dispatcher**, and cancel it when the session's resources are released.

Ordering matters in two places:

- Cancel **before** unregistering/closing the native stream: a blocked read holds the native stream `io_lock` that `close_and_release` waits for.
- Cancel the player-level parent at the **top of `closeImpl`**, before the teardown thread runs `handle.destroy()` (which joins mpv threads that may be parked in a read).

Touched sites:

- `MpvMediampPlayer.jvm.kt` — `openImpl` + new `inputAwaitParent` + `closeImpl`
- `MpvMediampPlayer.ios.kt` — symmetric change
- `MpvPreviewDecoder.kt` — decoder-lifetime await job, cancelled first in `close()`
- `ExoPlayerMediampPlayer.kt` — session await job threaded through `PreparedSource` to the session resource closer and the open-failure path

### `Dispatchers.IO_` alias (second commit)

On native targets `Dispatchers.IO` is the extension property `kotlinx.coroutines.IO`, not a member — the bare `Dispatchers.IO` in the first commit's iOS change would not resolve. Mirroring animeko's `utils:coroutine` handling, `mediamp-internal-utils` now exposes `Dispatchers.IO_` (`expect` in commonMain; the member `IO` on JVM; `kotlinx.coroutines.IO` on iOS), and the mpv call sites use it so the twin JVM/iOS backends read identically and there is no per-file `kotlinx.coroutines.IO` import for IDE import-cleanup to drop while native targets are excluded from analysis. The android-only ExoPlayer backend keeps the plain member `Dispatchers.IO`. Existing per-file imports elsewhere (`MachinePlatform.ios.kt`, `SystemFileIoDispatcher.native.kt`, `FFmpegKit.ios.kt`) can migrate separately.

`ExoFramePreview`/`VlcFramePreview` still use the default `EmptyCoroutineContext` (a wait there blocks until data arrives instead of throwing) — different failure mode, intentionally left out of this PR.

## Test

New smoke-test regression (`MpvMediampPlayerSmokeTest`): the context recorded from `createInput` must stay active after the open completes, serve a `runBlocking` wait from a foreign thread mid-session (the exact `TorrentInput.fillBuffer` shape), and be cancelled once the session is released. Skips without a libmpv environment; runs under `-Pmediamp.mpv.test.required=true`.

Verified locally: `:mediamp-internal-utils:compileKotlinDesktop`, `:mediamp-internal-utils:compileAndroidMain`, `:mediamp-mpv:compileKotlinDesktop`, `:mediamp-mpv:compileAndroidMain`, `:mediamp-mpv:compileTestKotlinDesktop`, `:mediamp-exoplayer:compileAndroidMain` — BUILD SUCCESSFUL. The iOS target compiles only on CI (local machine lacks the Kotlin/Native toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)