### PR TITLE
fix(mpv): stop re-grading SDR to sRGB on desktop, keep target-* at auto

### DIFF
--- a/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
+++ b/mediamp-mpv/src/desktopMain/kotlin/internal/MpvPreviewDecoder.kt
@@ -78,8 +78,6 @@ internal class MpvPreviewDecoder(
         // HDR -> SDR tone-mapping, same as the main player (see there for the full
         // rationale) — without it HDR sources produce near-black thumbnails.
         handle.option("gpu-dumb-mode", "no")
-        handle.option("target-prim", "bt.709")
-        handle.option("target-trc", "srgb")
         handle.option("hwdec", "auto")
         handle.option("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
         // Prefer libdav1d for software AV1 — same rationale as the main player (see

--- a/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
+++ b/mediamp-mpv/src/jvmMain/kotlin/MpvMediampPlayer.jvm.kt
@@ -391,22 +391,14 @@ abstract class JvmMpvMediampPlayer(
 
         when (currentPlatform()) {
             is Platform.Windows, is Platform.MacOS, is Platform.Linux -> {
-                // HDR -> SDR tone-mapping. The desktop render API (render_d3d11.cpp /
-                // render_macos.mm) draws into an 8-bit SDR (sRGB) texture. By default
-                // mpv's renderer enters "dumb mode" (a fast passthrough blit) and writes
-                // HDR (PQ/bt2020) frames untonemapped — everything but the brightest
-                // highlights is crushed to black (symptom: an HDR video plays with audio
-                // but a near-black picture). check_dumb_mode() only inspects scaling /
-                // debanding / shaders, never the target colorspace, so the target-*
-                // options below cannot leave dumb mode on their own; gpu-dumb-mode=no
-                // forces the full color-management path. target-prim/target-trc then
-                // declare an SDR output so HDR is tone-mapped down to it. Values use
-                // libplacebo naming ("bt.709", not "bt709"). This is a no-op for SDR
-                // sources (target matches source). Android/iOS are excluded: Android
-                // uses vo=gpu-next, which does its own HDR handling.
+                // The desktop render API draws into an 8-bit SDR texture; force the full
+                // color-management path so HDR sources get tone-mapped instead of passed
+                // through near-black (check_dumb_mode() never inspects the colorspace).
+                // Keep target-prim/target-trc at "auto": it tone-maps HDR while passing
+                // SDR through untouched. Do not set target-trc=srgb — that re-grades SDR
+                // BT.1886 content to the sRGB curve, visibly darkening the whole picture
+                // compared to other players.
                 handle.option("gpu-dumb-mode", "no")
-                handle.option("target-prim", "bt.709")
-                handle.option("target-trc", "srgb")
             }
 
             else -> {}


### PR DESCRIPTION
## Problem

On desktop, video rendered through mediamp-mpv looks noticeably darker than the same file in other players (PotPlayer, Chrome, or stock mpv).

## Cause

`configureNativeHandle` sets `target-trc=srgb` (and `target-prim=bt.709`) on Windows/macOS/Linux. The comment claimed this is a no-op for SDR sources, but it is not: mpv interprets SDR BT.709-tagged content with the BT.1886 EOTF (pure power 2.4), so `target-trc=srgb` re-grades it through linear light to the sRGB curve. The two 2.4 exponents cancel, leaving a linear darkening ramp above the sRGB toe:

```
out = 1.055 * in - 0.055
```

Mid gray 128 → 121, code 32 → 20, code 16 → ~3; deep shadows below the toe are crushed even harder. Other players (and mpv's own default `target-trc=auto`, documented as "SDR content is not touched") pass SDR code values through unchanged, hence the visible difference, worst in dark scenes.

## Fix

Drop `target-prim`/`target-trc` and keep `gpu-dumb-mode=no`:

- `target-trc=auto` passes SDR through untouched and still auto-converts HDR/linear sources to gamma 2.2, so the original HDR near-black fix is preserved (it only ever required leaving dumb mode, which `gpu-dumb-mode=no` still forces).
- `target-prim=auto` already adapts wide gamuts (bt.2020) to BT.709 and leaves SDR primaries alone.

Same change applied to `MpvPreviewDecoder` so thumbnails match playback brightness. Android (`vo=gpu-next`) was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)