### PR TITLE
fix(exoplayer): read video size from track format under video effects

### DIFF
--- a/mediamp-exoplayer/src/androidHostTest/kotlin/org/openani/mediamp/exoplayer/internal/ExoVideoDisplaySizeTest.kt
+++ b/mediamp-exoplayer/src/androidHostTest/kotlin/org/openani/mediamp/exoplayer/internal/ExoVideoDisplaySizeTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer.internal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ExoVideoDisplaySizeTest {
+
+    @Test
+    fun `square pixels pass the stored size through`() {
+        assertEquals(
+            VideoDisplaySize(1920, 1080),
+            displaySizeOrNull(1920, 1080, pixelWidthHeightRatio = 1f, rotationDegrees = 0),
+        )
+    }
+
+    @Test
+    fun `anamorphic ratio widens the stored width`() {
+        // 720x576 PAL stored at 16:9 display aspect: PAR 1.4587 -> 1050x576.
+        assertEquals(
+            VideoDisplaySize(1050, 576),
+            displaySizeOrNull(720, 576, pixelWidthHeightRatio = 1.4587f, rotationDegrees = 0),
+        )
+    }
+
+    @Test
+    fun `quarter turns swap the axes`() {
+        for (rotation in listOf(90, 270)) {
+            assertEquals(
+                VideoDisplaySize(1080, 1920),
+                displaySizeOrNull(1920, 1080, pixelWidthHeightRatio = 1f, rotationDegrees = rotation),
+                "rotation=$rotation",
+            )
+        }
+    }
+
+    @Test
+    fun `half turns keep the axes`() {
+        assertEquals(
+            VideoDisplaySize(1920, 1080),
+            displaySizeOrNull(1920, 1080, pixelWidthHeightRatio = 1f, rotationDegrees = 180),
+        )
+    }
+
+    @Test
+    fun `a quarter turn scales the display height by the ratio`() {
+        // The ratio applies to the stored width, which becomes the display height after the turn.
+        assertEquals(
+            VideoDisplaySize(576, 1050),
+            displaySizeOrNull(720, 576, pixelWidthHeightRatio = 1.4587f, rotationDegrees = 90),
+        )
+    }
+
+    @Test
+    fun `an unknown stored size has no display size`() {
+        assertNull(displaySizeOrNull(0, 1080, pixelWidthHeightRatio = 1f, rotationDegrees = 0))
+        assertNull(displaySizeOrNull(1920, 0, pixelWidthHeightRatio = 1f, rotationDegrees = 0))
+        assertNull(displaySizeOrNull(-1, -1, pixelWidthHeightRatio = 1f, rotationDegrees = 0))
+    }
+}

--- a/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/ExoPlayerMediampPlayer.kt
@@ -62,6 +62,7 @@ import org.openani.mediamp.exoplayer.internal.ExoFramePreview
 import org.openani.mediamp.exoplayer.internal.SeekableInputDataSource
 import org.openani.mediamp.exoplayer.internal.WsolaRenderersFactory
 import org.openani.mediamp.exoplayer.internal.toPlaybackException
+import org.openani.mediamp.exoplayer.internal.videoDisplaySizeOrNull
 import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.Buffering
 import org.openani.mediamp.features.FramePreview
@@ -82,7 +83,6 @@ import org.openani.mediamp.source.SeekableInputMediaData
 import org.openani.mediamp.source.UriMediaData
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
-import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.seconds
 import androidx.media3.common.PlaybackException as Media3PlaybackException
 import androidx.media3.common.Player as Media3Player
@@ -622,12 +622,12 @@ public class ExoPlayerMediampPlayer @UiThread public constructor(
      */
     @MainThread
     private fun readMediaProperties(): MediaProperties {
-        val videoSize = exoPlayer.videoSize
+        val displaySize = exoPlayer.videoDisplaySizeOrNull()
         return MediaProperties(
             title = exoPlayer.mediaMetadata.title?.toString(),
             durationMillis = exoPlayer.duration.takeIf { it != C.TIME_UNSET && it >= 0 },
-            videoWidth = (videoSize.width * videoSize.pixelWidthHeightRatio).roundToInt().takeIf { it > 0 },
-            videoHeight = videoSize.height.takeIf { it > 0 },
+            videoWidth = displaySize?.width,
+            videoHeight = displaySize?.height,
         )
     }
 

--- a/mediamp-exoplayer/src/androidMain/kotlin/compose/ExoPlayerMediampSurface.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/compose/ExoPlayerMediampSurface.kt
@@ -10,14 +10,23 @@ package org.openani.mediamp.exoplayer.compose
 
 import androidx.annotation.OptIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import org.openani.mediamp.exoplayer.ExoPlayerMediampPlayer
+import org.openani.mediamp.exoplayer.internal.videoDisplaySizeOrNull
 import org.openani.mediamp.features.AspectRatioMode
 import org.openani.mediamp.features.VideoAspectRatio
 
@@ -31,13 +40,15 @@ fun ExoPlayerMediampPlayerSurface(
     val aspectRatioMode by mediampPlayer.features[VideoAspectRatio.Key]?.mode?.collectAsState() 
         ?: return // Return early if VideoAspectRatio feature is not available
     
+    var playerView by remember { mutableStateOf<PlayerView?>(null) }
+
     AndroidView(
         factory = { context ->
             PlayerView(context).apply {
                 useController = false
                 this.player = mediampPlayer.impl
                 configuration()
-            }
+            }.also { playerView = it }
         },
         modifier,
         update = { view ->
@@ -50,4 +61,36 @@ fun ExoPlayerMediampPlayerSurface(
             }
         },
     )
+
+    val player = mediampPlayer.impl
+    val view = playerView
+    if (view != null) {
+        DisposableEffect(view, player) {
+            // PlayerView takes the content frame aspect from Player.getVideoSize(): once in
+            // setPlayer, and after that only from its own onVideoSizeChanged, which returns
+            // early on VideoSize.UNKNOWN. Under video effects media3 1.9.0 never reports the
+            // real size, so the aspect keeps the 0 that setPlayer left it with and
+            // AspectRatioFrameLayout.onMeasure returns early, letting the frame fill its
+            // parent. The selected track's Format is the only remaining source.
+            val listener = object : Player.Listener {
+                override fun onTracksChanged(tracks: Tracks) = applyVideoAspectRatioFallback(view, player)
+                override fun onVideoSizeChanged(videoSize: VideoSize) = applyVideoAspectRatioFallback(view, player)
+            }
+            player.addListener(listener)
+            // Tracks may already be known by the time the view exists.
+            applyVideoAspectRatioFallback(view, player)
+            onDispose { player.removeListener(listener) }
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+private fun applyVideoAspectRatioFallback(view: PlayerView, player: ExoPlayer) {
+    if (player.videoSize.width > 0 && player.videoSize.height > 0) {
+        return // PlayerView applies the aspect ratio itself in this case.
+    }
+    val size = player.videoDisplaySizeOrNull() ?: return
+    val contentFrame = view.findViewById<AspectRatioFrameLayout>(androidx.media3.ui.R.id.exo_content_frame)
+        ?: return
+    contentFrame.setAspectRatio(size.width.toFloat() / size.height)
 }

--- a/mediamp-exoplayer/src/androidMain/kotlin/internal/ExoVideoDisplaySize.kt
+++ b/mediamp-exoplayer/src/androidMain/kotlin/internal/ExoVideoDisplaySize.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the Apache License version 2 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/mediamp/blob/main/LICENSE
+ */
+
+package org.openani.mediamp.exoplayer.internal
+
+import androidx.media3.common.C
+import androidx.media3.exoplayer.ExoPlayer
+import kotlin.math.roundToInt
+
+internal data class VideoDisplaySize(val width: Int, val height: Int)
+
+/**
+ * Display size of the current video, in pixels, with the pixel aspect ratio and rotation applied.
+ * Returns null while no video track is selected or its size is unknown.
+ *
+ * Once ExoPlayer.setVideoEffects has been called, even with an empty list, media3 1.9.0 routes
+ * video through the VideoSink path and stops reporting VideoSize to Player.Listener:
+ * MediaCodecVideoRenderer calls maybeNotifyVideoSizeChanged only while videoSink is null, and the
+ * sink listener it installs in configureVideoSink has an empty onVideoSizeChanged (b/292111083).
+ * The selected video track's Format is then the only source of the size.
+ */
+// TODO: drop the Format fallback once media3 reports video size on the VideoSink path.
+//  media3 removed that reporting on purpose, to keep the first frame rendered and the video
+//  restored after the screen goes off, so b/292111083 is a known-incomplete state rather than
+//  an oversight, and the sink path is not settled yet.
+//  Video size is not the only thing that changes there: MediaCodecVideoRenderer branches on
+//  whether videoSink is set in over thirty places, covering decoder frame dropping, the frame
+//  release control reset after a seek, and which surface the codec decodes into. Anything else
+//  this module reads from the renderer rather than from the track Format deserves the same
+//  scrutiny before it is trusted under video effects.
+internal fun ExoPlayer.videoDisplaySizeOrNull(): VideoDisplaySize? {
+    val videoSize = this.videoSize
+    if (videoSize.width > 0 && videoSize.height > 0) {
+        // VideoSize is already rotated.
+        return VideoDisplaySize(
+            (videoSize.width * videoSize.pixelWidthHeightRatio).roundToInt(),
+            videoSize.height,
+        )
+    }
+
+    val group = currentTracks.groups.firstOrNull { it.type == C.TRACK_TYPE_VIDEO && it.isSelected }
+        ?: return null
+    val selectedIndex = (0 until group.length).firstOrNull { group.isTrackSelected(it) } ?: 0
+    val format = group.getTrackFormat(selectedIndex)
+    return displaySizeOrNull(
+        format.width,
+        format.height,
+        format.pixelWidthHeightRatio,
+        format.rotationDegrees,
+    )
+}
+
+/**
+ * Display size of a video frame stored as [storedWidth] x [storedHeight], or null if either is
+ * unknown.
+ *
+ * [pixelWidthHeightRatio] describes the stored frame, so it scales the stored width; after a
+ * quarter-turn that axis is the display height. Format normalizes an unknown ratio to 1
+ * (Format.NO_VALUE never reaches here), so there is nothing to guard against.
+ */
+internal fun displaySizeOrNull(
+    storedWidth: Int,
+    storedHeight: Int,
+    pixelWidthHeightRatio: Float,
+    rotationDegrees: Int,
+): VideoDisplaySize? {
+    if (storedWidth <= 0 || storedHeight <= 0) return null
+    val width = (storedWidth * pixelWidthHeightRatio).roundToInt()
+    return if (rotationDegrees == 90 || rotationDegrees == 270) {
+        VideoDisplaySize(storedHeight, width)
+    } else {
+        VideoDisplaySize(width, storedHeight)
+    }
+}


### PR DESCRIPTION
## 概述

调用 `ExoPlayer.setVideoEffects` 之后，即使传入的是空列表，mediamp 也无法再获取视频尺寸。
`MediaProperties` 的 `videoWidth` 与 `videoHeight` 在整个播放过程中保持为 null，`PlayerView` 的
content frame 同样得不到宽高比，只能撑满父容器。

画面本身仍然正常显示，因为 effect 管线的最后一级会追加一个铺满输出 surface 的等比缩放，也就是
`FinalShaderProgramWrapper` 中的 `Presentation.LAYOUT_SCALE_TO_FIT`。真正受影响的是不经过该管线的
叠加层。Animeko 将 libass 挂在 `exo_subtitles` 上，而这个 View 位于 content frame 之内，因此内嵌
ASS 字幕在全屏下会被横向拉伸，也就是 open-ani/animeko#3364 报告的现象。

## 根因

`setVideoEffects` 会让 `MediaCodecVideoRenderer` 在下一次 enable 时建立 `VideoSink`，而渲染器只在
没有 sink 的情况下才上报解码得到的尺寸：

```java
// MediaCodecVideoRenderer.java:2244
if (videoSink == null) {
  maybeNotifyVideoSizeChanged(decodedVideoSize);
  maybeNotifyRenderedFirstFrame();
}
```

sink 一侧的回调则是空实现：

```java
// MediaCodecVideoRenderer.java:932
@Override
public void onVideoSizeChanged(VideoSize videoSize) {
  // TODO: b/292111083 - Report video size change to app. Video size reporting is
  //  removed at the moment to ensure the first frame is rendered, and the video is
  //  rendered after switching on/off the screen.
}
```

两条通道都不生效，`Player.getVideoSize()` 于是在整个播放过程中保持 `UNKNOWN`。有两处代码依赖这个值：

- `ExoPlayerMediampPlayer.readMediaProperties()` 直接读取 `exoPlayer.videoSize`。
- `PlayerView` 在 `setPlayer` 中按同一个值设置 content frame 的宽高比，此后仅由它自己的
  `onVideoSizeChanged` 更新，而该回调在收到 `UNKNOWN` 时会直接返回（`PlayerView.java:1881`）。
  宽高比因此一直保持为 `setPlayer` 写入的 0，`AspectRatioFrameLayout.onMeasure` 在宽高比小于等于 0
  时会提前返回，容器不再按比例裁切。

传入空列表同样会建立 sink，因为判断条件是 `videoEffects != null`，而不是列表非空。

## 改动

本 PR 新增 `ExoPlayer.videoDisplaySizeOrNull()`。它优先返回 `videoSize`；当该值不可用时，改为读取
选中视频轨的 `Format`，并应用其中的 pixel aspect ratio 与 rotation。`Format` 来自容器解析，经
`onTracksChanged` 派发，不经过 VideoSink，因此在两条渲染路径上都能得到正确的尺寸。

有两处代码使用了它：

- `readMediaProperties()` 改用它填充 `videoWidth` 与 `videoHeight`。
- `ExoPlayerMediampPlayerSurface` 注册了一个 listener，在 `videoSize` 不可用时据此设置 content frame
  的宽高比。当 `videoSize` 可用时该 listener 不做处理，仍由 `PlayerView` 自行设置。

回退分支保留了一条 TODO 注释。media3 是有意移除这项上报的，目的是保证首帧渲染以及息屏之后恢复播放，
因此 VideoSink 这条路径目前尚未稳定。尺寸也不是这条路径上唯一的差异：`MediaCodecVideoRenderer` 中以
`videoSink` 是否存在为条件的分支有三十多处，涉及解码器丢帧、seek 之后帧释放控制器的重置，以及解码器
输出到哪一张 surface。

## 验证

验证在 API 37 模拟器上进行，屏幕 1080x2424。测试素材是一个 1920x1080 的 MKV，它的 ASS 轨绘制了铺满
整个画面的边框、位于中心的圆形，以及每隔 192 px 的刻度，通过 HTTP 提供。边框可以直接当作标尺使用：
它在 ASS 坐标系中恰好铺满 `PlayResX`，任何缩放偏差都会体现为它的像素宽度变化。

| 预先建立 effect graph | 补丁 | `exo_content_frame` | ASS 边框宽度 |
|---|---|---|---|
| 是 | 无 | `0,0-2424,1080` | 2424 px（拉伸 1.2625） |
| 否 | 无 | `252,0-2172,1080` | 1920 px |
| 是 | 有 | `252,0-2172,1080` | 1920 px |

打上补丁之后，即使 effect graph 仍然预先建立，测得的结果也与关闭它的对照组完全一致。表中的 1.2625
等于 `(2424/1080) / (1920/1080)`，正是 libass 用 frame 的宽高比除以 storage 的宽高比得到的 pixel
aspect。

同一条 ASS 轨中的中心圆可以作为交叉验证。异常时它的水平半径为 378 px，修复后为 300 px，比值 1.26；
两种情况下垂直直径都是 600 px。绿框、刻度、字幕文字与这个圆的畸变系数完全一致，说明问题只出在
libass 拿到的 frame 宽高比上，而不是多处独立的偏差。

预先建立 effect graph、未打补丁：

<img width="2424" height="1080" alt="1-broken-preload-on" src="https://github.com/user-attachments/assets/6dde751c-9aea-4349-b72f-060bb981d250" />

关闭预先建立、未打补丁（对照）：

<img width="2424" height="1080" alt="2-control-preload-off" src="https://github.com/user-attachments/assets/27b09feb-4b22-4803-9545-f8086e3759a3" />

预先建立 effect graph、打上补丁：

<img width="2424" height="1080" alt="3-fixed-preload-on" src="https://github.com/user-attachments/assets/c35fb27e-d26e-4975-b9cf-b82ccedcf459" />

`ExoVideoDisplaySizeTest` 覆盖了 `Format` 一侧的换算：pixel aspect ratio 作用于存储宽度，而在旋转
90 度或 270 度之后，该轴对应的是显示高度。

```
./gradlew :mediamp-exoplayer:compileAndroidMain :mediamp-exoplayer:testAndroidHostTest
```
